### PR TITLE
Fix navigation from ingredient details to cocktail details

### DIFF
--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -117,8 +117,8 @@ export default function IngredientDetailsScreen() {
   const handleGoBack = useCallback(() => {
     if (fromCocktailId)
       navigation.navigate("Cocktails", {
-        screen: "CocktailDetails",
-        params: { id: fromCocktailId },
+        screen: "Create",
+        params: { screen: "CocktailDetails", params: { id: fromCocktailId } },
       });
     else if (previousTab) navigation.navigate(previousTab);
     else navigation.goBack();
@@ -366,8 +366,8 @@ export default function IngredientDetailsScreen() {
   const goToCocktail = useCallback(
     (goId) => {
       navigation.navigate("Cocktails", {
-        screen: "CocktailDetails",
-        params: { id: goId },
+        screen: "Create",
+        params: { screen: "CocktailDetails", params: { id: goId } },
       });
     },
     [navigation]


### PR DESCRIPTION
## Summary
- Ensure ingredient details screen navigates to cocktail details via the Create stack
- Route back to originating cocktail using correct nested navigation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d2205f2f08326bba1fa3fe6b0675e