### PR TITLE
feat: make garnishes optional when desired

### DIFF
--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -15,7 +15,12 @@ import IngredientIcon from "../../assets/lemon.svg";
 
 import IngredientTagsModal from "./IngredientTagsModal";
 
-import { getUseMetric, setUseMetric as saveUseMetric } from "../storage/settingsStorage";
+import {
+  getUseMetric,
+  setUseMetric as saveUseMetric,
+  getIgnoreGarnish,
+  setIgnoreGarnish as saveIgnoreGarnish,
+} from "../storage/settingsStorage";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 const MENU_WIDTH = SCREEN_WIDTH * 0.75;
@@ -56,12 +61,26 @@ export default function GeneralMenu({ visible, onClose }) {
         setUseMetric(!!stored);
       } catch {}
     })();
+    (async () => {
+      try {
+        const stored = await getIgnoreGarnish();
+        setIgnoreGarnish(!!stored);
+      } catch {}
+    })();
   }, []);
 
   const toggleUseMetric = () => {
     setUseMetric((v) => {
       const next = !v;
       saveUseMetric(next);
+      return next;
+    });
+  };
+
+  const toggleIgnoreGarnish = () => {
+    setIgnoreGarnish((v) => {
+      const next = !v;
+      saveIgnoreGarnish(next);
       return next;
     });
   };
@@ -86,7 +105,7 @@ export default function GeneralMenu({ visible, onClose }) {
             <View style={styles.itemRow}>
               <Checkbox
                 status={ignoreGarnish ? "checked" : "unchecked"}
-                onPress={() => setIgnoreGarnish((v) => !v)}
+                onPress={toggleIgnoreGarnish}
               />
               <View style={styles.itemText}>
                 <Text style={styles.itemTitle}>Ignore garnishes</Text>

--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -12,6 +12,10 @@ import HeaderWithSearch from "../../components/HeaderWithSearch";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
 import { getAllIngredients } from "../../storage/ingredientsStorage";
+import {
+  getIgnoreGarnish,
+  addIgnoreGarnishListener,
+} from "../../storage/settingsStorage";
 import { useTheme } from "react-native-paper";
 import TagFilterMenu from "../../components/TagFilterMenu";
 import { getAllCocktailTags } from "../../storage/cocktailTagsStorage";
@@ -33,6 +37,7 @@ export default function AllCocktailsScreen() {
   const [navigatingId, setNavigatingId] = useState(null);
   const [selectedTagIds, setSelectedTagIds] = useState([]);
   const [availableTags, setAvailableTags] = useState([]);
+  const [ignoreGarnish, setIgnoreGarnish] = useState(false);
 
   useEffect(() => {
     if (isFocused) setTab("cocktails", "All");
@@ -60,20 +65,24 @@ export default function AllCocktailsScreen() {
     if (!isFocused) return;
     (async () => {
       if (firstLoad.current) setLoading(true);
-      const [cocktailsList, ingredientsList] = await Promise.all([
+      const [cocktailsList, ingredientsList, ig] = await Promise.all([
         getAllCocktails(),
         getAllIngredients(),
+        getIgnoreGarnish(),
       ]);
       if (cancel) return;
       setCocktails(Array.isArray(cocktailsList) ? cocktailsList : []);
       setIngredients(Array.isArray(ingredientsList) ? ingredientsList : []);
+      setIgnoreGarnish(!!ig);
       if (firstLoad.current) {
         setLoading(false);
         firstLoad.current = false;
       }
     })();
+    const sub = addIgnoreGarnishListener(setIgnoreGarnish);
     return () => {
       cancel = true;
+      sub.remove();
     };
   }, [isFocused]);
 
@@ -95,7 +104,9 @@ export default function AllCocktailsScreen() {
           c.tags.some((t) => selectedTagIds.includes(t.id))
       );
     return list.map((c) => {
-      const required = (c.ingredients || []).filter((r) => !r.optional);
+      const required = (c.ingredients || []).filter(
+        (r) => !r.optional && !(ignoreGarnish && r.garnish)
+      );
       const missing = [];
       const ingredientNames = [];
       let allAvail = required.length > 0;
@@ -152,7 +163,7 @@ export default function AllCocktailsScreen() {
         ingredientLine,
       };
     });
-  }, [cocktails, ingredients, searchDebounced, selectedTagIds]);
+  }, [cocktails, ingredients, searchDebounced, selectedTagIds, ignoreGarnish]);
 
   const handlePress = useCallback(
     (id) => {

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -29,7 +29,11 @@ import { getAllIngredients } from "../../storage/ingredientsStorage";
 import { getUnitById, formatUnit } from "../../constants/measureUnits";
 import { getGlassById } from "../../constants/glassware";
 import { formatAmount, toMetric, toImperial } from "../../utils/units";
-import { getUseMetric } from "../../storage/settingsStorage";
+import {
+  getUseMetric,
+  getIgnoreGarnish,
+  addIgnoreGarnishListener,
+} from "../../storage/settingsStorage";
 
 /* ---------- helpers ---------- */
 const withAlpha = (hex, alpha) => {
@@ -157,6 +161,7 @@ export default function CocktailDetailsScreen() {
   const [ingList, setIngList] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showImperial, setShowImperial] = useState(false);
+  const [ignoreGarnish, setIgnoreGarnish] = useState(false);
 
   const handleGoBack = useCallback(() => {
     navigation.goBack();
@@ -218,15 +223,17 @@ export default function CocktailDetailsScreen() {
 
   const load = useCallback(async () => {
     setLoading(true);
-    const [loadedCocktail, allIngredients, useMetric] = await Promise.all([
+    const [loadedCocktail, allIngredients, useMetric, ig] = await Promise.all([
       getCocktailById(id),
       getAllIngredients(),
       getUseMetric(),
+      getIgnoreGarnish(),
     ]);
     setCocktail(loadedCocktail || null);
     setIngMap(new Map((allIngredients || []).map((i) => [i.id, i])));
     setIngList(allIngredients || []);
     setShowImperial(!useMetric);
+    setIgnoreGarnish(!!ig);
     setLoading(false);
   }, [id]);
 
@@ -240,6 +247,11 @@ export default function CocktailDetailsScreen() {
     }, [load])
   );
 
+  useEffect(() => {
+    const sub = addIgnoreGarnishListener(setIgnoreGarnish);
+    return () => sub.remove();
+  }, []);
+
   const rows = useMemo(() => {
     if (!cocktail) return [];
     const list = Array.isArray(cocktail.ingredients)
@@ -249,7 +261,7 @@ export default function CocktailDetailsScreen() {
     return list.map((r) => {
       const ing = r.ingredientId ? ingMap.get(r.ingredientId) : null;
       const originalName = ing?.name || r.name;
-      const inBar = ing?.inBar;
+      const inBar = ing?.inBar || (ignoreGarnish && r.garnish);
       let substitute = null;
       if (!inBar && ing) {
         const baseId = ing.baseIngredientId ?? ing.id;
@@ -305,7 +317,7 @@ export default function CocktailDetailsScreen() {
         substituteFor: substitute ? originalName : null,
       };
     });
-  }, [cocktail, ingMap, ingList, showImperial]);
+  }, [cocktail, ingMap, ingList, showImperial, ignoreGarnish]);
 
   if (loading)
     return (

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -12,6 +12,10 @@ import HeaderWithSearch from "../../components/HeaderWithSearch";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
 import { getAllIngredients } from "../../storage/ingredientsStorage";
+import {
+  getIgnoreGarnish,
+  addIgnoreGarnishListener,
+} from "../../storage/settingsStorage";
 import { useTheme } from "react-native-paper";
 import TagFilterMenu from "../../components/TagFilterMenu";
 import { getAllCocktailTags } from "../../storage/cocktailTagsStorage";
@@ -33,6 +37,7 @@ export default function FavoriteCocktailsScreen() {
   const [navigatingId, setNavigatingId] = useState(null);
   const [selectedTagIds, setSelectedTagIds] = useState([]);
   const [availableTags, setAvailableTags] = useState([]);
+  const [ignoreGarnish, setIgnoreGarnish] = useState(false);
 
   useEffect(() => {
     if (isFocused) setTab("cocktails", "Favorite");
@@ -60,20 +65,24 @@ export default function FavoriteCocktailsScreen() {
     if (!isFocused) return;
     (async () => {
       if (firstLoad.current) setLoading(true);
-      const [cocktailsList, ingredientsList] = await Promise.all([
+      const [cocktailsList, ingredientsList, ig] = await Promise.all([
         getAllCocktails(),
         getAllIngredients(),
+        getIgnoreGarnish(),
       ]);
       if (cancel) return;
       setCocktails(Array.isArray(cocktailsList) ? cocktailsList : []);
       setIngredients(Array.isArray(ingredientsList) ? ingredientsList : []);
+      setIgnoreGarnish(!!ig);
       if (firstLoad.current) {
         setLoading(false);
         firstLoad.current = false;
       }
     })();
+    const sub = addIgnoreGarnishListener(setIgnoreGarnish);
     return () => {
       cancel = true;
+      sub.remove();
     };
   }, [isFocused]);
 
@@ -95,7 +104,9 @@ export default function FavoriteCocktailsScreen() {
           c.tags.some((t) => selectedTagIds.includes(t.id))
       );
     return list.map((c) => {
-      const required = (c.ingredients || []).filter((r) => !r.optional);
+      const required = (c.ingredients || []).filter(
+        (r) => !r.optional && !(ignoreGarnish && r.garnish)
+      );
       const missing = [];
       const ingredientNames = [];
       let allAvail = required.length > 0;
@@ -152,7 +163,7 @@ export default function FavoriteCocktailsScreen() {
         ingredientLine,
       };
     });
-  }, [cocktails, ingredients, searchDebounced, selectedTagIds]);
+  }, [cocktails, ingredients, searchDebounced, selectedTagIds, ignoreGarnish]);
 
   const handlePress = useCallback(
     (id) => {

--- a/src/storage/settingsStorage.js
+++ b/src/storage/settingsStorage.js
@@ -1,6 +1,10 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { DeviceEventEmitter } from "react-native";
 
 const USE_METRIC_KEY = "useMetric";
+const IGNORE_GARNISH_KEY = "ignoreGarnish";
+
+export const IGNORE_GARNISH_EVENT = "ignoreGarnishChanged";
 
 export async function getUseMetric() {
   try {
@@ -16,4 +20,25 @@ export async function setUseMetric(value) {
   try {
     await AsyncStorage.setItem(USE_METRIC_KEY, value ? "true" : "false");
   } catch {}
+}
+
+export async function getIgnoreGarnish() {
+  try {
+    const value = await AsyncStorage.getItem(IGNORE_GARNISH_KEY);
+    if (value === null) return false;
+    return value === "true";
+  } catch {
+    return false;
+  }
+}
+
+export async function setIgnoreGarnish(value) {
+  try {
+    await AsyncStorage.setItem(IGNORE_GARNISH_KEY, value ? "true" : "false");
+  } catch {}
+  DeviceEventEmitter.emit(IGNORE_GARNISH_EVENT, value);
+}
+
+export function addIgnoreGarnishListener(listener) {
+  return DeviceEventEmitter.addListener(IGNORE_GARNISH_EVENT, listener);
 }


### PR DESCRIPTION
## Summary
- persist `Ignore garnishes` setting and expose change event
- allow cocktail lists and details to ignore missing garnishes when setting enabled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e76af77dc8326bc0f7f3337c4e9af