### PR TITLE
Align branded stripe across cocktail lists

### DIFF
--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -365,5 +365,5 @@ const styles = StyleSheet.create({
   },
   tagText: { fontSize: 10, color: "white", fontWeight: "bold" },
 
-  brandedStripe: { borderLeftWidth: 4, paddingLeft: 4 },
+  brandedStripe: { borderLeftWidth: 4, paddingLeft: 8 },
 });

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -473,7 +473,7 @@ const styles = StyleSheet.create({
   tagText: { fontSize: 10, color: "white", fontWeight: "bold" },
 
   cartIcon: { position: "absolute", bottom: 4, right: 36, zIndex: 1 },
-  brandedStripe: { borderLeftWidth: 4, paddingLeft: 4 },
+  brandedStripe: { borderLeftWidth: 4, paddingLeft: 8 },
 
   checkButton: { marginLeft: 8, paddingVertical: 6, paddingHorizontal: 4 },
   pressedCheck: { opacity: 0.7, transform: [{ scale: 0.92 }] },

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -388,6 +388,6 @@ const styles = StyleSheet.create({
   tagText: { fontSize: 10, color: "white", fontWeight: "bold" },
 
   cartIcon: { position: "absolute", bottom: 4, right: 36, zIndex: 1 },
-  brandedStripe: { borderLeftWidth: 4, paddingLeft: 4 },
+  brandedStripe: { borderLeftWidth: 4, paddingLeft: 8 },
 });
 

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -407,7 +407,7 @@ const styles = StyleSheet.create({
   },
   tagText: { fontSize: 10, color: "white", fontWeight: "bold" },
 
-  brandedStripe: { borderLeftWidth: 4, paddingLeft: 4 },
+  brandedStripe: { borderLeftWidth: 4, paddingLeft: 8 },
 
   removeButton: { marginLeft: 8, paddingVertical: 6, paddingHorizontal: 4 },
   pressedRemove: { opacity: 0.7, transform: [{ scale: 0.92 }] },


### PR DESCRIPTION
## Summary
- ensure cocktails with branded ingredients show a 4px primary-colored stripe
- keep list content aligned by adding offset padding for branded items across cocktail and ingredient lists

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ce222536883269bcf8c407dd8b5ca