### PR TITLE
feat: square ingredient photos

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1875,13 +1875,19 @@ const styles = StyleSheet.create({
     marginTop: 8,
     width: IMAGE_SIZE,
     height: IMAGE_SIZE,
+    aspectRatio: 1,
     borderWidth: 1,
     borderRadius: 8,
     overflow: "hidden",
     justifyContent: "center",
     alignItems: "center",
   },
-  mediaImg: { width: IMAGE_SIZE, height: IMAGE_SIZE, resizeMode: "cover" },
+  mediaImg: {
+    width: IMAGE_SIZE,
+    height: IMAGE_SIZE,
+    aspectRatio: 1,
+    resizeMode: "cover",
+  },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },
   tag: {
@@ -2029,6 +2035,7 @@ const styles = StyleSheet.create({
   modalItemAvatar: {
     width: 32,
     height: 32,
+    aspectRatio: 1,
     borderRadius: 6,
     backgroundColor: "#ccc",
   },

--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -367,6 +367,7 @@ const styles = StyleSheet.create({
   image: {
     width: IMAGE_SIZE,
     height: IMAGE_SIZE,
+    aspectRatio: 1,
     borderRadius: 8,
     marginRight: 12,
     overflow: "hidden",

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -486,6 +486,7 @@ const styles = StyleSheet.create({
   ingImage: {
     width: IMAGE_SIZE,
     height: IMAGE_SIZE,
+    aspectRatio: 1,
     borderRadius: 8,
     marginRight: 12,
     overflow: "hidden",

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1909,13 +1909,19 @@ const styles = StyleSheet.create({
     marginTop: 8,
     width: IMAGE_SIZE,
     height: IMAGE_SIZE,
+    aspectRatio: 1,
     borderWidth: 1,
     borderRadius: 8,
     overflow: "hidden",
     justifyContent: "center",
     alignItems: "center",
   },
-  mediaImg: { width: IMAGE_SIZE, height: IMAGE_SIZE, resizeMode: "cover" },
+  mediaImg: {
+    width: IMAGE_SIZE,
+    height: IMAGE_SIZE,
+    aspectRatio: 1,
+    resizeMode: "cover",
+  },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },
   tag: {
@@ -2063,6 +2069,7 @@ const styles = StyleSheet.create({
   modalItemAvatar: {
     width: 32,
     height: 32,
+    aspectRatio: 1,
     borderRadius: 6,
     backgroundColor: "#ccc",
   },

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -638,6 +638,7 @@ const styles = StyleSheet.create({
     marginTop: 8,
     width: IMAGE_SIZE,
     height: IMAGE_SIZE,
+    aspectRatio: 1,
     borderWidth: 1,
     borderRadius: 8,
     overflow: "hidden",
@@ -645,7 +646,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     alignSelf: "flex-start",
   },
-  image: { width: IMAGE_SIZE, height: IMAGE_SIZE, resizeMode: "cover" },
+  image: { width: IMAGE_SIZE, height: IMAGE_SIZE, aspectRatio: 1, resizeMode: "cover" },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },
   tag: {
@@ -665,7 +666,13 @@ const styles = StyleSheet.create({
   },
   menuRow: { paddingHorizontal: 12, paddingVertical: 8 },
   menuRowInner: { flexDirection: "row", alignItems: "center", gap: 8 },
-  menuImg: { width: 40, height: 40, borderRadius: 8, backgroundColor: "#fff" },
+  menuImg: {
+    width: 40,
+    height: 40,
+    aspectRatio: 1,
+    borderRadius: 8,
+    backgroundColor: "#fff",
+  },
   menuImgPlaceholder: { backgroundColor: "#EAEAEA" },
 
   saveButton: {

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -479,6 +479,7 @@ const styles = StyleSheet.create({
   image: {
     width: IMAGE_SIZE,
     height: IMAGE_SIZE,
+    aspectRatio: 1,
     borderRadius: 8,
     marginRight: 12,
     overflow: "hidden",

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -733,6 +733,7 @@ const styles = StyleSheet.create({
     marginTop: 8,
     width: IMAGE_SIZE,
     height: IMAGE_SIZE,
+    aspectRatio: 1,
     borderWidth: 1,
     borderRadius: 8,
     overflow: "hidden",
@@ -740,7 +741,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     alignSelf: "flex-start",
   },
-  image: { width: IMAGE_SIZE, height: IMAGE_SIZE, resizeMode: "cover" },
+  image: { width: IMAGE_SIZE, height: IMAGE_SIZE, aspectRatio: 1, resizeMode: "cover" },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },
   tag: {
@@ -760,7 +761,7 @@ const styles = StyleSheet.create({
   },
   menuRow: { paddingHorizontal: 12, paddingVertical: 8 },
   menuRowInner: { flexDirection: "row", alignItems: "center", gap: 8 },
-  menuImg: { width: 40, height: 40, borderRadius: 8 },
+  menuImg: { width: 40, height: 40, aspectRatio: 1, borderRadius: 8 },
 
   saveButton: {
     marginTop: 24,

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -318,8 +318,8 @@ export default function IngredientDetailsScreen() {
       {ingredient.photoUri ? (
         <Image
           source={{ uri: ingredient.photoUri }}
-          style={[styles.photo, { backgroundColor: theme.colors.surface }]}
-          resizeMode="contain"
+          style={styles.photo}
+          resizeMode="cover"
         />
       ) : (
         <View

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -32,6 +32,7 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import { useTheme } from "react-native-paper";
 
+const PHOTO_SIZE = 200;
 const THUMB = 40;
 
 /** Gray-square photo (no icon/initials), uses theme */
@@ -481,7 +482,12 @@ const styles = StyleSheet.create({
   container: { padding: 24 }, // bg is set via theme inline
   title: { fontSize: 22, fontWeight: "bold" },
 
-  photo: { width: "100%", height: 200, marginTop: 12, alignSelf: "center" },
+  photo: {
+    width: PHOTO_SIZE,
+    height: PHOTO_SIZE,
+    marginTop: 12,
+    alignSelf: "center",
+  },
 
   section: { marginTop: 16 },
   sectionLabel: { fontWeight: "bold", marginBottom: 8 },
@@ -507,7 +513,13 @@ const styles = StyleSheet.create({
   rowMain: { flexDirection: "row", alignItems: "center", flex: 1 },
   singleRow: { borderWidth: 1, borderRadius: 8 },
 
-  thumb: { width: THUMB, height: THUMB, borderRadius: 8, marginRight: 10 },
+  thumb: {
+    width: THUMB,
+    height: THUMB,
+    aspectRatio: 1,
+    borderRadius: 8,
+    marginRight: 10,
+  },
   thumbPlaceholder: {},
 
   rowText: { flex: 1, fontSize: 16 },

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -393,6 +393,7 @@ const styles = StyleSheet.create({
   image: {
     width: IMAGE_SIZE,
     height: IMAGE_SIZE,
+    aspectRatio: 1,
     borderRadius: 8,
     marginRight: 12,
     overflow: "hidden",

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -413,6 +413,7 @@ const styles = StyleSheet.create({
   image: {
     width: IMAGE_SIZE,
     height: IMAGE_SIZE,
+    aspectRatio: 1,
     borderRadius: 8,
     marginRight: 12,
     overflow: "hidden",


### PR DESCRIPTION
## Summary
- make ingredient detail photo placeholder square
- enforce square thumbnails across ingredient and cocktail lists

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d0789c5048326aa0ae0ba870bd28f