### PR TITLE
Reset cocktail creation form when leaving tab

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -22,7 +22,6 @@ import {
   Dimensions,
   Keyboard,
   BackHandler,
-  InteractionManager,
 } from "react-native";
 import Animated, {
   FadeInDown,
@@ -1312,29 +1311,23 @@ export default function AddCocktailScreen() {
     [navigation]
   );
 
-  useFocusEffect(
-    useCallback(() => {
-      let active = true;
-      const id = setTimeout(() => {
-        InteractionManager.runAfterInteractions(() => {
-          if (!active) return;
-          if (cameFromIngredient.current) {
-            cameFromIngredient.current = false;
-            return;
-          }
-          const incoming = route.params?.initialIngredient;
-          resetForm(incoming);
-          if (incoming) {
-            navigation.setParams({ initialIngredient: undefined });
-          }
-        });
-      }, 0);
-      return () => {
-        active = false;
-        clearTimeout(id);
-      };
-    }, [navigation, resetForm])
-  );
+  useEffect(() => {
+    if (!isFocused) return;
+    if (cameFromIngredient.current) {
+      cameFromIngredient.current = false;
+      return;
+    }
+    const incoming = route.params?.initialIngredient;
+    resetForm(incoming);
+    if (incoming) {
+      navigation.setParams({ initialIngredient: undefined });
+    }
+  }, [
+    isFocused,
+    route.params?.initialIngredient,
+    navigation,
+    resetForm,
+  ]);
 
   // Catch created ingredient returned from AddIngredient
   useFocusEffect(

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1317,9 +1317,12 @@ export default function AddCocktailScreen() {
         cameFromIngredient.current = false;
         return;
       }
-      resetForm(route.params?.initialIngredient);
-      navigation.setParams({ initialIngredient: undefined });
-    }, [navigation, resetForm, route.params?.initialIngredient])
+      const incoming = route.params?.initialIngredient;
+      resetForm(incoming);
+      if (incoming) {
+        navigation.setParams({ initialIngredient: undefined });
+      }
+    }, [navigation, resetForm])
   );
 
   // Catch created ingredient returned from AddIngredient

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -22,6 +22,7 @@ import {
   Dimensions,
   Keyboard,
   BackHandler,
+  InteractionManager,
 } from "react-native";
 import Animated, {
   FadeInDown,
@@ -1313,15 +1314,25 @@ export default function AddCocktailScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      if (cameFromIngredient.current) {
-        cameFromIngredient.current = false;
-        return;
-      }
-      const incoming = route.params?.initialIngredient;
-      resetForm(incoming);
-      if (incoming) {
-        navigation.setParams({ initialIngredient: undefined });
-      }
+      let active = true;
+      const id = setTimeout(() => {
+        InteractionManager.runAfterInteractions(() => {
+          if (!active) return;
+          if (cameFromIngredient.current) {
+            cameFromIngredient.current = false;
+            return;
+          }
+          const incoming = route.params?.initialIngredient;
+          resetForm(incoming);
+          if (incoming) {
+            navigation.setParams({ initialIngredient: undefined });
+          }
+        });
+      }, 0);
+      return () => {
+        active = false;
+        clearTimeout(id);
+      };
     }, [navigation, resetForm])
   );
 

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1322,12 +1322,7 @@ export default function AddCocktailScreen() {
     if (incoming) {
       navigation.setParams({ initialIngredient: undefined });
     }
-  }, [
-    isFocused,
-    route.params?.initialIngredient,
-    navigation,
-    resetForm,
-  ]);
+  }, [isFocused, navigation, resetForm]);
 
   // Catch created ingredient returned from AddIngredient
   useFocusEffect(


### PR DESCRIPTION
## Summary
- Ensure Add Cocktail screen resets to a fresh form unless returning from ingredient creation
- Pre-fill new cocktail form with ingredient passed from Ingredients tab

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c8840e5608326b7d1b8eca76df281