### PR TITLE
style: color ingredient volumes in cocktail details

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -121,7 +121,9 @@ const IngredientRow = memo(function IngredientRow({
         </View>
 
         {amount ? (
-          <Text style={[styles.amountText, { color: theme.colors.onSurface }]}>
+          <Text
+            style={[styles.amountText, { color: theme.colors.onSurfaceVariant }]}
+          >
             {amount} {unitName}
           </Text>
         ) : null}


### PR DESCRIPTION
## Summary
- render cocktail ingredient amounts using onSurfaceVariant color

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cca5ba41483269d7ae1fe3b25320d