### PR TITLE
Remember last Cocktails tab

### DIFF
--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -1,7 +1,18 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { View, Text, StyleSheet } from "react-native";
+import { useTabMemory } from "../../context/TabMemoryContext";
 
 export default function AllCocktailsScreen() {
+  const { setTab } = useTabMemory();
+  const didSetTabRef = useRef(false);
+
+  useEffect(() => {
+    if (!didSetTabRef.current) {
+      setTab("cocktails", "All");
+      didSetTabRef.current = true;
+    }
+  }, [setTab]);
+
   return (
     <View style={styles.container}>
       <Text style={styles.text}>Cocktails coming soon!</Text>

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -1,7 +1,56 @@
-import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import React, { useCallback, useEffect, useLayoutEffect } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Platform,
+} from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { useTheme } from "react-native-paper";
+import { MaterialIcons } from "@expo/vector-icons";
+import { useTabMemory } from "../../context/TabMemoryContext";
 
 export default function CocktailDetailsScreen() {
+  const navigation = useNavigation();
+  const theme = useTheme();
+  const { getTab } = useTabMemory();
+  const previousTab = getTab("cocktails");
+
+  const handleGoBack = useCallback(() => {
+    if (previousTab) navigation.navigate(previousTab);
+    else navigation.goBack();
+  }, [navigation, previousTab]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerBackVisible: false,
+      headerLeft: () => (
+        <TouchableOpacity
+          onPress={handleGoBack}
+          style={styles.headerBackBtn}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+        >
+          <MaterialIcons
+            name={Platform.OS === "ios" ? "arrow-back-ios" : "arrow-back"}
+            size={24}
+            color={theme.colors.onSurface}
+          />
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation, handleGoBack, theme.colors.onSurface]);
+
+  useEffect(() => {
+    const unsub = navigation.addListener("beforeRemove", (e) => {
+      e.preventDefault();
+      handleGoBack();
+    });
+    return unsub;
+  }, [navigation, handleGoBack]);
+
   return (
     <View style={styles.container}>
       <Text style={styles.text}>Cocktails' Details coming soon!</Text>
@@ -12,4 +61,5 @@ export default function CocktailDetailsScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: "center", alignItems: "center" },
   text: { fontSize: 20 },
+  headerBackBtn: { paddingHorizontal: 8, paddingVertical: 4 },
 });

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -1,7 +1,18 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { View, Text, StyleSheet } from "react-native";
+import { useTabMemory } from "../../context/TabMemoryContext";
 
 export default function FavoriteCocktailsScreen() {
+  const { setTab } = useTabMemory();
+  const didSetTabRef = useRef(false);
+
+  useEffect(() => {
+    if (!didSetTabRef.current) {
+      setTab("cocktails", "Favorite");
+      didSetTabRef.current = true;
+    }
+  }, [setTab]);
+
   return (
     <View style={styles.container}>
       <Text style={styles.text}>Favorite cocktails coming soon!</Text>

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -1,7 +1,18 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { View, Text, StyleSheet } from "react-native";
+import { useTabMemory } from "../../context/TabMemoryContext";
 
 export default function MyCocktailsScreen() {
+  const { setTab } = useTabMemory();
+  const didSetTabRef = useRef(false);
+
+  useEffect(() => {
+    if (!didSetTabRef.current) {
+      setTab("cocktails", "My");
+      didSetTabRef.current = true;
+    }
+  }, [setTab]);
+
   return (
     <View style={styles.container}>
       <Text style={styles.text}>My cocktails coming soon!</Text>


### PR DESCRIPTION
## Summary
- track active Cocktails tab through TabMemory
- return to last visited Cocktails tab when leaving add or details screens

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_689c80c3267c832684741bdfdc8f2471