### PR TITLE
Fix infinite back navigation loop

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1082,6 +1082,7 @@ export default function AddCocktailScreen() {
     if (!isFocused) return;
 
     const beforeRemoveSub = navigation.addListener("beforeRemove", (e) => {
+      if (e.data.action.type === "NAVIGATE") return;
       e.preventDefault();
       if (fromIngredientFlow) {
         navigation.navigate("Ingredients", {

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -199,11 +199,12 @@ export default function CocktailDetailsScreen() {
 
   useEffect(() => {
     const unsub = navigation.addListener("beforeRemove", (e) => {
+      if (e.data.action.type === "NAVIGATE" || !previousTab) return;
       e.preventDefault();
-      handleGoBack();
+      navigation.navigate(previousTab);
     });
     return unsub;
-  }, [navigation, handleGoBack]);
+  }, [navigation, previousTab]);
 
   const load = useCallback(async () => {
     setLoading(true);

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -179,6 +179,7 @@ export default function AddIngredientScreen() {
     if (!isFocused) return;
 
     const beforeRemoveSub = navigation.addListener("beforeRemove", (e) => {
+      if (e.data.action.type === "NAVIGATE") return;
       e.preventDefault();
       if (fromCocktailFlow) {
         navigation.navigate("Cocktails", { screen: returnTo });

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -201,6 +201,7 @@ export default function EditIngredientScreen() {
   // перехоплюємо системний back/gesture
   useEffect(() => {
     const unsub = navigation.addListener("beforeRemove", (e) => {
+      if (e.data.action.type === "NAVIGATE") return;
       e.preventDefault();
       handleGoBack();
     });

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -159,11 +159,16 @@ export default function IngredientDetailsScreen() {
 
   useEffect(() => {
     const unsub = navigation.addListener("beforeRemove", (e) => {
+      if (
+        e.data.action.type === "NAVIGATE" ||
+        (!fromCocktailId && !previousTab)
+      )
+        return;
       e.preventDefault();
       handleGoBack();
     });
     return unsub;
-  }, [navigation, handleGoBack]);
+  }, [navigation, handleGoBack, fromCocktailId, previousTab]);
 
   useFocusEffect(
     useCallback(() => {


### PR DESCRIPTION
## Summary
- Skip `beforeRemove` handlers for navigation actions to avoid endless back navigation and call stack overflow
- Only intercept `beforeRemove` when a custom return target exists

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689cdbf2ff548326a9327dc1edf3e4a8