### PR TITLE
Remember last non-create tab

### DIFF
--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -43,7 +43,7 @@ function CreateCocktailStack() {
 export default function CocktailsTabsScreen() {
   const theme = useTheme();
   const tabRef = React.useRef(null);
-  const { getTab } = useTabMemory();
+  const { getTab, setTab } = useTabMemory();
 
   const [createKey, setCreateKey] = React.useState(0);
 
@@ -52,8 +52,7 @@ export default function CocktailsTabsScreen() {
 
   useFocusEffect(
     React.useCallback(() => {
-      const state = tabRef.current?.getState();
-      const active = state?.routes?.[state?.index ?? 0]?.name;
+      const active = tabRef.current?.getCurrentRoute?.()?.name;
       if (active === "Create") {
         const last =
           (typeof getTab === "function" && getTab("cocktails")) || "All";
@@ -83,9 +82,21 @@ export default function CocktailsTabsScreen() {
         tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
       })}
     >
-      <Tab.Screen name="All" component={AllCocktailsScreen} />
-      <Tab.Screen name="My" component={MyCocktailsScreen} />
-      <Tab.Screen name="Favorite" component={FavoriteCocktailsScreen} />
+      <Tab.Screen
+        name="All"
+        component={AllCocktailsScreen}
+        listeners={{ focus: () => setTab("cocktails", "All") }}
+      />
+      <Tab.Screen
+        name="My"
+        component={MyCocktailsScreen}
+        listeners={{ focus: () => setTab("cocktails", "My") }}
+      />
+      <Tab.Screen
+        name="Favorite"
+        component={FavoriteCocktailsScreen}
+        listeners={{ focus: () => setTab("cocktails", "Favorite") }}
+      />
       <Tab.Screen
         name="Create"
         // Через render-prop ми можемо підставити key для примусового ремоунта

--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -54,7 +54,7 @@ export default function CocktailsTabsScreen() {
     React.useCallback(() => {
       return () => {
         const state = tabRef.current?.getState();
-        const active = state.routes[state.index]?.name;
+        const active = state?.routes?.[state?.index ?? 0]?.name;
         if (active === "Create") {
           const last =
             (typeof getTab === "function" && getTab("cocktails")) || "All";

--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -52,14 +52,14 @@ export default function CocktailsTabsScreen() {
 
   useFocusEffect(
     React.useCallback(() => {
+      const state = tabRef.current?.getState();
+      const active = state?.routes?.[state?.index ?? 0]?.name;
+      if (active === "Create") {
+        const last =
+          (typeof getTab === "function" && getTab("cocktails")) || "All";
+        tabRef.current?.navigate(last);
+      }
       return () => {
-        const state = tabRef.current?.getState();
-        const active = state?.routes?.[state?.index ?? 0]?.name;
-        if (active === "Create") {
-          const last =
-            (typeof getTab === "function" && getTab("cocktails")) || "All";
-          tabRef.current?.navigate(last);
-        }
         setCreateKey((k) => k + 1);
       };
     }, [getTab])

--- a/src/screens/Ingredients/IngredientsTabsScreen.js
+++ b/src/screens/Ingredients/IngredientsTabsScreen.js
@@ -53,15 +53,13 @@ export default function IngredientsTabsScreen() {
 
   useFocusEffect(
     React.useCallback(() => {
-      return () => {
-        const state = tabRef.current?.getState();
-        const active = state?.routes?.[state?.index ?? 0]?.name;
-        if (active === "Create") {
-          const last =
-            (typeof getTab === "function" && getTab("ingredients")) || "All";
-          tabRef.current?.navigate(last);
-        }
-      };
+      const state = tabRef.current?.getState();
+      const active = state?.routes?.[state?.index ?? 0]?.name;
+      if (active === "Create") {
+        const last =
+          (typeof getTab === "function" && getTab("ingredients")) || "All";
+        tabRef.current?.navigate(last);
+      }
     }, [getTab])
   );
 

--- a/src/screens/Ingredients/IngredientsTabsScreen.js
+++ b/src/screens/Ingredients/IngredientsTabsScreen.js
@@ -1,8 +1,11 @@
 import React from "react";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { useFocusEffect } from "@react-navigation/native";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useTheme } from "react-native-paper";
+
+import { useTabMemory } from "../../context/TabMemoryContext";
 
 import AllIngredientsScreen from "./AllIngredientsScreen";
 
@@ -42,8 +45,30 @@ function CreateIngredientStack() {
 
 export default function IngredientsTabsScreen() {
   const theme = useTheme();
+  const tabRef = React.useRef(null);
+  const { getTab } = useTabMemory();
+
+  const initialTab =
+    (typeof getTab === "function" && getTab("ingredients")) || "All";
+
+  useFocusEffect(
+    React.useCallback(() => {
+      return () => {
+        const state = tabRef.current?.getState();
+        const active = state.routes[state.index]?.name;
+        if (active === "Create") {
+          const last =
+            (typeof getTab === "function" && getTab("ingredients")) || "All";
+          tabRef.current?.navigate(last);
+        }
+      };
+    }, [getTab])
+  );
+
   return (
     <Tab.Navigator
+      ref={tabRef}
+      initialRouteName={initialTab}
       screenOptions={({ route }) => ({
         headerShown: false,
         tabBarIcon: ({ color, size }) => {

--- a/src/screens/Ingredients/IngredientsTabsScreen.js
+++ b/src/screens/Ingredients/IngredientsTabsScreen.js
@@ -46,15 +46,14 @@ function CreateIngredientStack() {
 export default function IngredientsTabsScreen() {
   const theme = useTheme();
   const tabRef = React.useRef(null);
-  const { getTab } = useTabMemory();
+  const { getTab, setTab } = useTabMemory();
 
   const initialTab =
     (typeof getTab === "function" && getTab("ingredients")) || "All";
 
   useFocusEffect(
     React.useCallback(() => {
-      const state = tabRef.current?.getState();
-      const active = state?.routes?.[state?.index ?? 0]?.name;
+      const active = tabRef.current?.getCurrentRoute?.()?.name;
       if (active === "Create") {
         const last =
           (typeof getTab === "function" && getTab("ingredients")) || "All";
@@ -81,9 +80,21 @@ export default function IngredientsTabsScreen() {
         tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
       })}
     >
-      <Tab.Screen name="All" component={AllIngredientsScreen} />
-      <Tab.Screen name="My" component={MyIngredientsScreen} />
-      <Tab.Screen name="Shopping" component={ShoppingIngredientsScreen} />
+      <Tab.Screen
+        name="All"
+        component={AllIngredientsScreen}
+        listeners={{ focus: () => setTab("ingredients", "All") }}
+      />
+      <Tab.Screen
+        name="My"
+        component={MyIngredientsScreen}
+        listeners={{ focus: () => setTab("ingredients", "My") }}
+      />
+      <Tab.Screen
+        name="Shopping"
+        component={ShoppingIngredientsScreen}
+        listeners={{ focus: () => setTab("ingredients", "Shopping") }}
+      />
       <Tab.Screen
         name="Create"
         component={CreateIngredientStack}

--- a/src/screens/Ingredients/IngredientsTabsScreen.js
+++ b/src/screens/Ingredients/IngredientsTabsScreen.js
@@ -55,7 +55,7 @@ export default function IngredientsTabsScreen() {
     React.useCallback(() => {
       return () => {
         const state = tabRef.current?.getState();
-        const active = state.routes[state.index]?.name;
+        const active = state?.routes?.[state?.index ?? 0]?.name;
         if (active === "Create") {
           const last =
             (typeof getTab === "function" && getTab("ingredients")) || "All";


### PR DESCRIPTION
## Summary
- redirect Cocktails and Ingredients away from Create tab on blur
- restore last visited tab using TabMemory for initial route

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cf64f220c8326bc8255f9d434b137