### PR TITLE
Ensure consistent highlight on cocktail lists

### DIFF
--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -199,7 +199,7 @@ export default function AllCocktailsScreen() {
     );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
       <HeaderWithSearch
         searchValue={search}
         setSearchValue={setSearch}

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -199,7 +199,7 @@ export default function FavoriteCocktailsScreen() {
     );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
       <HeaderWithSearch
         searchValue={search}
         setSearchValue={setSearch}

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -204,7 +204,7 @@ export default function MyCocktailsScreen() {
     );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
       <HeaderWithSearch
         searchValue={search}
         setSearchValue={setSearch}


### PR DESCRIPTION
## Summary
- Set cocktail list screens to use `theme.colors.background` so highlighted rows render consistently

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e55b9ccc48326bcdbbe6d923d99dd