### PR TITLE
Show glass when cocktail photo missing

### DIFF
--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -57,7 +57,11 @@ const ItemRow = memo(
       () => ({ color: withAlpha(theme.colors.tertiary, 0.35) }),
       [theme.colors.tertiary]
     );
-    const glassImage = glassId ? getGlassById(glassId)?.image : null;
+    const imageSource = photoUri
+      ? { uri: photoUri }
+      : glassId
+      ? getGlassById(glassId)?.image
+      : null;
     const backgroundColor = isAllAvailable
       ? withAlpha(theme.colors.secondary, 0.25)
       : theme.colors.background;
@@ -89,18 +93,9 @@ const ItemRow = memo(
           ]}
           hitSlop={{ top: 4, bottom: 4 }}
         >
-          {photoUri ? (
+          {imageSource ? (
             <Image
-              source={{ uri: photoUri }}
-              style={[
-                styles.image,
-                { backgroundColor: theme.colors.background },
-              ]}
-              resizeMode="cover"
-            />
-          ) : glassImage ? (
-            <Image
-              source={glassImage}
+              source={imageSource}
               style={[
                 styles.image,
                 { backgroundColor: theme.colors.background },

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -249,12 +249,15 @@ export default function CocktailDetailsScreen() {
     );
 
   const glass = cocktail.glassId ? getGlassById(cocktail.glassId) : null;
+  const imageSource = cocktail.photoUri
+    ? { uri: cocktail.photoUri }
+    : glass?.image || null;
 
   return (
     <View style={styles.container}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
-        {cocktail.photoUri && (
-          <Image source={{ uri: cocktail.photoUri }} style={styles.photo} />
+        {imageSource && (
+          <Image source={imageSource} style={styles.photo} />
         )}
 
         <Text style={[styles.title, { color: theme.colors.onSurface }]}>


### PR DESCRIPTION
## Summary
- show glassware image for cocktails without photos in list view
- use same glassware fallback in cocktail details screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ca1fbf0288326b0e86970e61928f5