### PR TITLE
Show glass when cocktail lacks photo

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -274,7 +274,11 @@ export default function CocktailDetailsScreen() {
       {cocktail.photoUri ? (
         <Image source={{ uri: cocktail.photoUri }} style={styles.photo} />
       ) : glass ? (
-        <Image source={glass.image} style={styles.photo} />
+        <Image
+          source={glass.image}
+          style={styles.photo}
+          resizeMode="contain"
+        />
       ) : null}
 
       <View style={styles.body}>


### PR DESCRIPTION
## Summary
- fallback to glass image on cocktail details when no photo is provided

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ccc6e2a248326a20f88c1de039868