### PR TITLE
Add cocktail details screen

### DIFF
--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -92,13 +92,19 @@ const ItemRow = memo(
           {photoUri ? (
             <Image
               source={{ uri: photoUri }}
-              style={[styles.image, { backgroundColor: theme.colors.background }]}
+              style={[
+                styles.image,
+                { backgroundColor: theme.colors.background },
+              ]}
               resizeMode="cover"
             />
           ) : glassImage ? (
             <Image
               source={glassImage}
-              style={[styles.image, { backgroundColor: theme.colors.background }]}
+              style={[
+                styles.image,
+                { backgroundColor: theme.colors.background },
+              ]}
               resizeMode="cover"
             />
           ) : (
@@ -189,9 +195,7 @@ export default function AllCocktailsScreen() {
         getAllIngredients(),
       ]);
       if (cancel) return;
-      const ingMap = new Map(
-        (ingredientsList || []).map((i) => [i.id, i])
-      );
+      const ingMap = new Map((ingredientsList || []).map((i) => [i.id, i]));
       let list = Array.isArray(cocktailsList) ? cocktailsList : [];
       const q = searchDebounced.trim().toLowerCase();
       if (q) list = list.filter((c) => c.name.toLowerCase().includes(q));
@@ -220,7 +224,10 @@ export default function AllCocktailsScreen() {
   const handlePress = useCallback(
     (id) => {
       setNavigatingId(id);
-      navigation.navigate("CocktailDetails", { id });
+      navigation.navigate("Create", {
+        screen: "CocktailDetails",
+        params: { id },
+      });
       setTimeout(() => setNavigatingId(null), 500);
     },
     [navigation]
@@ -328,4 +335,3 @@ const styles = StyleSheet.create({
 
   brandedStripe: { borderLeftWidth: 4, paddingLeft: 4 },
 });
-

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -1,21 +1,142 @@
-import React, { useCallback, useEffect, useLayoutEffect } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  useMemo,
+  memo,
+} from "react";
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
   Platform,
+  ScrollView,
+  Image,
+  ActivityIndicator,
 } from "react-native";
-import { useNavigation } from "@react-navigation/native";
+import {
+  useNavigation,
+  useRoute,
+  useFocusEffect,
+} from "@react-navigation/native";
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useTabMemory } from "../../context/TabMemoryContext";
+import { getCocktailById } from "../../storage/cocktailsStorage";
+import { getAllIngredients } from "../../storage/ingredientsStorage";
+import { getUnitById } from "../../constants/measureUnits";
+import { getGlassById } from "../../constants/glassware";
+
+/* ---------- helpers ---------- */
+const withAlpha = (hex, alpha) => {
+  if (!hex || hex[0] !== "#" || (hex.length !== 7 && hex.length !== 9))
+    return hex;
+  const a = Math.round(alpha * 255)
+    .toString(16)
+    .padStart(2, "0");
+  return hex.length === 7 ? `${hex}${a}` : `${hex.slice(0, 7)}${a}`;
+};
+
+/* ---------- Ingredient row (like AllIngredients) ---------- */
+const IMAGE_SIZE = 50;
+const ROW_VERTICAL = 8;
+const ROW_BORDER = 1;
+
+const IngredientRow = memo(function IngredientRow({
+  name,
+  photoUri,
+  amount,
+  unitName,
+  inBar,
+  garnish,
+  substituteFor,
+}) {
+  const theme = useTheme();
+  const backgroundColor = inBar
+    ? withAlpha(theme.colors.secondary, 0.25)
+    : theme.colors.background;
+
+  return (
+    <View
+      style={[
+        styles.ingWrapper,
+        { borderBottomColor: theme.colors.background, backgroundColor },
+      ]}
+    >
+      <View style={[styles.ingItem, !inBar && styles.dimmed]}>
+        {photoUri ? (
+          <Image
+            source={{ uri: photoUri }}
+            style={[styles.ingImage, { backgroundColor: theme.colors.background }]}
+            resizeMode="cover"
+          />
+        ) : (
+          <View
+            style={[
+              styles.ingImage,
+              styles.placeholder,
+              { backgroundColor: theme.colors.surface },
+            ]}
+          >
+            <Text
+              style={[
+                styles.placeholderText,
+                { color: theme.colors.onSurfaceVariant },
+              ]}
+            >
+              No image
+            </Text>
+          </View>
+        )}
+
+        <View style={styles.ingInfo}>
+          <Text
+            numberOfLines={1}
+            style={[styles.name, { color: theme.colors.onSurface }]}
+          >
+            {name}
+          </Text>
+          {amount ? (
+            <Text style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}>
+              {amount} {unitName}
+            </Text>
+          ) : null}
+          {garnish && (
+            <Text style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}>
+              (garnish)
+            </Text>
+          )}
+          {substituteFor && (
+            <Text style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}>
+              substitute for {substituteFor}
+            </Text>
+          )}
+        </View>
+
+        <MaterialIcons
+          name={inBar ? "check-circle" : "radio-button-unchecked"}
+          size={22}
+          color={
+            inBar ? theme.colors.primary : theme.colors.onSurfaceVariant
+          }
+        />
+      </View>
+    </View>
+  );
+});
 
 export default function CocktailDetailsScreen() {
   const navigation = useNavigation();
+  const { id } = useRoute().params;
   const theme = useTheme();
   const { getTab } = useTabMemory();
   const previousTab = getTab("cocktails");
+
+  const [cocktail, setCocktail] = useState(null);
+  const [ingMap, setIngMap] = useState(new Map());
+  const [loading, setLoading] = useState(true);
 
   const handleGoBack = useCallback(() => {
     if (previousTab) navigation.navigate(previousTab);
@@ -51,15 +172,189 @@ export default function CocktailDetailsScreen() {
     return unsub;
   }, [navigation, handleGoBack]);
 
+  const load = useCallback(async () => {
+    setLoading(true);
+    const [loadedCocktail, allIngredients] = await Promise.all([
+      getCocktailById(id),
+      getAllIngredients(),
+    ]);
+    setCocktail(loadedCocktail || null);
+    setIngMap(new Map((allIngredients || []).map((i) => [i.id, i])));
+    setLoading(false);
+  }, [id]);
+
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        try {
+          await load();
+        } catch {}
+      })();
+    }, [load])
+  );
+
+  const rows = useMemo(() => {
+    if (!cocktail) return [];
+    const list = Array.isArray(cocktail.ingredients)
+      ? [...cocktail.ingredients].sort((a, b) => a.order - b.order)
+      : [];
+    return list.map((r) => {
+      const ing = r.ingredientId ? ingMap.get(r.ingredientId) : null;
+      const originalName = ing?.name || r.name;
+      const inBar = ing?.inBar;
+      let substitute = null;
+      if (!inBar && r.allowBaseSubstitution && ing) {
+        const baseId = ing.baseIngredientId ?? ing.id;
+        substitute = Array.from(ingMap.values()).find((i) => {
+          if (!i.inBar) return false;
+          if (i.id === baseId) return true;
+          return i.baseIngredientId === baseId;
+        });
+      }
+      const display = substitute || ing || {};
+      return {
+        key: `${r.order}-${r.ingredientId ?? "free"}`,
+        name: display.name || r.name,
+        photoUri: display.photoUri || null,
+        amount: r.amount,
+        unitName: getUnitById(r.unitId)?.name || "",
+        inBar: substitute ? substitute.inBar : inBar,
+        garnish: !!r.garnish,
+        substituteFor: substitute ? originalName : null,
+      };
+    });
+  }, [cocktail, ingMap]);
+
+  if (loading)
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+
+  if (!cocktail)
+    return (
+      <View style={styles.loadingContainer}>
+        <Text style={{ color: theme.colors.onSurfaceVariant }}>
+          Cocktail not found
+        </Text>
+      </View>
+    );
+
+  const glass = cocktail.glassId ? getGlassById(cocktail.glassId) : null;
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>Cocktails' Details coming soon!</Text>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        {cocktail.photoUri && (
+          <Image source={{ uri: cocktail.photoUri }} style={styles.photo} />
+        )}
+
+        <Text style={[styles.title, { color: theme.colors.onSurface }]}>
+          {cocktail.name}
+        </Text>
+
+        {glass && (
+          <Text style={[styles.glass, { color: theme.colors.onSurfaceVariant }]}>
+            {glass.name}
+          </Text>
+        )}
+
+        {Array.isArray(cocktail.tags) && cocktail.tags.length > 0 && (
+          <View style={styles.tagRow}>
+            {cocktail.tags.map((tag) => (
+              <View
+                key={tag.id}
+                style={[styles.tag, { backgroundColor: tag.color }]}
+              >
+                <Text style={styles.tagText}>{tag.name}</Text>
+              </View>
+            ))}
+          </View>
+        )}
+
+        {cocktail.description ? (
+          <Text
+            style={[styles.sectionText, { color: theme.colors.onSurface }]}>
+            {cocktail.description}
+          </Text>
+        ) : null}
+
+        {cocktail.instructions ? (
+          <View style={{ marginTop: 16 }}>
+            <Text
+              style={[styles.sectionTitle, { color: theme.colors.onSurface }]}
+            >
+              Instructions
+            </Text>
+            <Text
+              style={[styles.sectionText, { color: theme.colors.onSurface }]}
+            >
+              {cocktail.instructions}
+            </Text>
+          </View>
+        ) : null}
+
+        {rows.length > 0 && (
+          <View style={{ marginTop: 24 }}>
+            <Text
+              style={[styles.sectionTitle, { color: theme.colors.onSurface }]}
+            >
+              Ingredients
+            </Text>
+            <View style={styles.ingList}>
+              {rows.map((r) => (
+                <IngredientRow key={r.key} {...r} />
+              ))}
+            </View>
+          </View>
+        )}
+      </ScrollView>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: "center", alignItems: "center" },
-  text: { fontSize: 20 },
+  container: { flex: 1 },
+  loadingContainer: { flex: 1, justifyContent: "center", alignItems: "center" },
   headerBackBtn: { paddingHorizontal: 8, paddingVertical: 4 },
+  scrollContent: { paddingBottom: 24 },
+  photo: { width: "100%", height: 200 },
+  title: { fontSize: 24, fontWeight: "bold", marginHorizontal: 16, marginTop: 16 },
+  glass: { marginHorizontal: 16, marginTop: 4 },
+  tagRow: { flexDirection: "row", flexWrap: "wrap", marginHorizontal: 16, marginTop: 8 },
+  tag: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+    marginRight: 6,
+    marginBottom: 4,
+  },
+  tagText: { fontSize: 10, color: "white", fontWeight: "bold" },
+  sectionTitle: { fontSize: 18, fontWeight: "bold", marginHorizontal: 16, marginBottom: 4 },
+  sectionText: { marginHorizontal: 16, marginTop: 8, lineHeight: 20 },
+
+  ingList: { marginTop: 8 },
+  ingWrapper: { borderBottomWidth: ROW_BORDER },
+  ingItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: ROW_VERTICAL,
+    paddingHorizontal: 12,
+    position: "relative",
+  },
+  ingImage: {
+    width: IMAGE_SIZE,
+    height: IMAGE_SIZE,
+    borderRadius: 8,
+    marginRight: 12,
+    overflow: "hidden",
+  },
+  placeholder: { justifyContent: "center", alignItems: "center" },
+  placeholderText: { fontSize: 10, textAlign: "center" },
+  ingInfo: { flex: 1, paddingRight: 8 },
+  name: { fontSize: 16, fontWeight: "bold" },
+  meta: { fontSize: 12, marginTop: 2 },
+  dimmed: { opacity: 0.88 },
 });
+

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -69,7 +69,10 @@ const IngredientRow = memo(function IngredientRow({
         {photoUri ? (
           <Image
             source={{ uri: photoUri }}
-            style={[styles.ingImage, { backgroundColor: theme.colors.background }]}
+            style={[
+              styles.ingImage,
+              { backgroundColor: theme.colors.background },
+            ]}
             resizeMode="cover"
           />
         ) : (
@@ -99,17 +102,23 @@ const IngredientRow = memo(function IngredientRow({
             {name}
           </Text>
           {amount ? (
-            <Text style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}>
+            <Text
+              style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}
+            >
               {amount} {unitName}
             </Text>
           ) : null}
           {garnish && (
-            <Text style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}>
+            <Text
+              style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}
+            >
               (garnish)
             </Text>
           )}
           {substituteFor && (
-            <Text style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}>
+            <Text
+              style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}
+            >
               substitute for {substituteFor}
             </Text>
           )}
@@ -118,9 +127,7 @@ const IngredientRow = memo(function IngredientRow({
         <MaterialIcons
           name={inBar ? "check-circle" : "radio-button-unchecked"}
           size={22}
-          color={
-            inBar ? theme.colors.primary : theme.colors.onSurfaceVariant
-          }
+          color={inBar ? theme.colors.primary : theme.colors.onSurfaceVariant}
         />
       </View>
     </View>
@@ -255,7 +262,9 @@ export default function CocktailDetailsScreen() {
         </Text>
 
         {glass && (
-          <Text style={[styles.glass, { color: theme.colors.onSurfaceVariant }]}>
+          <Text
+            style={[styles.glass, { color: theme.colors.onSurfaceVariant }]}
+          >
             {glass.name}
           </Text>
         )}
@@ -274,8 +283,7 @@ export default function CocktailDetailsScreen() {
         )}
 
         {cocktail.description ? (
-          <Text
-            style={[styles.sectionText, { color: theme.colors.onSurface }]}>
+          <Text style={[styles.sectionText, { color: theme.colors.onSurface }]}>
             {cocktail.description}
           </Text>
         ) : null}
@@ -303,8 +311,8 @@ export default function CocktailDetailsScreen() {
               Ingredients
             </Text>
             <View style={styles.ingList}>
-              {rows.map((r) => (
-                <IngredientRow key={r.key} {...r} />
+              {rows.map(({ key, ...props }) => (
+                <IngredientRow key={key} {...props} />
               ))}
             </View>
           </View>
@@ -320,9 +328,19 @@ const styles = StyleSheet.create({
   headerBackBtn: { paddingHorizontal: 8, paddingVertical: 4 },
   scrollContent: { paddingBottom: 24 },
   photo: { width: "100%", height: 200 },
-  title: { fontSize: 24, fontWeight: "bold", marginHorizontal: 16, marginTop: 16 },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    marginHorizontal: 16,
+    marginTop: 16,
+  },
   glass: { marginHorizontal: 16, marginTop: 4 },
-  tagRow: { flexDirection: "row", flexWrap: "wrap", marginHorizontal: 16, marginTop: 8 },
+  tagRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    marginHorizontal: 16,
+    marginTop: 8,
+  },
   tag: {
     paddingHorizontal: 8,
     paddingVertical: 2,
@@ -331,7 +349,12 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   tagText: { fontSize: 10, color: "white", fontWeight: "bold" },
-  sectionTitle: { fontSize: 18, fontWeight: "bold", marginHorizontal: 16, marginBottom: 4 },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "bold",
+    marginHorizontal: 16,
+    marginBottom: 4,
+  },
   sectionText: { marginHorizontal: 16, marginTop: 8, lineHeight: 20 },
 
   ingList: { marginTop: 8 },
@@ -357,4 +380,3 @@ const styles = StyleSheet.create({
   meta: { fontSize: 12, marginTop: 2 },
   dimmed: { opacity: 0.88 },
 });
-


### PR DESCRIPTION
## Summary
- implement cocktail details screen showing cocktail info and ordered ingredient list
- support garnish note and base substitutes when ingredients are missing

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c91ec75f48326a18b67dde7735f38