### PR TITLE
Add rating sort to favorite cocktails

### DIFF
--- a/src/components/SortMenu.js
+++ b/src/components/SortMenu.js
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import { TouchableOpacity } from "react-native";
+import { Menu, useTheme } from "react-native-paper";
+import { MaterialIcons } from "@expo/vector-icons";
+
+export default function SortMenu({ order = "desc", onChange }) {
+  const theme = useTheme();
+  const [visible, setVisible] = useState(false);
+
+  const select = (o) => {
+    onChange?.(o);
+    setVisible(false);
+  };
+
+  return (
+    <Menu
+      visible={visible}
+      onDismiss={() => setVisible(false)}
+      anchor={
+        <TouchableOpacity
+          onPress={() => setVisible(true)}
+          style={{ paddingVertical: 4, paddingHorizontal: 2 }}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8, borderRadius: 16 }}
+        >
+          <MaterialIcons
+            name="sort"
+            size={28}
+            color={theme.colors.onSurface}
+          />
+        </TouchableOpacity>
+      }
+      anchorPosition="bottom"
+      contentStyle={{
+        paddingHorizontal: 4,
+        paddingVertical: 4,
+        backgroundColor: theme.colors.surface,
+        borderRadius: 8,
+      }}
+    >
+      <Menu.Item
+        onPress={() => select("asc")}
+        title="Rating: Low to High"
+        leadingIcon={
+          order === "asc"
+            ? () => (
+                <MaterialIcons
+                  name="check"
+                  size={20}
+                  color={theme.colors.primary}
+                />
+              )
+            : undefined
+        }
+      />
+      <Menu.Item
+        onPress={() => select("desc")}
+        title="Rating: High to Low"
+        leadingIcon={
+          order === "desc"
+            ? () => (
+                <MaterialIcons
+                  name="check"
+                  size={20}
+                  color={theme.colors.primary}
+                />
+              )
+            : undefined
+        }
+      />
+    </Menu>
+  );
+}

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -20,6 +20,7 @@ import {
 } from "../../storage/settingsStorage";
 import { useTheme } from "react-native-paper";
 import TagFilterMenu from "../../components/TagFilterMenu";
+import SortMenu from "../../components/SortMenu";
 import { getAllCocktailTags } from "../../storage/cocktailTagsStorage";
 import CocktailRow, {
   COCKTAIL_ROW_HEIGHT as ITEM_HEIGHT,
@@ -41,6 +42,7 @@ export default function FavoriteCocktailsScreen() {
   const [availableTags, setAvailableTags] = useState([]);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
   const [minRating, setMinRating] = useState(0);
+  const [sortOrder, setSortOrder] = useState("desc");
 
   useEffect(() => {
     if (isFocused) setTab("cocktails", "Favorite");
@@ -110,7 +112,7 @@ export default function FavoriteCocktailsScreen() {
           Array.isArray(c.tags) &&
           c.tags.some((t) => selectedTagIds.includes(t.id))
       );
-    return list.map((c) => {
+    const mapped = list.map((c) => {
       const required = (c.ingredients || []).filter(
         (r) => !r.optional && !(ignoreGarnish && r.garnish)
       );
@@ -170,6 +172,13 @@ export default function FavoriteCocktailsScreen() {
         ingredientLine,
       };
     });
+    mapped.sort((a, b) => {
+      const aRating = a.rating ?? 0;
+      const bRating = b.rating ?? 0;
+      if (aRating === bRating) return a.name.localeCompare(b.name);
+      return sortOrder === "asc" ? aRating - bRating : bRating - aRating;
+    });
+    return mapped;
   }, [
     cocktails,
     ingredients,
@@ -177,6 +186,7 @@ export default function FavoriteCocktailsScreen() {
     selectedTagIds,
     ignoreGarnish,
     minRating,
+    sortOrder,
   ]);
 
   const handlePress = useCallback(
@@ -225,11 +235,14 @@ export default function FavoriteCocktailsScreen() {
         searchValue={search}
         setSearchValue={setSearch}
         filterComponent={
-          <TagFilterMenu
-            tags={availableTags}
-            selected={selectedTagIds}
-            setSelected={setSelectedTagIds}
-          />
+          <View style={{ flexDirection: "row" }}>
+            <SortMenu order={sortOrder} onChange={setSortOrder} />
+            <TagFilterMenu
+              tags={availableTags}
+              selected={selectedTagIds}
+              setSelected={setSelectedTagIds}
+            />
+          </View>
         }
       />
       <FlashList

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -236,7 +236,9 @@ export default function FavoriteCocktailsScreen() {
         setSearchValue={setSearch}
         filterComponent={
           <View style={{ flexDirection: "row" }}>
-            <SortMenu order={sortOrder} onChange={setSortOrder} />
+            {minRating < 5 && (
+              <SortMenu order={sortOrder} onChange={setSortOrder} />
+            )}
             <TagFilterMenu
               tags={availableTags}
               selected={selectedTagIds}


### PR DESCRIPTION
## Summary
- add menu for sorting favorite cocktails by rating
- sort favorites list ascending or descending with name tiebreaker

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f1da5489083268109785231b363ad