### PR TITLE
feat: manage ingredient tags via modal

### DIFF
--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -12,18 +12,18 @@ import {
 import { Checkbox } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import IngredientIcon from "../../assets/lemon.svg";
-import { useNavigation } from "@react-navigation/native";
+import IngredientTagsModal from "./IngredientTagsModal";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 const MENU_WIDTH = SCREEN_WIDTH * 0.75;
 
 export default function GeneralMenu({ visible, onClose }) {
-  const navigation = useNavigation();
   const slideAnim = useRef(new Animated.Value(-MENU_WIDTH)).current;
 
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
   const [useMetric, setUseMetric] = useState(true);
   const [keepAwake, setKeepAwake] = useState(false);
+  const [tagsVisible, setTagsVisible] = useState(false);
 
   useEffect(() => {
     if (visible) {
@@ -41,23 +41,26 @@ export default function GeneralMenu({ visible, onClose }) {
     }
   }, [visible, slideAnim]);
 
-  const navigateToIngredientTags = () => {
+  const openTagsModal = () => {
     onClose?.();
-    navigation.navigate("EditCustomTags");
+    setTagsVisible(true);
   };
 
+  const closeTagsModal = () => setTagsVisible(false);
+
   return (
-    <Modal
-      transparent
-      visible={visible}
-      animationType="none"
-      onRequestClose={onClose}
-    >
-      <Pressable style={styles.overlay} onPress={onClose}>
-        <Animated.View
-          style={[styles.menu, { width: MENU_WIDTH, transform: [{ translateX: slideAnim }] }]}
-          onStartShouldSetResponder={() => true}
-        >
+    <>
+      <Modal
+        transparent
+        visible={visible}
+        animationType="none"
+        onRequestClose={onClose}
+      >
+        <Pressable style={styles.overlay} onPress={onClose}>
+          <Animated.View
+            style={[styles.menu, { width: MENU_WIDTH, transform: [{ translateX: slideAnim }] }]}
+            onStartShouldSetResponder={() => true}
+          >
           <Text style={styles.title}>Settings</Text>
 
           <View style={styles.itemRow}>
@@ -95,7 +98,7 @@ export default function GeneralMenu({ visible, onClose }) {
             </View>
           </View>
 
-          <TouchableOpacity style={styles.linkRow} onPress={navigateToIngredientTags}>
+          <TouchableOpacity style={styles.linkRow} onPress={openTagsModal}>
             <IngredientIcon
               width={22}
               height={22}
@@ -134,7 +137,9 @@ export default function GeneralMenu({ visible, onClose }) {
           </TouchableOpacity>
         </Animated.View>
       </Pressable>
-    </Modal>
+      </Modal>
+      <IngredientTagsModal visible={tagsVisible} onClose={closeTagsModal} />
+    </>
   );
 }
 

--- a/src/components/IngredientTagsModal.js
+++ b/src/components/IngredientTagsModal.js
@@ -1,44 +1,18 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { View, StyleSheet, FlatList, TouchableOpacity, Alert, Modal } from "react-native";
+import { View, StyleSheet, FlatList, TouchableOpacity, Alert } from "react-native";
 import {
-  Provider as PaperProvider,
   Text,
   TextInput,
   Button,
   IconButton,
   Portal,
+  Modal,
   Dialog,
   Divider,
   Chip,
-  MD3LightTheme as BaseTheme,
+  useTheme,
 } from "react-native-paper";
 import { getUserTags, saveUserTags } from "../storage/ingredientTagsStorage";
-
-// Theme setup
-const theme = {
-  ...BaseTheme,
-  version: 3,
-  colors: {
-    ...BaseTheme.colors,
-    primary: "#4DABF7",
-    background: "#FFFFFF",
-    surface: "#ecececff",
-    outline: "#E5EAF0",
-    outlineVariant: "#E9EEF4",
-    error: "#FF6B6B",
-    errorContainer: "#FFE3E6",
-    onError: "#FFFFFF",
-    onErrorContainer: "#7A1C1C",
-    onPrimary: "#FFFFFF",
-    onBackground: "#000000",
-    onSurface: "#000000",
-    secondary: "#74C0FC",
-    tertiary: "#A5D8FF",
-    disabled: "#CED4DA",
-    placeholder: "#A1A1A1",
-    backdrop: "rgba(0,0,0,0.4)",
-  },
-};
 
 const COLOR_PALETTE = [
   "#FF6B6B",
@@ -56,6 +30,7 @@ const COLOR_PALETTE = [
 ];
 
 export default function IngredientTagsModal({ visible, onClose }) {
+  const theme = useTheme();
   const [tags, setTags] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -149,12 +124,17 @@ export default function IngredientTagsModal({ visible, onClose }) {
   };
 
   const renderItem = ({ item }) => (
-    <View style={styles.row}>
+    <View style={[styles.row, { borderBottomColor: theme.colors.outline }]}>
       <View style={styles.left}>
-        <View style={[styles.swatch, { backgroundColor: item.color || "#ccc" }]} />
+        <View
+          style={[
+            styles.swatch,
+            { backgroundColor: item.color || "#ccc", borderColor: theme.colors.outlineVariant },
+          ]}
+        />
         <View style={styles.tagTextBox}>
-          <Text style={styles.tagName}>{item.name}</Text>
-          <Text style={styles.tagColorCode}>{item.color}</Text>
+          <Text style={[styles.tagName, { color: theme.colors.onSurface }]}>{item.name}</Text>
+          <Text style={[styles.tagColorCode, { color: theme.colors.onSurfaceVariant }]}>{item.color}</Text>
         </View>
       </View>
       <View style={styles.right}>
@@ -165,107 +145,147 @@ export default function IngredientTagsModal({ visible, onClose }) {
   );
 
   return (
-    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
-      <PaperProvider theme={theme}>
-        <View style={styles.container}>
-          <View style={styles.header}>
-            <Text style={styles.title}>Custom Tags</Text>
-            <IconButton icon="close" onPress={onClose} accessibilityLabel="Close" />
-          </View>
-          <Text style={styles.subtitle}>
-            Create, edit, or remove your own ingredient tags.
-          </Text>
-
-          <Button mode="contained" onPress={openAdd} style={styles.addBtn} icon="plus">
-            Add new tag
-          </Button>
-
-          <Divider />
-
-          <FlatList
-            data={tags}
-            keyExtractor={(item) => String(item.id)}
-            renderItem={renderItem}
-            ListEmptyComponent={
-              !loading && (
-                <View style={styles.emptyBox}>
-                  <Text style={styles.emptyText}>
-                    You don’t have any custom tags yet.
-                  </Text>
-                </View>
-              )
-            }
-            contentContainerStyle={{ paddingBottom: 24 }}
-          />
+    <Portal>
+      <Modal
+        visible={visible}
+        onDismiss={onClose}
+        contentContainerStyle={[
+          styles.container,
+          {
+            backgroundColor: theme.colors.surface,
+            borderColor: theme.colors.outline,
+          },
+        ]}
+      >
+        <View style={styles.header}>
+          <Text style={[styles.title, { color: theme.colors.onSurface }]}>Custom Tags</Text>
+          <IconButton icon="close" onPress={onClose} accessibilityLabel="Close" />
         </View>
+        <Text style={[styles.subtitle, { color: theme.colors.onSurfaceVariant }]}> 
+          Create, edit, or remove your own ingredient tags.
+        </Text>
 
-        <Portal>
-          <Dialog visible={dialogVisible} onDismiss={() => setDialogVisible(false)} style={{ backgroundColor: theme.colors.surface }}>
-            <Dialog.Title>{editingId ? "Edit tag" : "New tag"}</Dialog.Title>
-            <Dialog.Content>
-              <TextInput
-                label="Name"
-                mode="outlined"
-                value={name}
-                onChangeText={setName}
-                error={!!nameError}
-                style={{ marginBottom: 8 }}
-                theme={{ colors: { error: theme.colors.error, errorContainer: theme.colors.errorContainer } }}
-              />
-              {nameError ? <Text style={styles.errorText}>{nameError}</Text> : null}
+        <Button
+          mode="contained"
+          onPress={openAdd}
+          style={styles.addBtn}
+          icon="plus"
+        >
+          Add new tag
+        </Button>
 
-              <Text style={styles.sectionLabel}>Color</Text>
-              <View style={styles.palette}>
-                {COLOR_PALETTE.map((c) => {
-                  const selected = c.toLowerCase() === (color || "").toLowerCase();
-                  return (
-                    <TouchableOpacity
-                      key={c}
-                      style={[styles.colorDot, { backgroundColor: c }, selected && styles.colorDotSelected]}
-                      onPress={() => setColor(c)}
-                      accessibilityLabel={`Pick color ${c}`}
-                    />
-                  );
-                })}
+        <Divider />
+
+        <FlatList
+          data={tags}
+          keyExtractor={(item) => String(item.id)}
+          renderItem={renderItem}
+          ListEmptyComponent={
+            !loading && (
+              <View style={styles.emptyBox}>
+                <Text style={[styles.emptyText, { color: theme.colors.onSurfaceVariant }]}>You don't have any custom tags yet.</Text>
               </View>
+            )
+          }
+          contentContainerStyle={{ paddingBottom: 24 }}
+          style={{ maxHeight: 400 }}
+        />
+      </Modal>
 
-              <TextInput
-                label="HEX (#RRGGBB or #RRGGBBAA)"
-                mode="outlined"
-                value={color}
-                onChangeText={setColor}
-                error={!isValidHex}
-                theme={{ colors: { error: theme.colors.error, errorContainer: theme.colors.errorContainer } }}
-              />
-              {!isValidHex ? (
-                <Text style={styles.errorText}>Enter a valid hex color</Text>
-              ) : null}
+      <Dialog
+        visible={dialogVisible}
+        onDismiss={() => setDialogVisible(false)}
+        style={{ backgroundColor: theme.colors.surface }}
+      >
+        <Dialog.Title>{editingId ? "Edit tag" : "New tag"}</Dialog.Title>
+        <Dialog.Content>
+          <TextInput
+            label="Name"
+            mode="outlined"
+            value={name}
+            onChangeText={setName}
+            error={!!nameError}
+            style={{ marginBottom: 8 }}
+            theme={{
+              colors: {
+                error: theme.colors.error,
+                errorContainer: theme.colors.errorContainer,
+              },
+            }}
+          />
+          {nameError ? (
+            <Text style={[styles.errorText, { color: theme.colors.error }]}>{nameError}</Text>
+          ) : null}
 
-              <View style={styles.previewBox}>
-                <Text style={{ marginBottom: 8 }}>Preview</Text>
-                <Chip selected style={{ backgroundColor: color || "#ccc" }} textStyle={{ color: "#fff", fontWeight: "700" }}>
-                  {name || "Tag name"}
-                </Chip>
-              </View>
-            </Dialog.Content>
-            <Dialog.Actions>
-              <Button onPress={() => setDialogVisible(false)}>Cancel</Button>
-              <Button onPress={onSave} disabled={!canSave}>
-                Save
-              </Button>
-            </Dialog.Actions>
-          </Dialog>
-        </Portal>
-      </PaperProvider>
-    </Modal>
+          <Text style={[styles.sectionLabel, { color: theme.colors.onSurface }]}>Color</Text>
+          <View style={styles.palette}>
+            {COLOR_PALETTE.map((c) => {
+              const selected = c.toLowerCase() === (color || "").toLowerCase();
+              return (
+                <TouchableOpacity
+                  key={c}
+                  style={[
+                    styles.colorDot,
+                    { backgroundColor: c },
+                    selected && { borderColor: theme.colors.onSurface },
+                  ]}
+                  onPress={() => setColor(c)}
+                  accessibilityLabel={`Pick color ${c}`}
+                />
+              );
+            })}
+          </View>
+
+          <TextInput
+            label="HEX (#RRGGBB or #RRGGBBAA)"
+            mode="outlined"
+            value={color}
+            onChangeText={setColor}
+            error={!isValidHex}
+            theme={{
+              colors: {
+                error: theme.colors.error,
+                errorContainer: theme.colors.errorContainer,
+              },
+            }}
+          />
+          {!isValidHex ? (
+            <Text style={[styles.errorText, { color: theme.colors.error }]}>Enter a valid hex color</Text>
+          ) : null}
+
+          <View style={styles.previewBox}>
+            <Text style={{ marginBottom: 8, color: theme.colors.onSurface }}>Preview</Text>
+            <Chip
+              selected
+              style={{ backgroundColor: color || "#ccc" }}
+              textStyle={{ color: "#fff", fontWeight: "700" }}
+            >
+              {name || "Tag name"}
+            </Chip>
+          </View>
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button onPress={() => setDialogVisible(false)}>Cancel</Button>
+          <Button onPress={onSave} disabled={!canSave}>
+            Save
+          </Button>
+        </Dialog.Actions>
+      </Dialog>
+    </Portal>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#fff", padding: 16 },
+  container: {
+    marginHorizontal: 24,
+    marginVertical: 48,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+  },
   header: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
   title: { fontSize: 20, fontWeight: "700", marginBottom: 4 },
-  subtitle: { color: "#666", marginBottom: 12 },
+  subtitle: { marginBottom: 12 },
   addBtn: { alignSelf: "flex-start", marginBottom: 8 },
   row: {
     flexDirection: "row",
@@ -273,7 +293,6 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 4,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: "#eee",
   },
   left: { flexDirection: "row", alignItems: "center", flex: 1 },
   right: { flexDirection: "row", alignItems: "center" },
@@ -283,18 +302,16 @@ const styles = StyleSheet.create({
     borderRadius: 6,
     marginRight: 10,
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: "rgba(0,0,0,0.1)",
   },
   tagTextBox: { flexDirection: "column" },
-  tagName: { fontSize: 16, fontWeight: "600", color: "#111" },
-  tagColorCode: { fontSize: 12, color: "#6c757d" },
-  errorText: { color: "#FF6B6B", marginTop: -4, marginBottom: 6 },
+  tagName: { fontSize: 16, fontWeight: "600" },
+  tagColorCode: { fontSize: 12 },
+  errorText: { marginTop: -4, marginBottom: 6 },
   sectionLabel: { fontWeight: "600", marginBottom: 6, marginTop: 4 },
   palette: { flexDirection: "row", flexWrap: "wrap", gap: 10, marginBottom: 8 },
   colorDot: { width: 28, height: 28, borderRadius: 14, borderWidth: 2, borderColor: "transparent" },
-  colorDotSelected: { borderColor: "#333" },
   previewBox: { marginTop: 10, marginBottom: 4 },
   emptyBox: { paddingVertical: 24, alignItems: "center" },
-  emptyText: { color: "#666" },
+  emptyText: {},
 });
 

--- a/src/components/IngredientTagsModal.js
+++ b/src/components/IngredientTagsModal.js
@@ -5,8 +5,7 @@ import {
   FlatList,
   TouchableOpacity,
   Alert,
-  KeyboardAvoidingView,
-  Platform,
+  Keyboard,
 } from "react-native";
 import {
   Text,
@@ -46,6 +45,7 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
   const [editingId, setEditingId] = useState(null);
   const [name, setName] = useState("");
   const [color, setColor] = useState(COLOR_PALETTE[0]);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   useEffect(() => {
     if (!visible) return;
@@ -73,6 +73,17 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
       openAdd();
     }
   }, [visible, autoAdd]);
+
+  useEffect(() => {
+    const show = Keyboard.addListener("keyboardDidShow", (e) => {
+      setKeyboardHeight(e.endCoordinates.height);
+    });
+    const hide = Keyboard.addListener("keyboardDidHide", () => setKeyboardHeight(0));
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
 
   const openEdit = (tag) => {
     setEditingId(tag.id);
@@ -206,10 +217,7 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
         />
       </Modal>
 
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-        style={styles.dialogWrapper}
-      >
+      <View style={[styles.dialogWrapper, { paddingBottom: keyboardHeight }]}> 
         <Dialog
           visible={dialogVisible}
           onDismiss={() => setDialogVisible(false)}
@@ -289,7 +297,7 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
           </Button>
         </Dialog.Actions>
         </Dialog>
-      </KeyboardAvoidingView>
+      </View>
     </Portal>
   );
 }

--- a/src/components/IngredientTagsModal.js
+++ b/src/components/IngredientTagsModal.js
@@ -29,7 +29,7 @@ const COLOR_PALETTE = [
   "#20C997",
 ];
 
-export default function IngredientTagsModal({ visible, onClose }) {
+export default function IngredientTagsModal({ visible, onClose, autoAdd = false }) {
   const theme = useTheme();
   const [tags, setTags] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -59,6 +59,12 @@ export default function IngredientTagsModal({ visible, onClose }) {
     resetDialog();
     setDialogVisible(true);
   };
+
+  useEffect(() => {
+    if (visible && autoAdd) {
+      openAdd();
+    }
+  }, [visible, autoAdd]);
 
   const openEdit = (tag) => {
     setEditingId(tag.id);

--- a/src/components/IngredientTagsModal.js
+++ b/src/components/IngredientTagsModal.js
@@ -1,5 +1,13 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { View, StyleSheet, FlatList, TouchableOpacity, Alert } from "react-native";
+import {
+  View,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
 import {
   Text,
   TextInput,
@@ -198,16 +206,20 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
         />
       </Modal>
 
-      <Dialog
-        visible={dialogVisible}
-        onDismiss={() => setDialogVisible(false)}
-        style={{ backgroundColor: theme.colors.surface }}
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={styles.dialogWrapper}
       >
-        <Dialog.Title>{editingId ? "Edit tag" : "New tag"}</Dialog.Title>
-        <Dialog.Content>
-          <TextInput
-            label="Name"
-            mode="outlined"
+        <Dialog
+          visible={dialogVisible}
+          onDismiss={() => setDialogVisible(false)}
+          style={{ backgroundColor: theme.colors.surface }}
+        >
+          <Dialog.Title>{editingId ? "Edit tag" : "New tag"}</Dialog.Title>
+          <Dialog.Content>
+            <TextInput
+              label="Name"
+              mode="outlined"
             value={name}
             onChangeText={setName}
             error={!!nameError}
@@ -276,7 +288,8 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
             Save
           </Button>
         </Dialog.Actions>
-      </Dialog>
+        </Dialog>
+      </KeyboardAvoidingView>
     </Portal>
   );
 }
@@ -319,5 +332,6 @@ const styles = StyleSheet.create({
   previewBox: { marginTop: 10, marginBottom: 4 },
   emptyBox: { paddingVertical: 24, alignItems: "center" },
   emptyText: {},
+  dialogWrapper: { flex: 1, justifyContent: "center" },
 });
 

--- a/src/components/IngredientTagsModal.js
+++ b/src/components/IngredientTagsModal.js
@@ -203,7 +203,7 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
         <Dialog
           visible={dialogVisible}
           onDismiss={() => setDialogVisible(false)}
-          style={{ backgroundColor: theme.colors.surface }}
+          style={{ backgroundColor: theme.colors.surface, marginTop: 50 }}
         >
           <Dialog.Title>{editingId ? "Edit tag" : "New tag"}</Dialog.Title>
           <Dialog.Content>
@@ -322,6 +322,6 @@ const styles = StyleSheet.create({
   previewBox: { marginTop: 10, marginBottom: 4 },
   emptyBox: { paddingVertical: 24, alignItems: "center" },
   emptyText: {},
-  dialogWrapper: { flex: 1, justifyContent: "flex-start", paddingTop: 40 },
+  dialogWrapper: { flex: 1, justifyContent: "flex-start" },
 });
 

--- a/src/components/IngredientTagsModal.js
+++ b/src/components/IngredientTagsModal.js
@@ -1,12 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import {
-  View,
-  StyleSheet,
-  FlatList,
-  TouchableOpacity,
-  Alert,
-  Keyboard,
-} from "react-native";
+import { View, StyleSheet, FlatList, TouchableOpacity, Alert } from "react-native";
 import {
   Text,
   TextInput,
@@ -45,7 +38,6 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
   const [editingId, setEditingId] = useState(null);
   const [name, setName] = useState("");
   const [color, setColor] = useState(COLOR_PALETTE[0]);
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   useEffect(() => {
     if (!visible) return;
@@ -74,16 +66,6 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
     }
   }, [visible, autoAdd]);
 
-  useEffect(() => {
-    const show = Keyboard.addListener("keyboardDidShow", (e) => {
-      setKeyboardHeight(e.endCoordinates.height);
-    });
-    const hide = Keyboard.addListener("keyboardDidHide", () => setKeyboardHeight(0));
-    return () => {
-      show.remove();
-      hide.remove();
-    };
-  }, []);
 
   const openEdit = (tag) => {
     setEditingId(tag.id);
@@ -217,7 +199,7 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
         />
       </Modal>
 
-      <View style={[styles.dialogWrapper, { paddingBottom: keyboardHeight }]}> 
+      <View style={styles.dialogWrapper}>
         <Dialog
           visible={dialogVisible}
           onDismiss={() => setDialogVisible(false)}
@@ -340,6 +322,6 @@ const styles = StyleSheet.create({
   previewBox: { marginTop: 10, marginBottom: 4 },
   emptyBox: { paddingVertical: 24, alignItems: "center" },
   emptyText: {},
-  dialogWrapper: { flex: 1, justifyContent: "center" },
+  dialogWrapper: { flex: 1, justifyContent: "flex-start", paddingTop: 40 },
 });
 

--- a/src/components/IngredientTagsModal.js
+++ b/src/components/IngredientTagsModal.js
@@ -1,0 +1,300 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { View, StyleSheet, FlatList, TouchableOpacity, Alert, Modal } from "react-native";
+import {
+  Provider as PaperProvider,
+  Text,
+  TextInput,
+  Button,
+  IconButton,
+  Portal,
+  Dialog,
+  Divider,
+  Chip,
+  MD3LightTheme as BaseTheme,
+} from "react-native-paper";
+import { getUserTags, saveUserTags } from "../storage/ingredientTagsStorage";
+
+// Theme setup
+const theme = {
+  ...BaseTheme,
+  version: 3,
+  colors: {
+    ...BaseTheme.colors,
+    primary: "#4DABF7",
+    background: "#FFFFFF",
+    surface: "#ecececff",
+    outline: "#E5EAF0",
+    outlineVariant: "#E9EEF4",
+    error: "#FF6B6B",
+    errorContainer: "#FFE3E6",
+    onError: "#FFFFFF",
+    onErrorContainer: "#7A1C1C",
+    onPrimary: "#FFFFFF",
+    onBackground: "#000000",
+    onSurface: "#000000",
+    secondary: "#74C0FC",
+    tertiary: "#A5D8FF",
+    disabled: "#CED4DA",
+    placeholder: "#A1A1A1",
+    backdrop: "rgba(0,0,0,0.4)",
+  },
+};
+
+const COLOR_PALETTE = [
+  "#FF6B6B",
+  "#FF8787",
+  "#FFA94D",
+  "#FFD43B",
+  "#69DB7C",
+  "#38D9A9",
+  "#4DABF7",
+  "#9775FA",
+  "#8AADCFFF",
+  "#AFC9C3FF",
+  "#F06595",
+  "#20C997",
+];
+
+export default function IngredientTagsModal({ visible, onClose }) {
+  const [tags, setTags] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const [dialogVisible, setDialogVisible] = useState(false);
+  const [editingId, setEditingId] = useState(null);
+  const [name, setName] = useState("");
+  const [color, setColor] = useState(COLOR_PALETTE[0]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const load = async () => {
+      const data = await getUserTags();
+      setTags(Array.isArray(data) ? data : []);
+      setLoading(false);
+    };
+    load();
+  }, [visible]);
+
+  const resetDialog = () => {
+    setEditingId(null);
+    setName("");
+    setColor(COLOR_PALETTE[0]);
+  };
+
+  const openAdd = () => {
+    resetDialog();
+    setDialogVisible(true);
+  };
+
+  const openEdit = (tag) => {
+    setEditingId(tag.id);
+    setName(tag.name);
+    setColor(tag.color || COLOR_PALETTE[0]);
+    setDialogVisible(true);
+  };
+
+  const onDelete = (tag) => {
+    Alert.alert(
+      "Delete tag",
+      `Are you sure you want to delete “${tag.name}”?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: async () => {
+            const next = tags.filter((t) => t.id !== tag.id);
+            setTags(next);
+            await saveUserTags(next);
+          },
+        },
+      ]
+    );
+  };
+
+  const isValidHex = useMemo(() => {
+    const v = color?.trim() || "";
+    return /^#([0-9a-f]{6}|[0-9a-f]{8})$/i.test(v);
+  }, [color]);
+
+  const nameError = useMemo(() => {
+    const n = name.trim();
+    if (!n) return "Name is required";
+    const dup = tags.some(
+      (t) =>
+        t.name.toLowerCase() === n.toLowerCase() &&
+        (editingId ? t.id !== editingId : true)
+    );
+    if (dup) return "Tag with this name already exists";
+    return null;
+  }, [name, tags, editingId]);
+
+  const canSave = !nameError && isValidHex;
+
+  const onSave = async () => {
+    const n = name.trim();
+    if (!canSave) return;
+    let next;
+    if (editingId) {
+      next = tags.map((t) =>
+        t.id === editingId ? { ...t, name: n, color } : t
+      );
+    } else {
+      const id = Date.now();
+      next = [...tags, { id, name: n, color }];
+    }
+    setTags(next);
+    await saveUserTags(next);
+    setDialogVisible(false);
+    resetDialog();
+  };
+
+  const renderItem = ({ item }) => (
+    <View style={styles.row}>
+      <View style={styles.left}>
+        <View style={[styles.swatch, { backgroundColor: item.color || "#ccc" }]} />
+        <View style={styles.tagTextBox}>
+          <Text style={styles.tagName}>{item.name}</Text>
+          <Text style={styles.tagColorCode}>{item.color}</Text>
+        </View>
+      </View>
+      <View style={styles.right}>
+        <IconButton icon="pencil" size={20} onPress={() => openEdit(item)} accessibilityLabel="Edit tag" />
+        <IconButton icon="delete" size={20} onPress={() => onDelete(item)} accessibilityLabel="Delete tag" />
+      </View>
+    </View>
+  );
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <PaperProvider theme={theme}>
+        <View style={styles.container}>
+          <View style={styles.header}>
+            <Text style={styles.title}>Custom Tags</Text>
+            <IconButton icon="close" onPress={onClose} accessibilityLabel="Close" />
+          </View>
+          <Text style={styles.subtitle}>
+            Create, edit, or remove your own ingredient tags.
+          </Text>
+
+          <Button mode="contained" onPress={openAdd} style={styles.addBtn} icon="plus">
+            Add new tag
+          </Button>
+
+          <Divider />
+
+          <FlatList
+            data={tags}
+            keyExtractor={(item) => String(item.id)}
+            renderItem={renderItem}
+            ListEmptyComponent={
+              !loading && (
+                <View style={styles.emptyBox}>
+                  <Text style={styles.emptyText}>
+                    You don’t have any custom tags yet.
+                  </Text>
+                </View>
+              )
+            }
+            contentContainerStyle={{ paddingBottom: 24 }}
+          />
+        </View>
+
+        <Portal>
+          <Dialog visible={dialogVisible} onDismiss={() => setDialogVisible(false)} style={{ backgroundColor: theme.colors.surface }}>
+            <Dialog.Title>{editingId ? "Edit tag" : "New tag"}</Dialog.Title>
+            <Dialog.Content>
+              <TextInput
+                label="Name"
+                mode="outlined"
+                value={name}
+                onChangeText={setName}
+                error={!!nameError}
+                style={{ marginBottom: 8 }}
+                theme={{ colors: { error: theme.colors.error, errorContainer: theme.colors.errorContainer } }}
+              />
+              {nameError ? <Text style={styles.errorText}>{nameError}</Text> : null}
+
+              <Text style={styles.sectionLabel}>Color</Text>
+              <View style={styles.palette}>
+                {COLOR_PALETTE.map((c) => {
+                  const selected = c.toLowerCase() === (color || "").toLowerCase();
+                  return (
+                    <TouchableOpacity
+                      key={c}
+                      style={[styles.colorDot, { backgroundColor: c }, selected && styles.colorDotSelected]}
+                      onPress={() => setColor(c)}
+                      accessibilityLabel={`Pick color ${c}`}
+                    />
+                  );
+                })}
+              </View>
+
+              <TextInput
+                label="HEX (#RRGGBB or #RRGGBBAA)"
+                mode="outlined"
+                value={color}
+                onChangeText={setColor}
+                error={!isValidHex}
+                theme={{ colors: { error: theme.colors.error, errorContainer: theme.colors.errorContainer } }}
+              />
+              {!isValidHex ? (
+                <Text style={styles.errorText}>Enter a valid hex color</Text>
+              ) : null}
+
+              <View style={styles.previewBox}>
+                <Text style={{ marginBottom: 8 }}>Preview</Text>
+                <Chip selected style={{ backgroundColor: color || "#ccc" }} textStyle={{ color: "#fff", fontWeight: "700" }}>
+                  {name || "Tag name"}
+                </Chip>
+              </View>
+            </Dialog.Content>
+            <Dialog.Actions>
+              <Button onPress={() => setDialogVisible(false)}>Cancel</Button>
+              <Button onPress={onSave} disabled={!canSave}>
+                Save
+              </Button>
+            </Dialog.Actions>
+          </Dialog>
+        </Portal>
+      </PaperProvider>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#fff", padding: 16 },
+  header: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+  title: { fontSize: 20, fontWeight: "700", marginBottom: 4 },
+  subtitle: { color: "#666", marginBottom: 12 },
+  addBtn: { alignSelf: "flex-start", marginBottom: 8 },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 4,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#eee",
+  },
+  left: { flexDirection: "row", alignItems: "center", flex: 1 },
+  right: { flexDirection: "row", alignItems: "center" },
+  swatch: {
+    width: 24,
+    height: 24,
+    borderRadius: 6,
+    marginRight: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "rgba(0,0,0,0.1)",
+  },
+  tagTextBox: { flexDirection: "column" },
+  tagName: { fontSize: 16, fontWeight: "600", color: "#111" },
+  tagColorCode: { fontSize: 12, color: "#6c757d" },
+  errorText: { color: "#FF6B6B", marginTop: -4, marginBottom: 6 },
+  sectionLabel: { fontWeight: "600", marginBottom: 6, marginTop: 4 },
+  palette: { flexDirection: "row", flexWrap: "wrap", gap: 10, marginBottom: 8 },
+  colorDot: { width: 28, height: 28, borderRadius: 14, borderWidth: 2, borderColor: "transparent" },
+  colorDotSelected: { borderColor: "#333" },
+  previewBox: { marginTop: 10, marginBottom: 4 },
+  emptyBox: { paddingVertical: 24, alignItems: "center" },
+  emptyText: { color: "#666" },
+});
+

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -123,6 +123,7 @@ export default function AddIngredientScreen() {
   // reference lists
   const [availableTags, setAvailableTags] = useState([]);
   const [tagsModalVisible, setTagsModalVisible] = useState(false);
+  const [tagsModalAutoAdd, setTagsModalAutoAdd] = useState(false);
 
   const loadAvailableTags = useCallback(async () => {
     const custom = await getAllTags();
@@ -131,7 +132,13 @@ export default function AddIngredientScreen() {
 
   const closeTagsModal = () => {
     setTagsModalVisible(false);
+    setTagsModalAutoAdd(false);
     loadAvailableTags();
+  };
+
+  const openAddTagModal = () => {
+    setTagsModalAutoAdd(true);
+    setTagsModalVisible(true);
   };
 
   // base list
@@ -447,9 +454,33 @@ export default function AddIngredientScreen() {
                 onToggle={toggleTagById}
               />
             ))}
+          <Pressable
+            onPress={openAddTagModal}
+            style={[
+              styles.addTagButton,
+              {
+                borderColor: theme.colors.primary,
+                backgroundColor: theme.colors.background,
+              },
+            ]}
+          >
+            <Text
+              style={[
+                styles.addTagButtonText,
+                { color: theme.colors.primary },
+              ]}
+            >
+              +Add
+            </Text>
+          </Pressable>
         </View>
 
-        <Pressable onPress={() => setTagsModalVisible(true)}>
+        <Pressable
+          onPress={() => {
+            setTagsModalAutoAdd(false);
+            setTagsModalVisible(true);
+          }}
+        >
           <Text style={[styles.manageTagsLink, { color: theme.colors.primary }]}>Manage tags</Text>
         </Pressable>
 
@@ -627,7 +658,11 @@ export default function AddIngredientScreen() {
           </Text>
         </Pressable>
       </ScrollView>
-      <IngredientTagsModal visible={tagsModalVisible} onClose={closeTagsModal} />
+      <IngredientTagsModal
+        visible={tagsModalVisible}
+        onClose={closeTagsModal}
+        autoAdd={tagsModalAutoAdd}
+      />
     </KeyboardAvoidingView>
   );
 }
@@ -662,6 +697,15 @@ const styles = StyleSheet.create({
     margin: 4,
   },
   tagText: { color: "white", fontWeight: "bold" },
+
+  addTagButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 16,
+    margin: 4,
+    borderWidth: 1,
+  },
+  addTagButtonText: { fontWeight: "500" },
 
   manageTagsLink: { marginTop: 8, marginBottom: 4, fontWeight: "500" },
 

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -136,6 +136,7 @@ export default function EditIngredientScreen() {
   // reference lists
   const [availableTags, setAvailableTags] = useState([]); // builtin + custom
   const [tagsModalVisible, setTagsModalVisible] = useState(false);
+  const [tagsModalAutoAdd, setTagsModalAutoAdd] = useState(false);
 
   const loadAvailableTags = useCallback(async () => {
     const custom = await getAllTags();
@@ -144,7 +145,13 @@ export default function EditIngredientScreen() {
 
   const closeTagsModal = () => {
     setTagsModalVisible(false);
+    setTagsModalAutoAdd(false);
     loadAvailableTags();
+  };
+
+  const openAddTagModal = () => {
+    setTagsModalAutoAdd(true);
+    setTagsModalVisible(true);
   };
 
   // base list (lazy) — кешуємо nameLower для швидкого фільтру
@@ -546,9 +553,33 @@ export default function EditIngredientScreen() {
                 onToggle={toggleTagById}
               />
             ))}
+          <Pressable
+            onPress={openAddTagModal}
+            style={[
+              styles.addTagButton,
+              {
+                borderColor: theme.colors.primary,
+                backgroundColor: theme.colors.background,
+              },
+            ]}
+          >
+            <Text
+              style={[
+                styles.addTagButtonText,
+                { color: theme.colors.primary },
+              ]}
+            >
+              +Add
+            </Text>
+          </Pressable>
         </View>
 
-        <Pressable onPress={() => setTagsModalVisible(true)}>
+        <Pressable
+          onPress={() => {
+            setTagsModalAutoAdd(false);
+            setTagsModalVisible(true);
+          }}
+        >
           <Text style={[styles.manageTagsLink, { color: theme.colors.primary }]}>Manage tags</Text>
         </Pressable>
 
@@ -733,7 +764,11 @@ export default function EditIngredientScreen() {
         </Pressable>
 
       </ScrollView>
-      <IngredientTagsModal visible={tagsModalVisible} onClose={closeTagsModal} />
+      <IngredientTagsModal
+        visible={tagsModalVisible}
+        onClose={closeTagsModal}
+        autoAdd={tagsModalAutoAdd}
+      />
     </KeyboardAvoidingView>
   );
 }
@@ -768,6 +803,14 @@ const styles = StyleSheet.create({
     margin: 4,
   },
   tagText: { fontWeight: "bold" },
+  addTagButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 16,
+    margin: 4,
+    borderWidth: 1,
+  },
+  addTagButtonText: { fontWeight: "500" },
   manageTagsLink: { marginTop: 8, marginBottom: 4, fontWeight: "500" },
 
   menuSearchBox: { paddingHorizontal: 12, paddingVertical: 8 },


### PR DESCRIPTION
## Summary
- add IngredientTagsModal to create and edit custom tags
- open tag manager modal from menu and ingredient screens

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e5ad4c32083268a7bfe46a4147a6a