### PR TITLE
fix: show tag filter menu below button

### DIFF
--- a/src/components/TagFilterMenu.js
+++ b/src/components/TagFilterMenu.js
@@ -40,6 +40,7 @@ export default function TagFilterMenu({
           />
         </TouchableOpacity>
       }
+      anchorPosition="bottom"
       contentStyle={{
         paddingHorizontal: 4,
         paddingVertical: 4,


### PR DESCRIPTION
## Summary
- ensure tag filter dropdown displays beneath filter button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cc4bade648326bd10b5f002a49667