### PR TITLE
feat: show optional ingredient info

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -51,6 +51,7 @@ const IngredientRow = memo(function IngredientRow({
   unitName,
   inBar,
   garnish,
+  optional,
   substituteFor,
   onPress,
 }) {
@@ -104,6 +105,13 @@ const IngredientRow = memo(function IngredientRow({
           >
             {name}
           </Text>
+          {optional && (
+            <Text
+              style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}
+            >
+              (optional)
+            </Text>
+          )}
           {garnish && (
             <Text
               style={[styles.meta, { color: theme.colors.onSurfaceVariant }]}
@@ -274,6 +282,7 @@ export default function CocktailDetailsScreen() {
         unitName: getUnitById(r.unitId)?.name || "",
         inBar: substitute ? substitute.inBar : inBar,
         garnish: !!r.garnish,
+        optional: !!r.optional,
         substituteFor: substitute ? originalName : null,
       };
     });


### PR DESCRIPTION
## Summary
- show `(optional)` under optional ingredients on cocktail details screen

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689d215616c08326a8daea2a22c8fd76