### PR TITLE
Handle base ingredient IDs without truthiness assumptions

### DIFF
--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -237,7 +237,7 @@ export default function AddIngredientScreen() {
       await InteractionManager.runAfterInteractions();
       const ingredients = await getAllIngredients();
       const baseOnly = ingredients
-        .filter((i) => !i.baseIngredientId)
+        .filter((i) => i.baseIngredientId == null)
         .sort((a, b) =>
           a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
         )
@@ -307,7 +307,7 @@ export default function AddIngredientScreen() {
       description,
       photoUri,
       tags,
-      baseIngredientId: baseIngredientId || null,
+      baseIngredientId: baseIngredientId ?? null,
       createdAt: Date.now(),
     };
 
@@ -321,7 +321,7 @@ export default function AddIngredientScreen() {
             id: newIng.id,
             name: newIng.name,
             photoUri: newIng.photoUri || null,
-            baseIngredientId: newIng.baseIngredientId || null,
+            baseIngredientId: newIng.baseIngredientId ?? null,
             tags: newIng.tags || [],
           },
           targetLocalId,

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -57,7 +57,7 @@ const ItemRow = memo(
     isNavigating,
   }) {
     const theme = useTheme();
-    const isBranded = !!baseIngredientId;
+    const isBranded = baseIngredientId != null;
 
     const ripple = useMemo(
       () => ({ color: withAlpha(theme.colors.tertiary, 0.35) }),

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -228,7 +228,7 @@ export default function EditIngredientScreen() {
           setDescription(data.description || "");
           setPhotoUri(data.photoUri || null);
           setTags(Array.isArray(data.tags) ? data.tags : []);
-          setBaseIngredientId(data.baseIngredientId || null);
+          setBaseIngredientId(data.baseIngredientId ?? null);
         }
       } catch {}
     })();
@@ -246,7 +246,7 @@ export default function EditIngredientScreen() {
       await InteractionManager.runAfterInteractions();
       const ingredients = await getAllIngredients();
       const baseOnly = ingredients
-        .filter((i) => !i.baseIngredientId && i.id !== currentId)
+        .filter((i) => i.baseIngredientId == null && i.id !== currentId)
         .sort((a, b) =>
           a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
         )
@@ -317,7 +317,7 @@ export default function EditIngredientScreen() {
       description,
       photoUri,
       tags,
-      baseIngredientId: baseIngredientId || null,
+      baseIngredientId: baseIngredientId ?? null,
     };
     await saveIngredient(updated);
     navigation.navigate("IngredientDetails", { id: updated.id });

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -162,9 +162,10 @@ export default function IngredientDetailsScreen() {
       .sort((a, b) => collator.compare(a.name, b.name));
     setBrandedChildren(children);
 
-    const base = loaded.baseIngredientId
-      ? all.find((i) => i.id === loaded.baseIngredientId)
-      : null;
+    const base =
+      loaded.baseIngredientId != null
+        ? all.find((i) => i.id === loaded.baseIngredientId)
+        : null;
     setBaseIngredient(base || null);
   }, [id, collator]);
 
@@ -201,7 +202,7 @@ export default function IngredientDetailsScreen() {
   }, []);
 
   const unlinkFromBase = useCallback(() => {
-    if (!ingredient?.baseIngredientId) return;
+    if (ingredient?.baseIngredientId == null) return;
     Alert.alert("Unlink", "Remove link to base ingredient?", [
       { text: "Cancel", style: "cancel" },
       {
@@ -255,7 +256,7 @@ export default function IngredientDetailsScreen() {
   }
 
   const isBase = brandedChildren.length > 0;
-  const isBranded = !!ingredient.baseIngredientId;
+  const isBranded = ingredient.baseIngredientId != null;
 
   return (
     <ScrollView

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -34,7 +34,7 @@ export async function addIngredient(ingredient) {
       ...ingredient,
       inBar: false,
       inShoppingList: false,
-      baseIngredientId: ingredient.baseIngredientId || null,
+      baseIngredientId: ingredient.baseIngredientId ?? null,
     },
   ];
   await saveAllIngredients(newList);


### PR DESCRIPTION
## Summary
- treat `baseIngredientId` as nullable instead of falsy across storage and ingredient screens
- prevent valid ID `0` from being dropped or misclassified when creating, editing, or viewing ingredients

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c7cc5d0548326929e6fda7c7fef0e