### PR TITLE
Fix cocktail availability to use branded substitutes

### DIFF
--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -114,7 +114,8 @@ export default function AllCocktailsScreen() {
             const base = ingMap.get(baseId);
             if (base?.inBar) used = base;
           }
-          if (!used && r.allowBrandedSubstitutes) {
+          const isBaseIngredient = ing?.baseIngredientId == null;
+          if (!used && (r.allowBrandedSubstitutes || isBaseIngredient)) {
             const brand = findBrand(baseId);
             if (brand) used = brand;
           }

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -254,7 +254,8 @@ export default function CocktailDetailsScreen() {
           if (base) substitute = base;
         }
 
-        if (!substitute && r.allowBrandedSubstitutes) {
+        const isBaseIngredient = ing.baseIngredientId == null;
+        if (!substitute && (r.allowBrandedSubstitutes || isBaseIngredient)) {
           const brand = allIngs.find(
             (i) => i.inBar && i.baseIngredientId === baseId
           );

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -85,6 +85,10 @@ export default function FavoriteCocktailsScreen() {
     const ingMap = new Map(
       (ingredients || []).map((i) => [String(i.id), i])
     );
+    const findBrand = (baseId) =>
+      ingredients.find(
+        (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
+      );
     const q = searchDebounced.trim().toLowerCase();
     let list = cocktails.filter((c) => c.rating > 0);
     if (q) list = list.filter((c) => c.name.toLowerCase().includes(q));
@@ -97,36 +101,38 @@ export default function FavoriteCocktailsScreen() {
     return list.map((c) => {
       const required = (c.ingredients || []).filter((r) => !r.optional);
       const missing = [];
+      const ingredientNames = [];
       let allAvail = required.length > 0;
       for (const r of required) {
         const ing = ingMap.get(String(r.ingredientId));
-        let isAvailable = false;
+        const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
+        let used = null;
         if (ing?.inBar) {
-          isAvailable = true;
-        } else if (ing) {
-          const baseId = String(ing.baseIngredientId ?? ing.id);
-          if (!isAvailable && r.allowBaseSubstitution) {
+          used = ing;
+        } else {
+          if (r.allowBaseSubstitution) {
             const base = ingMap.get(baseId);
-            if (base?.inBar) isAvailable = true;
+            if (base?.inBar) used = base;
           }
-          if (!isAvailable && r.allowBrandedSubstitutes) {
-            const brand = ingredients.find(
-              (i) => i.inBar && String(i.baseIngredientId) === baseId
-            );
-            if (brand) isAvailable = true;
+          if (!used && r.allowBrandedSubstitutes) {
+            const brand = findBrand(baseId);
+            if (brand) used = brand;
           }
-        }
-        if (!isAvailable && Array.isArray(r.substitutes)) {
-          for (const s of r.substitutes) {
-            const candidate = ingMap.get(String(s.id));
-            if (candidate?.inBar) {
-              isAvailable = true;
-              break;
+          if (!used && Array.isArray(r.substitutes)) {
+            for (const s of r.substitutes) {
+              const candidate = ingMap.get(String(s.id));
+              if (candidate?.inBar) {
+                used = candidate;
+                break;
+              }
             }
           }
         }
-        if (!isAvailable) {
-          if (ing?.name) missing.push(ing.name);
+        if (used) {
+          ingredientNames.push(used.name);
+        } else {
+          const missingName = ing?.name || r.name || "";
+          if (missingName) missing.push(missingName);
           allAvail = false;
         }
       }
@@ -134,15 +140,12 @@ export default function FavoriteCocktailsScreen() {
         const ing = ingMap.get(String(r.ingredientId));
         return ing && ing.baseIngredientId != null;
       });
-      const ingredientNames = (c.ingredients || [])
-        .map((r) => ingMap.get(String(r.ingredientId))?.name)
-        .filter(Boolean);
       let ingredientLine = ingredientNames.join(", ");
       if (!allAvail) {
         if (missing.length > 0 && missing.length <= 2) {
           ingredientLine = `Missing: ${missing.join(", ")}`;
-        } else if (missing.length >= 3) {
-          ingredientLine = `Missing: ${missing.length} ingredients`;
+        } else if (missing.length >= 3 || missing.length === 0) {
+          ingredientLine = `Missing: ${missing.length || required.length} ingredients`;
         }
       }
       return {

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -114,7 +114,8 @@ export default function FavoriteCocktailsScreen() {
             const base = ingMap.get(baseId);
             if (base?.inBar) used = base;
           }
-          if (!used && r.allowBrandedSubstitutes) {
+          const isBaseIngredient = ing?.baseIngredientId == null;
+          if (!used && (r.allowBrandedSubstitutes || isBaseIngredient)) {
             const brand = findBrand(baseId);
             if (brand) used = brand;
           }

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -114,7 +114,8 @@ export default function MyCocktailsScreen() {
             const base = ingMap.get(baseId);
             if (base?.inBar) used = base;
           }
-          if (!used && r.allowBrandedSubstitutes) {
+          const isBaseIngredient = ing?.baseIngredientId == null;
+          if (!used && (r.allowBrandedSubstitutes || isBaseIngredient)) {
             const brand = findBrand(baseId);
             if (brand) used = brand;
           }

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -85,6 +85,10 @@ export default function MyCocktailsScreen() {
     const ingMap = new Map(
       (ingredients || []).map((i) => [String(i.id), i])
     );
+    const findBrand = (baseId) =>
+      ingredients.find(
+        (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
+      );
     const q = searchDebounced.trim().toLowerCase();
     let list = cocktails;
     if (q) list = list.filter((c) => c.name.toLowerCase().includes(q));
@@ -97,36 +101,38 @@ export default function MyCocktailsScreen() {
     return list.map((c) => {
       const required = (c.ingredients || []).filter((r) => !r.optional);
       const missing = [];
+      const ingredientNames = [];
       let allAvail = required.length > 0;
       for (const r of required) {
         const ing = ingMap.get(String(r.ingredientId));
-        let isAvailable = false;
+        const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
+        let used = null;
         if (ing?.inBar) {
-          isAvailable = true;
-        } else if (ing) {
-          const baseId = String(ing.baseIngredientId ?? ing.id);
-          if (!isAvailable && r.allowBaseSubstitution) {
+          used = ing;
+        } else {
+          if (r.allowBaseSubstitution) {
             const base = ingMap.get(baseId);
-            if (base?.inBar) isAvailable = true;
+            if (base?.inBar) used = base;
           }
-          if (!isAvailable && r.allowBrandedSubstitutes) {
-            const brand = ingredients.find(
-              (i) => i.inBar && String(i.baseIngredientId) === baseId
-            );
-            if (brand) isAvailable = true;
+          if (!used && r.allowBrandedSubstitutes) {
+            const brand = findBrand(baseId);
+            if (brand) used = brand;
           }
-        }
-        if (!isAvailable && Array.isArray(r.substitutes)) {
-          for (const s of r.substitutes) {
-            const candidate = ingMap.get(String(s.id));
-            if (candidate?.inBar) {
-              isAvailable = true;
-              break;
+          if (!used && Array.isArray(r.substitutes)) {
+            for (const s of r.substitutes) {
+              const candidate = ingMap.get(String(s.id));
+              if (candidate?.inBar) {
+                used = candidate;
+                break;
+              }
             }
           }
         }
-        if (!isAvailable) {
-          if (ing?.name) missing.push(ing.name);
+        if (used) {
+          ingredientNames.push(used.name);
+        } else {
+          const missingName = ing?.name || r.name || "";
+          if (missingName) missing.push(missingName);
           allAvail = false;
         }
       }
@@ -134,15 +140,12 @@ export default function MyCocktailsScreen() {
         const ing = ingMap.get(String(r.ingredientId));
         return ing && ing.baseIngredientId != null;
       });
-      const ingredientNames = (c.ingredients || [])
-        .map((r) => ingMap.get(String(r.ingredientId))?.name)
-        .filter(Boolean);
       let ingredientLine = ingredientNames.join(", ");
       if (!allAvail) {
         if (missing.length > 0 && missing.length <= 2) {
           ingredientLine = `Missing: ${missing.join(", ")}`;
-        } else if (missing.length >= 3) {
-          ingredientLine = `Missing: ${missing.length} ingredients`;
+        } else if (missing.length >= 3 || missing.length === 0) {
+          ingredientLine = `Missing: ${missing.length || required.length} ingredients`;
         }
       }
       return {

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -247,7 +247,8 @@ export default function IngredientDetailsScreen() {
               const base = ingMap.get(baseId);
               if (base?.inBar) used = base;
             }
-            if (!used && r.allowBrandedSubstitutes) {
+            const isBaseIngredient = ing?.baseIngredientId == null;
+            if (!used && (r.allowBrandedSubstitutes || isBaseIngredient)) {
               const brand = findBrand(baseId);
               if (brand) used = brand;
             }

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -223,6 +223,10 @@ export default function IngredientDetailsScreen() {
     const map = mapCocktailsByIngredient(all, cocktails);
     const byId = new Map(cocktails.map((c) => [c.id, c]));
     const ingMap = new Map(all.map((i) => [String(i.id), i]));
+    const findBrand = (baseId) =>
+      all.find(
+        (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
+      );
     const list = (map[loaded.id] || [])
       .map((cid) => byId.get(cid))
       .filter(Boolean)
@@ -230,36 +234,38 @@ export default function IngredientDetailsScreen() {
       .map((c) => {
         const required = (c.ingredients || []).filter((r) => !r.optional);
         const missing = [];
+        const ingredientNames = [];
         let allAvail = required.length > 0;
         for (const r of required) {
           const ing = ingMap.get(String(r.ingredientId));
-          let isAvailable = false;
+          const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
+          let used = null;
           if (ing?.inBar) {
-            isAvailable = true;
-          } else if (ing) {
-            const baseId = String(ing.baseIngredientId ?? ing.id);
-            if (!isAvailable && r.allowBaseSubstitution) {
+            used = ing;
+          } else {
+            if (r.allowBaseSubstitution) {
               const base = ingMap.get(baseId);
-              if (base?.inBar) isAvailable = true;
+              if (base?.inBar) used = base;
             }
-            if (!isAvailable && r.allowBrandedSubstitutes) {
-              const brand = all.find(
-                (i) => i.inBar && String(i.baseIngredientId) === baseId
-              );
-              if (brand) isAvailable = true;
+            if (!used && r.allowBrandedSubstitutes) {
+              const brand = findBrand(baseId);
+              if (brand) used = brand;
             }
-          }
-          if (!isAvailable && Array.isArray(r.substitutes)) {
-            for (const s of r.substitutes) {
-              const candidate = ingMap.get(String(s.id));
-              if (candidate?.inBar) {
-                isAvailable = true;
-                break;
+            if (!used && Array.isArray(r.substitutes)) {
+              for (const s of r.substitutes) {
+                const candidate = ingMap.get(String(s.id));
+                if (candidate?.inBar) {
+                  used = candidate;
+                  break;
+                }
               }
             }
           }
-          if (!isAvailable) {
-            if (ing?.name) missing.push(ing.name);
+          if (used) {
+            ingredientNames.push(used.name);
+          } else {
+            const missingName = ing?.name || r.name || "";
+            if (missingName) missing.push(missingName);
             allAvail = false;
           }
         }
@@ -267,15 +273,12 @@ export default function IngredientDetailsScreen() {
           const ing = ingMap.get(String(r.ingredientId));
           return ing && ing.baseIngredientId != null;
         });
-        const ingredientNames = (c.ingredients || [])
-          .map((r) => ingMap.get(String(r.ingredientId))?.name)
-          .filter(Boolean);
         let ingredientLine = ingredientNames.join(", ");
         if (!allAvail) {
           if (missing.length > 0 && missing.length <= 2) {
             ingredientLine = `Missing: ${missing.join(", ")}`;
-          } else if (missing.length >= 3) {
-            ingredientLine = `Missing: ${missing.length} ingredients`;
+          } else if (missing.length >= 3 || missing.length === 0) {
+            ingredientLine = `Missing: ${missing.length || required.length} ingredients`;
           }
         }
         return {

--- a/src/utils/ingredientUsage.js
+++ b/src/utils/ingredientUsage.js
@@ -36,10 +36,11 @@ export function mapCocktailsByIngredient(ingredients, cocktails) {
           if (item.id !== baseId) add(item.id, c.id);
         });
       } else {
-        // branded ingredient used
-        if (r.allowBaseSubstitution || r.allowBrandedSubstitutes) {
+        // branded ingredient used: base ingredient always counts
+        add(baseId, c.id);
+        if (r.allowBrandedSubstitutes) {
           group.forEach((item) => {
-            if (item.id !== ing.id) add(item.id, c.id);
+            if (item.id !== ing.id && item.id !== baseId) add(item.id, c.id);
           });
         }
       }


### PR DESCRIPTION
## Summary
- ensure cocktails remain available when a branded ingredient is in stock but its base ingredient is missing
- show substituted branded ingredient names in cocktail listings and ingredient details

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d2b809e3c8326b43586dbdafca297