### PR TITLE
fix: ensure cocktail detail photo fits

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -306,7 +306,11 @@ export default function CocktailDetailsScreen() {
       </Text>
 
       {cocktail.photoUri ? (
-        <Image source={{ uri: cocktail.photoUri }} style={styles.photo} />
+        <Image
+          source={{ uri: cocktail.photoUri }}
+          style={styles.photo}
+          resizeMode="contain"
+        />
       ) : glass ? (
         <Image source={glass.image} style={styles.photo} resizeMode="contain" />
       ) : null}


### PR DESCRIPTION
## Summary
- prevent cocktail photo cropping by displaying it with `resizeMode="contain"`

## Testing
- `npm test` *(fails: Missing script: "test"?)*

------
https://chatgpt.com/codex/tasks/task_e_689ce1606fd08326ab5487db943ae6c2