### PR TITLE
feat: add keep awake setting

### DIFF
--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -20,6 +20,8 @@ import {
   setUseMetric as saveUseMetric,
   getIgnoreGarnish,
   setIgnoreGarnish as saveIgnoreGarnish,
+  getKeepAwake,
+  setKeepAwake as saveKeepAwake,
 } from "../storage/settingsStorage";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
@@ -67,6 +69,12 @@ export default function GeneralMenu({ visible, onClose }) {
         setIgnoreGarnish(!!stored);
       } catch {}
     })();
+    (async () => {
+      try {
+        const stored = await getKeepAwake();
+        setKeepAwake(!!stored);
+      } catch {}
+    })();
   }, []);
 
   const toggleUseMetric = () => {
@@ -81,6 +89,14 @@ export default function GeneralMenu({ visible, onClose }) {
     setIgnoreGarnish((v) => {
       const next = !v;
       saveIgnoreGarnish(next);
+      return next;
+    });
+  };
+
+  const toggleKeepAwake = () => {
+    setKeepAwake((v) => {
+      const next = !v;
+      saveKeepAwake(next);
       return next;
     });
   };
@@ -127,11 +143,11 @@ export default function GeneralMenu({ visible, onClose }) {
             <View style={styles.itemRow}>
               <Checkbox
                 status={keepAwake ? "checked" : "unchecked"}
-                onPress={() => setKeepAwake((v) => !v)}
+                onPress={toggleKeepAwake}
               />
               <Pressable
                 style={styles.itemText}
-                onPress={() => setKeepAwake((v) => !v)}
+                onPress={toggleKeepAwake}
               >
                 <Text style={styles.itemTitle}>Keep screen awake</Text>
                 <Text style={styles.itemSub}>

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -33,7 +33,10 @@ import {
   getUseMetric,
   getIgnoreGarnish,
   addIgnoreGarnishListener,
+  getKeepAwake,
+  addKeepAwakeListener,
 } from "../../storage/settingsStorage";
+import { activateKeepAwakeAsync, deactivateKeepAwakeAsync } from "expo-keep-awake";
 
 /* ---------- helpers ---------- */
 const withAlpha = (hex, alpha) => {
@@ -163,6 +166,7 @@ export default function CocktailDetailsScreen() {
   const [loading, setLoading] = useState(true);
   const [showImperial, setShowImperial] = useState(false);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
+  const [keepAwake, setKeepAwake] = useState(false);
 
   const handleGoBack = useCallback(() => {
     navigation.goBack();
@@ -247,6 +251,30 @@ export default function CocktailDetailsScreen() {
       })();
     }, [load])
   );
+
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        try {
+          const enabled = await getKeepAwake();
+          setKeepAwake(!!enabled);
+        } catch {}
+      })();
+      const sub = addKeepAwakeListener(setKeepAwake);
+      return () => {
+        sub.remove();
+        deactivateKeepAwakeAsync();
+      };
+    }, [])
+  );
+
+  useEffect(() => {
+    if (keepAwake) {
+      activateKeepAwakeAsync();
+    } else {
+      deactivateKeepAwakeAsync();
+    }
+  }, [keepAwake]);
 
   useEffect(() => {
     const sub = addIgnoreGarnishListener(setIgnoreGarnish);

--- a/src/storage/settingsStorage.js
+++ b/src/storage/settingsStorage.js
@@ -3,8 +3,10 @@ import { DeviceEventEmitter } from "react-native";
 
 const USE_METRIC_KEY = "useMetric";
 const IGNORE_GARNISH_KEY = "ignoreGarnish";
+const KEEP_AWAKE_KEY = "keepAwake";
 
 export const IGNORE_GARNISH_EVENT = "ignoreGarnishChanged";
+export const KEEP_AWAKE_EVENT = "keepAwakeChanged";
 
 export async function getUseMetric() {
   try {
@@ -41,4 +43,25 @@ export async function setIgnoreGarnish(value) {
 
 export function addIgnoreGarnishListener(listener) {
   return DeviceEventEmitter.addListener(IGNORE_GARNISH_EVENT, listener);
+}
+
+export async function getKeepAwake() {
+  try {
+    const value = await AsyncStorage.getItem(KEEP_AWAKE_KEY);
+    if (value === null) return false;
+    return value === "true";
+  } catch {
+    return false;
+  }
+}
+
+export async function setKeepAwake(value) {
+  try {
+    await AsyncStorage.setItem(KEEP_AWAKE_KEY, value ? "true" : "false");
+  } catch {}
+  DeviceEventEmitter.emit(KEEP_AWAKE_EVENT, value);
+}
+
+export function addKeepAwakeListener(listener) {
+  return DeviceEventEmitter.addListener(KEEP_AWAKE_EVENT, listener);
 }


### PR DESCRIPTION
## Summary
- persist keep-awake preference in settings storage
- expose keep screen awake toggle in general menu
- keep cocktail detail screen awake when enabled

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689ee8450c0c8326b6db4e6c9ccd1e0a