### PR TITLE
Blur inputs when opening unit dropdown

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -162,6 +162,7 @@ const IngredientRow = memo(function IngredientRow({
   const [unitPlacement, setUnitPlacement] = useState("bottom");
   const [unitMenuOpen, setUnitMenuOpen] = useState(false);
   const openUnitMenuMeasured = useCallback(() => {
+    Keyboard.dismiss();
     if (!unitTriggerRef.current) {
       setUnitPlacement("bottom");
       setUnitMenuOpen(true);


### PR DESCRIPTION
## Summary
- dismiss keyboard when opening ingredient unit dropdown on AddCocktail screen

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cc630b0c88326a7bfe7d3ca2320c2