### PR TITLE
Respect Use Metric System setting

### DIFF
--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -13,6 +13,7 @@ import { Checkbox } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import IngredientIcon from "../../assets/lemon.svg";
 import { useNavigation } from "@react-navigation/native";
+import { getUseMetric, setUseMetric as saveUseMetric } from "../storage/settingsStorage";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 const MENU_WIDTH = SCREEN_WIDTH * 0.75;
@@ -40,6 +41,23 @@ export default function GeneralMenu({ visible, onClose }) {
       }).start();
     }
   }, [visible, slideAnim]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await getUseMetric();
+        setUseMetric(stored);
+      } catch {}
+    })();
+  }, []);
+
+  const toggleUseMetric = () => {
+    setUseMetric((v) => {
+      const next = !v;
+      saveUseMetric(next);
+      return next;
+    });
+  };
 
   const navigateToIngredientTags = () => {
     onClose?.();
@@ -74,7 +92,7 @@ export default function GeneralMenu({ visible, onClose }) {
           <View style={styles.itemRow}>
             <Checkbox
               status={useMetric ? "checked" : "unchecked"}
-              onPress={() => setUseMetric((v) => !v)}
+              onPress={toggleUseMetric}
             />
             <View style={styles.itemText}>
               <Text style={styles.itemTitle}>Use metric system</Text>

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -29,6 +29,7 @@ import { getAllIngredients } from "../../storage/ingredientsStorage";
 import { getUnitById, formatUnit } from "../../constants/measureUnits";
 import { getGlassById } from "../../constants/glassware";
 import { formatAmount, toMetric, toImperial } from "../../utils/units";
+import { getUseMetric } from "../../storage/settingsStorage";
 
 /* ---------- helpers ---------- */
 const withAlpha = (hex, alpha) => {
@@ -217,13 +218,15 @@ export default function CocktailDetailsScreen() {
 
   const load = useCallback(async () => {
     setLoading(true);
-    const [loadedCocktail, allIngredients] = await Promise.all([
+    const [loadedCocktail, allIngredients, useMetric] = await Promise.all([
       getCocktailById(id),
       getAllIngredients(),
+      getUseMetric(),
     ]);
     setCocktail(loadedCocktail || null);
     setIngMap(new Map((allIngredients || []).map((i) => [i.id, i])));
     setIngList(allIngredients || []);
+    setShowImperial(!useMetric);
     setLoading(false);
   }, [id]);
 

--- a/src/storage/settingsStorage.js
+++ b/src/storage/settingsStorage.js
@@ -1,0 +1,19 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const USE_METRIC_KEY = "useMetric";
+
+export async function getUseMetric() {
+  try {
+    const value = await AsyncStorage.getItem(USE_METRIC_KEY);
+    if (value === null) return true;
+    return value === "true";
+  } catch {
+    return true;
+  }
+}
+
+export async function setUseMetric(value) {
+  try {
+    await AsyncStorage.setItem(USE_METRIC_KEY, value ? "true" : "false");
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- persist metric unit preference in AsyncStorage
- apply saved preference on cocktail details screen
- wire settings menu checkbox to stored preference

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e67cdcd9083269a606a6c9a79062d