### PR TITLE
Prefill ingredient when creating cocktail from detail screen

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1043,6 +1043,7 @@ export default function AddCocktailScreen() {
   const route = useRoute();
   const isFocused = useIsFocused();
   const { getTab } = useTabMemory();
+  const initialIngredient = route.params?.initialIngredient;
   const lastCocktailsTab =
     (typeof getTab === "function" && getTab("cocktails")) || "All";
 
@@ -1092,8 +1093,8 @@ export default function AddCocktailScreen() {
   const [glassId, setGlassId] = useState("cocktail_glass");
 
   // ingredients list
-  const [ings, setIngs] = useState([
-    {
+  const [ings, setIngs] = useState(() => {
+    const baseRow = {
       localId: Date.now(),
       name: "",
       selectedId: null,
@@ -1105,8 +1106,19 @@ export default function AddCocktailScreen() {
       allowBaseSubstitute: false,
       allowBrandedSubstitutes: false,
       substitutes: [],
-    },
-  ]);
+    };
+    if (initialIngredient) {
+      return [
+        {
+          ...baseRow,
+          name: initialIngredient.name || "",
+          selectedId: initialIngredient.id ?? null,
+          selectedItem: initialIngredient,
+        },
+      ];
+    }
+    return [baseRow];
+  });
 
   // ingredients for suggestions
   const [allIngredients, setAllIngredients] = useState([]);

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -418,6 +418,15 @@ export default function IngredientDetailsScreen() {
           styles.addCocktailButton,
           { backgroundColor: theme.colors.primary },
         ]}
+        onPress={() =>
+          navigation.navigate("Cocktails", {
+            screen: "Create",
+            params: {
+              screen: "AddCocktail",
+              params: { initialIngredient: ingredient },
+            },
+          })
+        }
       >
         <Text
           style={[styles.addCocktailText, { color: theme.colors.onPrimary }]}


### PR DESCRIPTION
## Summary
- Allow jumping from ingredient details to cocktail creation
- Pre-fill first ingredient row in AddCocktail with selected ingredient

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_689c833dcf548326ad04287b4755ffd3