### PR TITLE
feat: refine ingredient lists with tag colors and usage counts

### DIFF
--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -29,6 +29,7 @@ import { useTheme } from "react-native-paper";
 import TagFilterMenu from "../../components/TagFilterMenu";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
+import { getAllCocktails } from "../../storage/cocktailsStorage";
 
 // ---- Helpers ----
 const withAlpha = (hex, alpha) => {
@@ -52,6 +53,7 @@ const ItemRow = memo(
     name,
     photoUri,
     tags,
+    usageCount,
     inBar,
     inShoppingList,
     baseIngredientId,
@@ -141,20 +143,34 @@ const ItemRow = memo(
               >
                 {name}
               </Text>
-              {Array.isArray(tags) && tags.length > 0 && (
-                <View style={styles.tagRow}>
-                  {tags.map((tag) => (
-                    <View
-                      key={tag.id}
-                      style={[styles.tag, { backgroundColor: tag.color }]}
-                    >
-                      <Text style={styles.tagText}>{tag.name}</Text>
-                    </View>
-                  ))}
-                </View>
-              )}
+              <Text
+                numberOfLines={1}
+                style={[
+                  styles.usage,
+                  { color: theme.colors.onSurfaceVariant },
+                ]}
+              >
+                {usageCount > 0
+                  ? `${usageCount} cocktail${usageCount === 1 ? "" : "s"}`
+                  : "\u00A0"}
+              </Text>
             </View>
           </Pressable>
+
+          {Array.isArray(tags) && tags.length > 0 && (
+            <View style={styles.tagDots}>
+              {tags.map((tag, idx) => (
+                <View
+                  key={tag.id}
+                  style={[
+                    styles.tagDot,
+                    idx === 0 && styles.firstTagDot,
+                    { backgroundColor: tag.color },
+                  ]}
+                />
+              ))}
+            </View>
+          )}
 
           <Pressable
             onPress={() => onToggleInBar(id)}
@@ -185,7 +201,8 @@ const ItemRow = memo(
     prev.inShoppingList === next.inShoppingList &&
     prev.baseIngredientId === next.baseIngredientId &&
     prev.isNavigating === next.isNavigating &&
-    prev.tags === next.tags
+    prev.tags === next.tags &&
+    prev.usageCount === next.usageCount
 );
 
 export default function AllIngredientsScreen() {
@@ -234,10 +251,25 @@ export default function AllIngredientsScreen() {
   }, []);
 
   const loadIngredients = useCallback(async () => {
-    const data = await getAllIngredients();
+    const [data, cocktails] = await Promise.all([
+      getAllIngredients(),
+      getAllCocktails(),
+    ]);
+
+    const usage = {};
+    cocktails.forEach((c) => {
+      if (Array.isArray(c.ingredients)) {
+        c.ingredients.forEach((ing) => {
+          if (ing.ingredientId != null)
+            usage[ing.ingredientId] = (usage[ing.ingredientId] || 0) + 1;
+        });
+      }
+    });
+
     const sorted = sortIngredients(data).map((item) => ({
       ...item,
       searchName: item.name.toLowerCase(),
+      usageCount: usage[item.id] || 0,
     }));
     setIngredients(sorted);
     const map = new Map();
@@ -280,7 +312,7 @@ export default function AllIngredientsScreen() {
       if (idx == null) return;
       const current = ingredients[idx];
       if (!current) return;
-      const { searchName, ...rest } = current;
+      const { searchName, usageCount, ...rest } = current;
       saveIngredient({ ...rest, inBar }).catch(() => {});
     });
   }, [ingredients]);
@@ -338,6 +370,7 @@ export default function AllIngredientsScreen() {
         name={item.name}
         photoUri={item.photoUri}
         tags={item.tags}
+        usageCount={item.usageCount}
         inBar={item.inBar === true}
         inShoppingList={item.inShoppingList === true}
         baseIngredientId={item.baseIngredientId}
@@ -460,19 +493,14 @@ const styles = StyleSheet.create({
   placeholderText: { fontSize: 10, textAlign: "center" },
 
   info: { flex: 1, paddingRight: 8 },
-  name: { fontSize: 16, fontWeight: "bold" },
+  name: { fontSize: 16 },
+  usage: { fontSize: 12, marginTop: 4 },
 
-  tagRow: { flexDirection: "row", flexWrap: "wrap", marginTop: 4 },
-  tag: {
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 12,
-    marginRight: 6,
-    marginBottom: 4,
-  },
-  tagText: { fontSize: 10, color: "white", fontWeight: "bold" },
+  tagDots: { flexDirection: "row", marginRight: 8 },
+  tagDot: { width: 8, height: 8, borderRadius: 4, marginLeft: 4 },
+  firstTagDot: { marginLeft: 0 },
 
-  cartIcon: { position: "absolute", bottom: 4, right: 36, zIndex: 1 },
+  cartIcon: { position: "absolute", bottom: 4, right: 60, zIndex: 1 },
   brandedStripe: { borderLeftWidth: 4, paddingLeft: 8 },
 
   checkButton: { marginLeft: 8, paddingVertical: 6, paddingHorizontal: 4 },

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -466,6 +466,7 @@ const styles = StyleSheet.create({
     paddingVertical: ROW_VERTICAL,
     paddingHorizontal: 12,
     position: "relative",
+    height: ITEM_HEIGHT - ROW_BORDER,
   },
   dimmed: { opacity: 0.88 },
 
@@ -496,7 +497,11 @@ const styles = StyleSheet.create({
   name: { fontSize: 16 },
   usage: { fontSize: 12, marginTop: 4 },
 
-  tagDots: { flexDirection: "row", marginRight: 8 },
+  tagDots: {
+    flexDirection: "row",
+    marginRight: 8,
+    alignSelf: "flex-start",
+  },
   tagDot: { width: 8, height: 8, borderRadius: 4, marginLeft: 4 },
   firstTagDot: { marginLeft: 0 },
 

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -26,6 +26,7 @@ import { useTheme } from "react-native-paper";
 import TagFilterMenu from "../../components/TagFilterMenu";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
+import { getAllCocktails } from "../../storage/cocktailsStorage";
 
 // ---- Helpers ----
 const withAlpha = (hex, alpha) => {
@@ -49,6 +50,7 @@ const ItemRow = memo(
     name,
     photoUri,
     tags,
+    usageCount,
     inBar,
     inShoppingList,
     baseIngredientId,
@@ -138,20 +140,34 @@ const ItemRow = memo(
               >
                 {name}
               </Text>
-              {Array.isArray(tags) && tags.length > 0 && (
-                <View style={styles.tagRow}>
-                  {tags.map((tag) => (
-                    <View
-                      key={tag.id}
-                      style={[styles.tag, { backgroundColor: tag.color }]}
-                    >
-                      <Text style={styles.tagText}>{tag.name}</Text>
-                    </View>
-                  ))}
-                </View>
-              )}
+              <Text
+                numberOfLines={1}
+                style={[
+                  styles.usage,
+                  { color: theme.colors.onSurfaceVariant },
+                ]}
+              >
+                {usageCount > 0
+                  ? `${usageCount} cocktail${usageCount === 1 ? "" : "s"}`
+                  : "\u00A0"}
+              </Text>
             </View>
           </Pressable>
+
+          {Array.isArray(tags) && tags.length > 0 && (
+            <View style={styles.tagDots}>
+              {tags.map((tag, idx) => (
+                <View
+                  key={tag.id}
+                  style={[
+                    styles.tagDot,
+                    idx === 0 && styles.firstTagDot,
+                    { backgroundColor: tag.color },
+                  ]}
+                />
+              ))}
+            </View>
+          )}
         </View>
       </View>
     );
@@ -164,7 +180,8 @@ const ItemRow = memo(
     prev.inShoppingList === next.inShoppingList &&
     prev.baseIngredientId === next.baseIngredientId &&
     prev.isNavigating === next.isNavigating &&
-    prev.tags === next.tags
+    prev.tags === next.tags &&
+    prev.usageCount === next.usageCount
 );
 
 export default function MyIngredientsScreen() {
@@ -211,11 +228,25 @@ export default function MyIngredientsScreen() {
   }, []);
 
   const loadIngredients = useCallback(async () => {
-    const data = await getAllIngredients();
+    const [data, cocktails] = await Promise.all([
+      getAllIngredients(),
+      getAllCocktails(),
+    ]);
+    const usage = {};
+    cocktails.forEach((c) => {
+      if (Array.isArray(c.ingredients)) {
+        c.ingredients.forEach((ing) => {
+          if (ing.ingredientId != null)
+            usage[ing.ingredientId] = (usage[ing.ingredientId] || 0) + 1;
+        });
+      }
+    });
+
     const filtered = data.filter((i) => i.inBar === true);
     const sorted = sortIngredients(filtered).map((item) => ({
       ...item,
       searchName: item.name.toLowerCase(),
+      usageCount: usage[item.id] || 0,
     }));
     setIngredients(sorted);
   }, [sortIngredients]);
@@ -271,6 +302,7 @@ export default function MyIngredientsScreen() {
         name={item.name}
         photoUri={item.photoUri}
         tags={item.tags}
+        usageCount={item.usageCount}
         inBar={item.inBar === true}
         inShoppingList={item.inShoppingList === true}
         baseIngredientId={item.baseIngredientId}
@@ -375,17 +407,12 @@ const styles = StyleSheet.create({
   placeholderText: { fontSize: 10, textAlign: "center" },
 
   info: { flex: 1, paddingRight: 8 },
-  name: { fontSize: 16, fontWeight: "bold" },
+  name: { fontSize: 16 },
+  usage: { fontSize: 12, marginTop: 4 },
 
-  tagRow: { flexDirection: "row", flexWrap: "wrap", marginTop: 4 },
-  tag: {
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 12,
-    marginRight: 6,
-    marginBottom: 4,
-  },
-  tagText: { fontSize: 10, color: "white", fontWeight: "bold" },
+  tagDots: { flexDirection: "row", marginRight: 8 },
+  tagDot: { width: 8, height: 8, borderRadius: 4, marginLeft: 4 },
+  firstTagDot: { marginLeft: 0 },
 
   cartIcon: { position: "absolute", bottom: 4, right: 36, zIndex: 1 },
   brandedStripe: { borderLeftWidth: 4, paddingLeft: 8 },

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -380,6 +380,7 @@ const styles = StyleSheet.create({
     paddingVertical: ROW_VERTICAL,
     paddingHorizontal: 12,
     position: "relative",
+    height: ITEM_HEIGHT - ROW_BORDER,
   },
   dimmed: { opacity: 0.88 },
 
@@ -410,7 +411,11 @@ const styles = StyleSheet.create({
   name: { fontSize: 16 },
   usage: { fontSize: 12, marginTop: 4 },
 
-  tagDots: { flexDirection: "row", marginRight: 8 },
+  tagDots: {
+    flexDirection: "row",
+    marginRight: 8,
+    alignSelf: "flex-start",
+  },
   tagDot: { width: 8, height: 8, borderRadius: 4, marginLeft: 4 },
   firstTagDot: { marginLeft: 0 },
 

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -400,6 +400,7 @@ const styles = StyleSheet.create({
     paddingVertical: ROW_VERTICAL,
     paddingHorizontal: 12,
     position: "relative",
+    height: ITEM_HEIGHT - ROW_BORDER,
   },
   dimmed: { opacity: 0.88 },
 
@@ -430,7 +431,11 @@ const styles = StyleSheet.create({
   name: { fontSize: 16 },
   usage: { fontSize: 12, marginTop: 4 },
 
-  tagDots: { flexDirection: "row", marginRight: 8 },
+  tagDots: {
+    flexDirection: "row",
+    marginRight: 8,
+    alignSelf: "flex-start",
+  },
   tagDot: { width: 8, height: 8, borderRadius: 4, marginLeft: 4 },
   firstTagDot: { marginLeft: 0 },
 


### PR DESCRIPTION
## Summary
- show how many cocktails use each ingredient
- display tags as colored circles on the right side of ingredient rows
- use normal font weight for ingredient names

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cfab3f64c8326b44c5d5888e20434