### PR TITLE
Fix ingredient navigation from cocktails

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1062,8 +1062,11 @@ export default function AddCocktailScreen() {
           onPress={() => {
             if (fromIngredientFlow) {
               navigation.navigate("Ingredients", {
-                screen: "IngredientDetails",
-                params: { id: initialIngredient?.id },
+                screen: "Create",
+                params: {
+                  screen: "IngredientDetails",
+                  params: { id: initialIngredient?.id },
+                },
               });
             } else {
               navigation.navigate("Cocktails", { screen: lastCocktailsTab });
@@ -1082,8 +1085,11 @@ export default function AddCocktailScreen() {
       e.preventDefault();
       if (fromIngredientFlow) {
         navigation.navigate("Ingredients", {
-          screen: "IngredientDetails",
-          params: { id: initialIngredient?.id },
+          screen: "Create",
+          params: {
+            screen: "IngredientDetails",
+            params: { id: initialIngredient?.id },
+          },
         });
       } else {
         navigation.navigate("Cocktails", { screen: lastCocktailsTab });
@@ -1093,8 +1099,11 @@ export default function AddCocktailScreen() {
     const hwSub = BackHandler.addEventListener("hardwareBackPress", () => {
       if (fromIngredientFlow) {
         navigation.navigate("Ingredients", {
-          screen: "IngredientDetails",
-          params: { id: initialIngredient?.id },
+          screen: "Create",
+          params: {
+            screen: "IngredientDetails",
+            params: { id: initialIngredient?.id },
+          },
         });
       } else {
         navigation.navigate("Cocktails", { screen: lastCocktailsTab });

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -365,8 +365,11 @@ export default function CocktailDetailsScreen() {
                     ingredientId
                       ? () =>
                           navigation.navigate("Ingredients", {
-                            screen: "IngredientDetails",
-                            params: { id: ingredientId },
+                            screen: "Create",
+                            params: {
+                              screen: "IngredientDetails",
+                              params: { id: ingredientId },
+                            },
                           })
                       : undefined
                   }

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -368,7 +368,7 @@ export default function CocktailDetailsScreen() {
                             screen: "Create",
                             params: {
                               screen: "IngredientDetails",
-                              params: { id: ingredientId },
+                              params: { id: ingredientId, fromCocktailId: id },
                             },
                           })
                       : undefined

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -94,7 +94,7 @@ const RelationRow = memo(function RelationRow({
 
 export default function IngredientDetailsScreen() {
   const navigation = useNavigation();
-  const { id } = useRoute().params;
+  const { id, fromCocktailId } = useRoute().params;
   const theme = useTheme();
 
   const [ingredient, setIngredient] = useState(null);
@@ -110,9 +110,14 @@ export default function IngredientDetailsScreen() {
   const previousTab = getTab("ingredients");
 
   const handleGoBack = useCallback(() => {
-    if (previousTab) navigation.navigate(previousTab);
+    if (fromCocktailId)
+      navigation.navigate("Cocktails", {
+        screen: "CocktailDetails",
+        params: { id: fromCocktailId },
+      });
+    else if (previousTab) navigation.navigate(previousTab);
     else navigation.goBack();
-  }, [navigation, previousTab]);
+  }, [navigation, previousTab, fromCocktailId]);
 
   const handleEdit = useCallback(() => {
     navigation.navigate("EditIngredient", { id });

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -16,6 +16,7 @@ import {
   ActivityIndicator,
   Platform,
   Alert,
+  BackHandler,
 } from "react-native";
 import {
   useNavigation,
@@ -163,6 +164,17 @@ export default function IngredientDetailsScreen() {
     });
     return unsub;
   }, [navigation, handleGoBack]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const onBack = () => {
+        handleGoBack();
+        return true;
+      };
+      BackHandler.addEventListener("hardwareBackPress", onBack);
+      return () => BackHandler.removeEventListener("hardwareBackPress", onBack);
+    }, [handleGoBack])
+  );
 
   const load = useCallback(async () => {
     const [loaded, all] = await Promise.all([

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -171,8 +171,8 @@ export default function IngredientDetailsScreen() {
         handleGoBack();
         return true;
       };
-      BackHandler.addEventListener("hardwareBackPress", onBack);
-      return () => BackHandler.removeEventListener("hardwareBackPress", onBack);
+      const sub = BackHandler.addEventListener("hardwareBackPress", onBack);
+      return () => sub.remove();
     }, [handleGoBack])
   );
 


### PR DESCRIPTION
## Summary
- fix ingredient row press in cocktail details to open ingredient details
- update cocktail creation flows to navigate back to ingredient details correctly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ccfba2b048326b254c4800855a367