### PR TITLE
Pluralize unit names by quantity

### DIFF
--- a/src/constants/measureUnits.js
+++ b/src/constants/measureUnits.js
@@ -70,3 +70,16 @@ export const searchUnits = (q) => {
   if (!s) return MEASURE_UNITS;
   return MEASURE_UNITS.filter((u) => u.name.toLowerCase().includes(s));
 };
+
+// Return singular or plural unit name based on quantity
+export const formatUnit = (unit, quantity) => {
+  // unit can be an object from MEASURE_UNITS or a string name
+  const u =
+    typeof unit === "string"
+      ? MEASURE_UNITS.find((m) => m.name === unit || m.plural === unit)
+      : unit;
+  if (!u) return typeof unit === "string" ? unit : "";
+  const q = Number(quantity);
+  if (!Number.isFinite(q) || q === 1) return u.name;
+  return u.plural || u.name;
+};

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -52,7 +52,7 @@ const { Popover } = renderers;
 import { getAllIngredients } from "../../storage/ingredientsStorage";
 import { addCocktail } from "../../storage/cocktailsStorage";
 import { BUILTIN_COCKTAIL_TAGS } from "../../constants/cocktailTags";
-import { UNIT_ID, getUnitById } from "../../constants/measureUnits";
+import { UNIT_ID, getUnitById, formatUnit } from "../../constants/measureUnits";
 import { GLASSWARE, getGlassById } from "../../constants/glassware";
 
 /* ---------- helpers ---------- */
@@ -685,7 +685,7 @@ const IngredientRow = memo(function IngredientRow({
                 ]}
               >
                 <Text style={{ color: theme.colors.onSurface }}>
-                  {selectedUnit?.name || "ml"}
+                  {formatUnit(selectedUnit, row.quantity) || "ml"}
                 </Text>
                 <MaterialIcons
                   name="arrow-drop-down"
@@ -741,7 +741,7 @@ const IngredientRow = memo(function IngredientRow({
                             fontWeight: row.unitId === item.id ? "700" : "400",
                           }}
                         >
-                          {item.name}
+                          {formatUnit(item, row.quantity)}
                         </Text>
                         {row.unitId === item.id ? (
                           <MaterialIcons
@@ -754,6 +754,7 @@ const IngredientRow = memo(function IngredientRow({
                     </MenuOption>
                   </View>
                 )}
+                extraData={row.quantity}
                 keyboardShouldPersistTaps="handled"
                 getItemLayout={(_, i) => ({
                   length: 48,

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -26,7 +26,7 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import { getCocktailById, saveCocktail } from "../../storage/cocktailsStorage";
 import { getAllIngredients } from "../../storage/ingredientsStorage";
-import { getUnitById } from "../../constants/measureUnits";
+import { getUnitById, formatUnit } from "../../constants/measureUnits";
 import { getGlassById } from "../../constants/glassware";
 import { formatAmount, toMetric, toImperial } from "../../utils/units";
 
@@ -284,7 +284,10 @@ export default function CocktailDetailsScreen() {
         } else {
           ({ amount, unit: unitName } = toMetric(amount, unitName));
         }
+        unitName = formatUnit(unitName, amount);
         amount = formatAmount(amount, showImperial);
+      } else {
+        unitName = formatUnit(unitName, amount);
       }
       return {
         key: `${r.order}-${r.ingredientId ?? "free"}`,

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -50,7 +50,7 @@ import {
   deleteCocktail,
 } from "../../storage/cocktailsStorage";
 import { BUILTIN_COCKTAIL_TAGS } from "../../constants/cocktailTags";
-import { UNIT_ID, getUnitById } from "../../constants/measureUnits";
+import { UNIT_ID, getUnitById, formatUnit } from "../../constants/measureUnits";
 import { GLASSWARE, getGlassById } from "../../constants/glassware";
 
 /* ---------- helpers ---------- */
@@ -685,7 +685,7 @@ const IngredientRow = memo(function IngredientRow({
                 ]}
               >
                 <Text style={{ color: theme.colors.onSurface }}>
-                  {selectedUnit?.name || "ml"}
+                  {formatUnit(selectedUnit, row.quantity) || "ml"}
                 </Text>
                 <MaterialIcons
                   name="arrow-drop-down"
@@ -741,7 +741,7 @@ const IngredientRow = memo(function IngredientRow({
                             fontWeight: row.unitId === item.id ? "700" : "400",
                           }}
                         >
-                          {item.name}
+                          {formatUnit(item, row.quantity)}
                         </Text>
                         {row.unitId === item.id ? (
                           <MaterialIcons
@@ -754,6 +754,7 @@ const IngredientRow = memo(function IngredientRow({
                     </MenuOption>
                   </View>
                 )}
+                extraData={row.quantity}
                 keyboardShouldPersistTaps="handled"
                 getItemLayout={(_, i) => ({
                   length: 48,


### PR DESCRIPTION
## Summary
- add helper to choose singular or plural unit name
- update cocktail detail and forms to switch unit labels based on quantity

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e1a835e6c8326926f7d6474dc7fd9