### PR TITLE
feat: toggle metric and imperial units for cocktails

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -28,6 +28,7 @@ import { getCocktailById, saveCocktail } from "../../storage/cocktailsStorage";
 import { getAllIngredients } from "../../storage/ingredientsStorage";
 import { getUnitById } from "../../constants/measureUnits";
 import { getGlassById } from "../../constants/glassware";
+import { formatAmount, toMetric, toImperial } from "../../utils/units";
 
 /* ---------- helpers ---------- */
 const withAlpha = (hex, alpha) => {
@@ -154,6 +155,7 @@ export default function CocktailDetailsScreen() {
   const [ingMap, setIngMap] = useState(new Map());
   const [ingList, setIngList] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [showImperial, setShowImperial] = useState(false);
 
   const handleGoBack = useCallback(() => {
     navigation.goBack();
@@ -274,20 +276,30 @@ export default function CocktailDetailsScreen() {
       }
 
       const display = substitute || ing || {};
+      let amount = r.amount;
+      let unitName = getUnitById(r.unitId)?.name || "";
+      if (amount != null) {
+        if (showImperial) {
+          ({ amount, unit: unitName } = toImperial(amount, unitName));
+        } else {
+          ({ amount, unit: unitName } = toMetric(amount, unitName));
+        }
+        amount = formatAmount(amount);
+      }
       return {
         key: `${r.order}-${r.ingredientId ?? "free"}`,
         ingredientId: display.id || null,
         name: display.name || r.name,
         photoUri: display.photoUri || null,
-        amount: r.amount,
-        unitName: getUnitById(r.unitId)?.name || "",
+        amount,
+        unitName,
         inBar: substitute ? substitute.inBar : inBar,
         garnish: !!r.garnish,
         optional: !!r.optional,
         substituteFor: substitute ? originalName : null,
       };
     });
-  }, [cocktail, ingMap, ingList]);
+  }, [cocktail, ingMap, ingList, showImperial]);
 
   if (loading)
     return (
@@ -345,6 +357,17 @@ export default function CocktailDetailsScreen() {
       ) : null}
 
       {ratingStars}
+
+      <TouchableOpacity
+        onPress={() => setShowImperial((v) => !v)}
+        style={styles.toggleBtn}
+        accessibilityRole="button"
+        accessibilityLabel={showImperial ? "Show in metric" : "Show in imperial"}
+      >
+        <Text style={{ color: theme.colors.primary }}>
+          {showImperial ? "Show in metric" : "Show in imperial"}
+        </Text>
+      </TouchableOpacity>
 
       <View style={styles.body}>
         {glass && (
@@ -471,6 +494,7 @@ const styles = StyleSheet.create({
     marginTop: 8,
     marginBottom: 8,
   },
+  toggleBtn: { alignSelf: "center", marginBottom: 8 },
   tagRow: { flexDirection: "row", flexWrap: "wrap" },
   tag: {
     paddingHorizontal: 10,

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -284,7 +284,7 @@ export default function CocktailDetailsScreen() {
         } else {
           ({ amount, unit: unitName } = toMetric(amount, unitName));
         }
-        amount = formatAmount(amount);
+        amount = formatAmount(amount, showImperial);
       }
       return {
         key: `${r.order}-${r.ingredientId ?? "free"}`,
@@ -360,7 +360,7 @@ export default function CocktailDetailsScreen() {
 
       <TouchableOpacity
         onPress={() => setShowImperial((v) => !v)}
-        style={styles.toggleBtn}
+        style={[styles.toggleBtn, { borderColor: theme.colors.primary }]}
         accessibilityRole="button"
         accessibilityLabel={showImperial ? "Show in metric" : "Show in imperial"}
       >
@@ -494,7 +494,14 @@ const styles = StyleSheet.create({
     marginTop: 8,
     marginBottom: 8,
   },
-  toggleBtn: { alignSelf: "center", marginBottom: 8 },
+  toggleBtn: {
+    alignSelf: "center",
+    marginBottom: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderWidth: 1,
+    borderRadius: 4,
+  },
   tagRow: { flexDirection: "row", flexWrap: "wrap" },
   tag: {
     paddingHorizontal: 10,

--- a/src/utils/units.js
+++ b/src/utils/units.js
@@ -1,0 +1,55 @@
+const FRACTIONS = [
+  { value: 1/8, symbol: "⅛" },
+  { value: 1/6, symbol: "⅙" },
+  { value: 1/5, symbol: "⅕" },
+  { value: 1/4, symbol: "¼" },
+  { value: 1/3, symbol: "⅓" },
+  { value: 3/8, symbol: "⅜" },
+  { value: 2/5, symbol: "⅖" },
+  { value: 1/2, symbol: "½" },
+  { value: 3/5, symbol: "⅗" },
+  { value: 5/8, symbol: "⅝" },
+  { value: 2/3, symbol: "⅔" },
+  { value: 3/4, symbol: "¾" },
+  { value: 4/5, symbol: "⅘" },
+  { value: 5/6, symbol: "⅚" },
+  { value: 7/8, symbol: "⅞" },
+];
+
+export function formatAmount(amount) {
+  if (amount == null) return "";
+  const whole = Math.trunc(amount);
+  const fraction = amount - whole;
+  const match = FRACTIONS.find((f) => Math.abs(f.value - fraction) < 0.02);
+  if (match) {
+    return `${whole ? whole + " " : ""}${match.symbol}`.trim();
+  }
+  if (fraction === 0) return `${whole}`;
+  const rounded = Math.round(amount * 100) / 100;
+  return `${rounded}`.replace(/\.0+$/, "");
+}
+
+export function toImperial(amount, unit) {
+  if (amount == null) return { amount, unit };
+  switch (unit) {
+    case "ml":
+    case "gr":
+      return { amount: amount / 30, unit: "oz" };
+    case "cl":
+      return { amount: amount / 3, unit: "oz" };
+    default:
+      return { amount, unit };
+  }
+}
+
+export function toMetric(amount, unit) {
+  if (amount == null) return { amount, unit };
+  switch (unit) {
+    case "oz":
+      return { amount: amount * 30, unit: "ml" };
+    case "cup":
+      return { amount: amount * 240, unit: "ml" };
+    default:
+      return { amount, unit };
+  }
+}

--- a/src/utils/units.js
+++ b/src/utils/units.js
@@ -1,31 +1,33 @@
 const FRACTIONS = [
-  { value: 1/8, symbol: "⅛" },
-  { value: 1/6, symbol: "⅙" },
-  { value: 1/5, symbol: "⅕" },
-  { value: 1/4, symbol: "¼" },
-  { value: 1/3, symbol: "⅓" },
-  { value: 3/8, symbol: "⅜" },
-  { value: 2/5, symbol: "⅖" },
-  { value: 1/2, symbol: "½" },
-  { value: 3/5, symbol: "⅗" },
-  { value: 5/8, symbol: "⅝" },
-  { value: 2/3, symbol: "⅔" },
-  { value: 3/4, symbol: "¾" },
-  { value: 4/5, symbol: "⅘" },
-  { value: 5/6, symbol: "⅚" },
-  { value: 7/8, symbol: "⅞" },
+  { value: 1 / 8, symbol: "⅛" },
+  { value: 1 / 6, symbol: "⅙" },
+  { value: 1 / 5, symbol: "⅕" },
+  { value: 1 / 4, symbol: "¼" },
+  { value: 1 / 3, symbol: "⅓" },
+  { value: 3 / 8, symbol: "⅜" },
+  { value: 2 / 5, symbol: "⅖" },
+  { value: 1 / 2, symbol: "½" },
+  { value: 3 / 5, symbol: "⅗" },
+  { value: 5 / 8, symbol: "⅝" },
+  { value: 2 / 3, symbol: "⅔" },
+  { value: 3 / 4, symbol: "¾" },
+  { value: 4 / 5, symbol: "⅘" },
+  { value: 5 / 6, symbol: "⅚" },
+  { value: 7 / 8, symbol: "⅞" },
 ];
 
-export function formatAmount(amount) {
+export function formatAmount(amount, useFractions = false) {
   if (amount == null) return "";
-  const whole = Math.trunc(amount);
-  const fraction = amount - whole;
-  const match = FRACTIONS.find((f) => Math.abs(f.value - fraction) < 0.02);
-  if (match) {
-    return `${whole ? whole + " " : ""}${match.symbol}`.trim();
-  }
-  if (fraction === 0) return `${whole}`;
   const rounded = Math.round(amount * 100) / 100;
+  if (useFractions) {
+    const whole = Math.trunc(rounded);
+    const fraction = rounded - whole;
+    const match = FRACTIONS.find((f) => Math.abs(f.value - fraction) < 0.02);
+    if (match) {
+      return `${whole ? whole + " " : ""}${match.symbol}`.trim();
+    }
+    if (fraction === 0) return `${whole}`;
+  }
   return `${rounded}`.replace(/\.0+$/, "");
 }
 


### PR DESCRIPTION
## Summary
- default cocktail details to metric units and provide toggle between metric and imperial
- convert ingredient amounts between oz/cup and ml and render common fractions as unicode

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d967de40483269d446c6d57638e86