### PR TITLE
Fix KeepAwake deactivation call

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -36,7 +36,7 @@ import {
   getKeepAwake,
   addKeepAwakeListener,
 } from "../../storage/settingsStorage";
-import { activateKeepAwakeAsync, deactivateKeepAwakeAsync } from "expo-keep-awake";
+import { activateKeepAwakeAsync, deactivateKeepAwake } from "expo-keep-awake";
 
 /* ---------- helpers ---------- */
 const withAlpha = (hex, alpha) => {
@@ -263,7 +263,7 @@ export default function CocktailDetailsScreen() {
       const sub = addKeepAwakeListener(setKeepAwake);
       return () => {
         sub.remove();
-        deactivateKeepAwakeAsync();
+        deactivateKeepAwake();
       };
     }, [])
   );
@@ -272,7 +272,7 @@ export default function CocktailDetailsScreen() {
     if (keepAwake) {
       activateKeepAwakeAsync();
     } else {
-      deactivateKeepAwakeAsync();
+      deactivateKeepAwake();
     }
   }, [keepAwake]);
 


### PR DESCRIPTION
## Summary
- use `deactivateKeepAwake` instead of non-existent `deactivateKeepAwakeAsync`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f10e0ab2c8326a07733e0b9327df5