### PR TITLE
Fix back navigation loop between cocktail detail and edit screens

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -147,9 +147,8 @@ export default function CocktailDetailsScreen() {
   const [loading, setLoading] = useState(true);
 
   const handleGoBack = useCallback(() => {
-    if (previousTab) navigation.navigate(previousTab);
-    else navigation.goBack();
-  }, [navigation, previousTab]);
+    navigation.goBack();
+  }, [navigation]);
 
   const handleEdit = useCallback(() => {
     navigation.navigate("EditCocktail", { id });
@@ -200,7 +199,6 @@ export default function CocktailDetailsScreen() {
   useEffect(() => {
     const unsub = navigation.addListener("beforeRemove", (e) => {
       if (e.data.action.type === "NAVIGATE" || !previousTab) return;
-      e.preventDefault();
       navigation.navigate(previousTab);
     });
     return unsub;


### PR DESCRIPTION
## Summary
- Ensure the details screen pops from the stack when leaving it
- Use hardware back handler to switch tabs without creating loops

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ce7bc4d3c8326973b36069ebff47b