### PR TITLE
Show available substitutes in cocktail screens

### DIFF
--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -237,7 +237,27 @@ export default function AllCocktailsScreen() {
         required.length > 0 &&
         required.every((r) => {
           const ing = ingMap.get(r.ingredientId);
-          return ing && ing.inBar;
+          if (ing?.inBar) return true;
+          if (ing) {
+            const baseId = ing.baseIngredientId ?? ing.id;
+            if (r.allowBaseSubstitution) {
+              const base = ingMap.get(baseId);
+              if (base?.inBar) return true;
+            }
+            if (r.allowBrandedSubstitutes) {
+              const brand = ingredients.find(
+                (i) => i.inBar && i.baseIngredientId === baseId
+              );
+              if (brand) return true;
+            }
+          }
+          if (Array.isArray(r.substitutes)) {
+            for (const s of r.substitutes) {
+              const candidate = ingMap.get(s.id);
+              if (candidate?.inBar) return true;
+            }
+          }
+          return false;
         });
       const branded = (c.ingredients || []).some((r) => {
         const ing = ingMap.get(r.ingredientId);

--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -221,7 +221,9 @@ export default function AllCocktailsScreen() {
   }, [isFocused]);
 
   const filtered = useMemo(() => {
-    const ingMap = new Map((ingredients || []).map((i) => [i.id, i]));
+    const ingMap = new Map(
+      (ingredients || []).map((i) => [String(i.id), i])
+    );
     const q = searchDebounced.trim().toLowerCase();
     let list = cocktails;
     if (q) list = list.filter((c) => c.name.toLowerCase().includes(q));
@@ -236,31 +238,31 @@ export default function AllCocktailsScreen() {
       const allAvail =
         required.length > 0 &&
         required.every((r) => {
-          const ing = ingMap.get(r.ingredientId);
+          const ing = ingMap.get(String(r.ingredientId));
           if (ing?.inBar) return true;
           if (ing) {
-            const baseId = ing.baseIngredientId ?? ing.id;
+            const baseId = String(ing.baseIngredientId ?? ing.id);
             if (r.allowBaseSubstitution) {
               const base = ingMap.get(baseId);
               if (base?.inBar) return true;
             }
             if (r.allowBrandedSubstitutes) {
               const brand = ingredients.find(
-                (i) => i.inBar && i.baseIngredientId === baseId
+                (i) => i.inBar && String(i.baseIngredientId) === baseId
               );
               if (brand) return true;
             }
           }
           if (Array.isArray(r.substitutes)) {
             for (const s of r.substitutes) {
-              const candidate = ingMap.get(s.id);
+              const candidate = ingMap.get(String(s.id));
               if (candidate?.inBar) return true;
             }
           }
           return false;
         });
       const branded = (c.ingredients || []).some((r) => {
-        const ing = ingMap.get(r.ingredientId);
+        const ing = ingMap.get(String(r.ingredientId));
         return ing && ing.baseIngredientId != null;
       });
       return { ...c, isAllAvailable: allAvail, hasBranded: branded };

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -144,6 +144,7 @@ export default function CocktailDetailsScreen() {
 
   const [cocktail, setCocktail] = useState(null);
   const [ingMap, setIngMap] = useState(new Map());
+  const [ingList, setIngList] = useState([]);
   const [loading, setLoading] = useState(true);
 
   const handleGoBack = useCallback(() => {
@@ -212,6 +213,7 @@ export default function CocktailDetailsScreen() {
     ]);
     setCocktail(loadedCocktail || null);
     setIngMap(new Map((allIngredients || []).map((i) => [i.id, i])));
+    setIngList(allIngredients || []);
     setLoading(false);
   }, [id]);
 
@@ -230,7 +232,7 @@ export default function CocktailDetailsScreen() {
     const list = Array.isArray(cocktail.ingredients)
       ? [...cocktail.ingredients].sort((a, b) => a.order - b.order)
       : [];
-    const allIngs = Array.from(ingMap.values());
+    const allIngs = ingList;
     return list.map((r) => {
       const ing = r.ingredientId ? ingMap.get(r.ingredientId) : null;
       const originalName = ing?.name || r.name;
@@ -275,7 +277,7 @@ export default function CocktailDetailsScreen() {
         substituteFor: substitute ? originalName : null,
       };
     });
-  }, [cocktail, ingMap]);
+  }, [cocktail, ingMap, ingList]);
 
   if (loading)
     return (


### PR DESCRIPTION
## Summary
- check for base, branded and custom substitutes when marking cocktails as available
- keep ingredient list ordering in cocktail details for correct substitute selection

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cf050027083268e0b7f4ebc8a5f3b