### PR TITLE
Ensure cocktails list is alphabetical

### DIFF
--- a/src/storage/cocktailsStorage.js
+++ b/src/storage/cocktailsStorage.js
@@ -17,6 +17,8 @@ const safeParse = (raw) => {
 const now = () => Date.now();
 const genId = () => now(); // сумісно з твоїми екранами (Date.now())
 
+const sortByName = (a, b) => a.name.localeCompare(b.name);
+
 const sanitizeIngredient = (r, idx) => ({
   order: Number(r?.order ?? idx + 1),
   ingredientId: r?.ingredientId ?? null, // може бути null для фрітекасту
@@ -59,11 +61,12 @@ const sanitizeCocktail = (c) => {
 // --- low-level IO ---
 async function readAll() {
   const raw = await AsyncStorage.getItem(STORAGE_KEY);
-  return safeParse(raw);
+  return safeParse(raw).sort(sortByName);
 }
 async function writeAll(list) {
-  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(list));
-  return list;
+  const sorted = [...list].sort(sortByName);
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(sorted));
+  return sorted;
 }
 
 // --- API ---


### PR DESCRIPTION
## Summary
- always sort cocktails by name in storage reads and writes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cdd13d91083268e5d26a9138506f7