### PR TITLE
Fix cocktail image aspect ratio in add and list screens

### DIFF
--- a/src/components/CocktailRow.js
+++ b/src/components/CocktailRow.js
@@ -68,14 +68,14 @@ function CocktailRow({
         {photoUri ? (
           <Image
             source={{ uri: photoUri }}
-            style={[styles.image, { backgroundColor: theme.colors.background }]}
-            resizeMode="cover"
+            style={[styles.image, { backgroundColor: theme.colors.surface }]}
+            resizeMode="contain"
           />
         ) : glassImage ? (
           <Image
             source={glassImage}
-            style={[styles.image, { backgroundColor: theme.colors.background }]}
-            resizeMode="cover"
+            style={[styles.image, { backgroundColor: theme.colors.surface }]}
+            resizeMode="contain"
           />
         ) : (
           <View

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1884,10 +1884,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   mediaImg: {
-    width: IMAGE_SIZE,
-    height: IMAGE_SIZE,
-    aspectRatio: 1,
-    resizeMode: "cover",
+    width: "100%",
+    height: "100%",
+    resizeMode: "contain",
   },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1918,10 +1918,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   mediaImg: {
-    width: IMAGE_SIZE,
-    height: IMAGE_SIZE,
-    aspectRatio: 1,
-    resizeMode: "cover",
+    width: "100%",
+    height: "100%",
+    resizeMode: "contain",
   },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },


### PR DESCRIPTION
## Summary
- avoid cropping cocktail photos by using contain sizing on add/edit screens
- render list thumbnails in a white square with preserved aspect ratio

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d22ffe8408326b456010d6d6e0771