### PR TITLE
Count branded ingredient usage including substitutions

### DIFF
--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -30,6 +30,7 @@ import TagFilterMenu from "../../components/TagFilterMenu";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
+import { calculateIngredientUsage } from "../../utils/ingredientUsage";
 
 // ---- Helpers ----
 const withAlpha = (hex, alpha) => {
@@ -256,15 +257,7 @@ export default function AllIngredientsScreen() {
       getAllCocktails(),
     ]);
 
-    const usage = {};
-    cocktails.forEach((c) => {
-      if (Array.isArray(c.ingredients)) {
-        c.ingredients.forEach((ing) => {
-          if (ing.ingredientId != null)
-            usage[ing.ingredientId] = (usage[ing.ingredientId] || 0) + 1;
-        });
-      }
-    });
+    const usage = calculateIngredientUsage(data, cocktails);
 
     const sorted = sortIngredients(data).map((item) => ({
       ...item,

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -27,6 +27,7 @@ import TagFilterMenu from "../../components/TagFilterMenu";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
+import { calculateIngredientUsage } from "../../utils/ingredientUsage";
 
 // ---- Helpers ----
 const withAlpha = (hex, alpha) => {
@@ -232,15 +233,7 @@ export default function MyIngredientsScreen() {
       getAllIngredients(),
       getAllCocktails(),
     ]);
-    const usage = {};
-    cocktails.forEach((c) => {
-      if (Array.isArray(c.ingredients)) {
-        c.ingredients.forEach((ing) => {
-          if (ing.ingredientId != null)
-            usage[ing.ingredientId] = (usage[ing.ingredientId] || 0) + 1;
-        });
-      }
-    });
+    const usage = calculateIngredientUsage(data, cocktails);
 
     const filtered = data.filter((i) => i.inBar === true);
     const sorted = sortIngredients(filtered).map((item) => ({

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -30,6 +30,7 @@ import TagFilterMenu from "../../components/TagFilterMenu";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
+import { calculateIngredientUsage } from "../../utils/ingredientUsage";
 
 // ---- Helpers ----
 const withAlpha = (hex, alpha) => {
@@ -240,15 +241,7 @@ export default function ShoppingIngredientsScreen() {
       getAllIngredients(),
       getAllCocktails(),
     ]);
-    const usage = {};
-    cocktails.forEach((c) => {
-      if (Array.isArray(c.ingredients)) {
-        c.ingredients.forEach((ing) => {
-          if (ing.ingredientId != null)
-            usage[ing.ingredientId] = (usage[ing.ingredientId] || 0) + 1;
-        });
-      }
-    });
+    const usage = calculateIngredientUsage(data, cocktails);
 
     const filtered = data.filter((i) => i.inShoppingList === true);
     const sorted = sortIngredients(filtered).map((item) => ({

--- a/src/utils/ingredientUsage.js
+++ b/src/utils/ingredientUsage.js
@@ -1,0 +1,60 @@
+export function calculateIngredientUsage(ingredients, cocktails) {
+  const byId = new Map(ingredients.map((i) => [i.id, i]));
+  const byBase = new Map();
+  ingredients.forEach((i) => {
+    const baseId = i.baseIngredientId ?? i.id;
+    if (!byBase.has(baseId)) byBase.set(baseId, []);
+    byBase.get(baseId).push(i);
+  });
+
+  const usageMap = new Map();
+  const add = (id, cocktailId) => {
+    if (id == null) return;
+    let set = usageMap.get(id);
+    if (!set) {
+      set = new Set();
+      usageMap.set(id, set);
+    }
+    set.add(cocktailId);
+  };
+
+  cocktails.forEach((c) => {
+    if (!Array.isArray(c.ingredients)) return;
+    c.ingredients.forEach((r) => {
+      if (r.ingredientId == null) return;
+      const ing = byId.get(r.ingredientId);
+      if (!ing) return;
+      const baseId = ing.baseIngredientId ?? ing.id;
+      const group = byBase.get(baseId) || [];
+
+      // direct usage
+      add(ing.id, c.id);
+
+      if (ing.id === baseId) {
+        // base ingredient used: count all branded versions
+        group.forEach((item) => {
+          if (item.id !== baseId) add(item.id, c.id);
+        });
+      } else {
+        // branded ingredient used
+        if (r.allowBaseSubstitution || r.allowBrandedSubstitutes) {
+          group.forEach((item) => {
+            if (item.id !== ing.id) add(item.id, c.id);
+          });
+        }
+      }
+
+      // explicit substitutes
+      if (Array.isArray(r.substitutes)) {
+        r.substitutes.forEach((s) => add(s.id, c.id));
+      }
+    });
+  });
+
+  const result = {};
+  ingredients.forEach((i) => {
+    const set = usageMap.get(i.id);
+    result[i.id] = set ? set.size : 0;
+  });
+  return result;
+}


### PR DESCRIPTION
## Summary
- compute ingredient usage across base and branded substitutes
- show combined usage counts on all ingredient list screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d03d203cc8326b26b2f6ff5107e44