### PR TITLE
Dismiss keyboard when selecting glassware

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -932,6 +932,7 @@ const GlassPopover = memo(function GlassPopover({ selectedGlass, onSelect }) {
       }}
     >
       <MenuTrigger
+        onPress={Keyboard.dismiss}
         customStyles={{
           TriggerTouchableComponent: Pressable,
           triggerTouchable: {},

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -930,6 +930,7 @@ const GlassPopover = memo(function GlassPopover({ selectedGlass, onSelect }) {
       }}
     >
       <MenuTrigger
+        onPress={Keyboard.dismiss}
         customStyles={{
           TriggerTouchableComponent: Pressable,
           triggerTouchable: {},


### PR DESCRIPTION
## Summary
- Dismiss keyboard when opening the glassware picker so text fields lose focus

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689d1a0d926c8326a298e97f45e431da