### PR TITLE
Align ingredient detail layout with cocktails

### DIFF
--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -202,17 +202,16 @@ export default function EditIngredientScreen() {
   const initialHashRef = useRef("{}");
   const [dirty, setDirty] = useState(false);
 
-  const serialize = useCallback(
-    () =>
-      JSON.stringify({
-        name: name.trim(),
-        description,
-        photoUri,
-        tags,
-        baseIngredientId,
-      }),
-    [name, description, photoUri, tags, baseIngredientId]
-  );
+  const serialize = useCallback(() => {
+    const tagIds = [...tags].map((t) => t.id).sort();
+    return JSON.stringify({
+      name: name.trim(),
+      description,
+      photoUri,
+      baseIngredientId,
+      tags: tagIds,
+    });
+  }, [name, description, photoUri, tags, baseIngredientId]);
 
   useEffect(() => {
     if (ingredient) initialHashRef.current = serialize();

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -396,6 +396,26 @@ export default function EditIngredientScreen() {
     ]);
   }, [ingredient, navigation, previousTab]);
 
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <TouchableOpacity
+          onPress={handleSave}
+          style={{ paddingHorizontal: 8, paddingVertical: 4 }}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          accessibilityRole="button"
+          accessibilityLabel="Save"
+        >
+          <MaterialIcons
+            name="check"
+            size={24}
+            color={theme.colors.onSurface}
+          />
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation, handleSave, theme.colors.onSurface]);
+
   const openMenu = useCallback(() => {
     if (!anchorRef.current) return;
     anchorRef.current.measureInWindow((x, y, w, h) => {
@@ -665,8 +685,8 @@ export default function EditIngredientScreen() {
           onChangeText={setDescription}
           style={[
             styles.input,
+            styles.multiline,
             {
-              height: 60,
               borderColor: theme.colors.outline,
               color: theme.colors.onSurface,
               backgroundColor: theme.colors.surface,
@@ -674,17 +694,6 @@ export default function EditIngredientScreen() {
           ]}
           multiline
         />
-
-        <Pressable
-          style={[styles.saveButton, { backgroundColor: theme.colors.primary }]}
-          onPress={handleSave}
-          android_ripple={{ color: theme.colors.onPrimary }}
-          disabled={!name.trim()}
-        >
-          <Text style={{ color: theme.colors.onPrimary, fontWeight: "bold" }}>
-            Save Changes
-          </Text>
-        </Pressable>
 
         <Pressable
           style={[styles.saveButton, { backgroundColor: theme.colors.error }]}
@@ -706,6 +715,8 @@ const styles = StyleSheet.create({
   input: { borderWidth: 1, padding: 10, marginTop: 8, borderRadius: 8 },
   anchorInput: { justifyContent: "center", minHeight: 44 },
   anchorRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+
+  multiline: { minHeight: 80, textAlignVertical: "top" },
 
   imageButton: {
     marginTop: 8,

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -400,21 +400,21 @@ export default function EditIngredientScreen() {
     navigation.setOptions({
       headerRight: () => (
         <TouchableOpacity
-          onPress={handleSave}
+          onPress={handleDelete}
           style={{ paddingHorizontal: 8, paddingVertical: 4 }}
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           accessibilityRole="button"
-          accessibilityLabel="Save"
+          accessibilityLabel="Delete ingredient"
         >
           <MaterialIcons
-            name="check"
+            name="delete"
             size={24}
             color={theme.colors.onSurface}
           />
         </TouchableOpacity>
       ),
     });
-  }, [navigation, handleSave, theme.colors.onSurface]);
+  }, [navigation, handleDelete, theme.colors.onSurface]);
 
   const openMenu = useCallback(() => {
     if (!anchorRef.current) return;
@@ -696,12 +696,12 @@ export default function EditIngredientScreen() {
         />
 
         <Pressable
-          style={[styles.saveButton, { backgroundColor: theme.colors.error }]}
-          onPress={handleDelete}
-          android_ripple={{ color: theme.colors.onErrorContainer }}
+          style={[styles.saveButton, { backgroundColor: theme.colors.primary }]}
+          onPress={handleSave}
+          android_ripple={{ color: theme.colors.onPrimaryContainer }}
         >
-          <Text style={{ color: theme.colors.onError, fontWeight: "bold" }}>
-            Delete Ingredient
+          <Text style={{ color: theme.colors.onPrimary, fontWeight: "bold" }}>
+            Save changes
           </Text>
         </Pressable>
       </ScrollView>

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -365,7 +365,10 @@ export default function EditIngredientScreen() {
       await saveIngredient(updated);
       initialHashRef.current = serialize();
       setDirty(false);
-      if (!stay) navigation.navigate("IngredientDetails", { id: updated.id });
+      if (!stay) {
+        skipPromptRef.current = true;
+        navigation.navigate("IngredientDetails", { id: updated.id });
+      }
       return updated;
     },
     [

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -27,7 +27,6 @@ import {
   getIngredientById,
   getAllIngredients,
   saveIngredient,
-  deleteIngredient,
 } from "../../storage/ingredientsStorage";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useTabMemory } from "../../context/TabMemoryContext";
@@ -124,26 +123,6 @@ export default function IngredientDetailsScreen() {
     navigation.navigate("EditIngredient", { id });
   }, [navigation, id]);
 
-  const handleDelete = useCallback(() => {
-    Alert.alert("Delete", "Delete this ingredient?", [
-      { text: "Cancel", style: "cancel" },
-      {
-        text: "Delete",
-        style: "destructive",
-        onPress: async () => {
-          await deleteIngredient(id);
-          if (fromCocktailId)
-            navigation.navigate("Cocktails", {
-              screen: "CocktailDetails",
-              params: { id: fromCocktailId },
-            });
-          else if (previousTab) navigation.navigate(previousTab);
-          else navigation.goBack();
-        },
-      },
-    ]);
-  }, [id, navigation, previousTab, fromCocktailId]);
-
   // Always show custom back button
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -164,41 +143,25 @@ export default function IngredientDetailsScreen() {
         </TouchableOpacity>
       ),
       headerRight: () => (
-        <View style={{ flexDirection: "row" }}>
-          <TouchableOpacity
-            onPress={handleEdit}
-            style={styles.headerEditBtn}
-            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-            accessibilityRole="button"
-            accessibilityLabel="Edit"
-          >
-            <MaterialIcons
-              name="edit"
-              size={24}
-              color={theme.colors.onSurface}
-            />
-          </TouchableOpacity>
-          <TouchableOpacity
-            onPress={handleDelete}
-            style={styles.headerEditBtn}
-            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-            accessibilityRole="button"
-            accessibilityLabel="Delete ingredient"
-          >
-            <MaterialIcons
-              name="delete"
-              size={24}
-              color={theme.colors.onSurface}
-            />
-          </TouchableOpacity>
-        </View>
+        <TouchableOpacity
+          onPress={handleEdit}
+          style={styles.headerEditBtn}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          accessibilityRole="button"
+          accessibilityLabel="Edit"
+        >
+          <MaterialIcons
+            name="edit"
+            size={24}
+            color={theme.colors.onSurface}
+          />
+        </TouchableOpacity>
       ),
     });
   }, [
     navigation,
     handleGoBack,
     handleEdit,
-    handleDelete,
     theme.colors.onSurface,
   ]);
 


### PR DESCRIPTION
## Summary
- Center ingredient photos at cocktail-size and move action icons below
- Add header delete button with consistent confirmation
- Prompt to save or discard changes when editing ingredients

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ce40231508326a872ed68df3c6521