### PR TITLE
feat: add cocktail tag management

### DIFF
--- a/src/components/CocktailTagsModal.js
+++ b/src/components/CocktailTagsModal.js
@@ -1,0 +1,326 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { View, StyleSheet, FlatList, TouchableOpacity, Alert } from "react-native";
+import {
+  Text,
+  TextInput,
+  Button,
+  IconButton,
+  Portal,
+  Modal,
+  Divider,
+  useTheme,
+} from "react-native-paper";
+import {
+  getCustomCocktailTags,
+  upsertCocktailTag,
+  deleteCocktailTag,
+} from "../storage/cocktailTagsStorage";
+
+const COLOR_PALETTE = [
+  "#FF6B6B",
+  "#FF8787",
+  "#FFA94D",
+  "#FFD43B",
+  "#69DB7C",
+  "#38D9A9",
+  "#4DABF7",
+  "#9775FA",
+  "#8AADCFFF",
+  "#AFC9C3FF",
+  "#F06595",
+  "#20C997",
+];
+
+const TOP_OFFSET = 0;
+
+export default function CocktailTagsModal({ visible, onClose, autoAdd = false }) {
+  const theme = useTheme();
+  const [tags, setTags] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const [dialogVisible, setDialogVisible] = useState(false);
+  const [editingId, setEditingId] = useState(null);
+  const [name, setName] = useState("");
+  const [color, setColor] = useState(COLOR_PALETTE[0]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const load = async () => {
+      const data = await getCustomCocktailTags();
+      setTags(Array.isArray(data) ? data : []);
+      setLoading(false);
+    };
+    load();
+  }, [visible]);
+
+  const resetDialog = () => {
+    setEditingId(null);
+    setName("");
+    setColor(COLOR_PALETTE[0]);
+  };
+
+  const openAdd = () => {
+    resetDialog();
+    setDialogVisible(true);
+  };
+
+  useEffect(() => {
+    if (visible && autoAdd) {
+      openAdd();
+    }
+  }, [visible, autoAdd]);
+
+  const openEdit = (tag) => {
+    setEditingId(tag.id);
+    setName(tag.name);
+    setColor(tag.color || COLOR_PALETTE[0]);
+    setDialogVisible(true);
+  };
+
+  const onDelete = (tag) => {
+    Alert.alert(
+      "Delete tag",
+      `Are you sure you want to delete “${tag.name}”?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: async () => {
+            setTags((prev) => prev.filter((t) => t.id !== tag.id));
+            await deleteCocktailTag(tag.id);
+          },
+        },
+      ]
+    );
+  };
+
+  const isValidHex = useMemo(() => {
+    const v = color?.trim() || "";
+    return /^#([0-9a-f]{6}|[0-9a-f]{8})$/i.test(v);
+  }, [color]);
+
+  const nameError = useMemo(() => {
+    const n = name.trim();
+    if (!n) return "Name is required";
+    const dup = tags.some(
+      (t) =>
+        t.name.toLowerCase() === n.toLowerCase() &&
+        (editingId ? t.id !== editingId : true)
+    );
+    if (dup) return "Tag with this name already exists";
+    return null;
+  }, [name, tags, editingId]);
+
+  const canSave = !nameError && isValidHex;
+
+  const onSave = async () => {
+    const n = name.trim();
+    if (!canSave) return;
+    let tag;
+    if (editingId) {
+      tag = { id: editingId, name: n, color };
+      setTags((prev) => prev.map((t) => (t.id === editingId ? tag : t)));
+    } else {
+      tag = { id: Date.now(), name: n, color };
+      setTags((prev) => [...prev, tag]);
+    }
+    await upsertCocktailTag(tag);
+    setDialogVisible(false);
+    resetDialog();
+  };
+
+  const renderItem = ({ item }) => (
+    <View style={[styles.row, { borderBottomColor: theme.colors.outline }]}> 
+      <View style={styles.left}>
+        <View
+          style={[
+            styles.swatch,
+            { backgroundColor: item.color || "#ccc", borderColor: theme.colors.outlineVariant },
+          ]}
+        />
+        <View style={styles.tagTextBox}>
+          <Text style={[styles.tagName, { color: theme.colors.onSurface }]}>{item.name}</Text>
+          <Text style={[styles.tagColorCode, { color: theme.colors.onSurfaceVariant }]}>{item.color}</Text>
+        </View>
+      </View>
+      <View style={styles.right}>
+        <IconButton icon="pencil" size={20} onPress={() => openEdit(item)} accessibilityLabel="Edit tag" />
+        <IconButton icon="delete" size={20} onPress={() => onDelete(item)} accessibilityLabel="Delete tag" />
+      </View>
+    </View>
+  );
+
+  return (
+    <Portal>
+      <Modal
+        visible={visible}
+        onDismiss={onClose}
+        style={{ justifyContent: "flex-start" }}
+        contentContainerStyle={[
+          styles.container,
+          {
+            backgroundColor: theme.colors.surface,
+            borderColor: theme.colors.outline,
+          },
+        ]}
+      >
+        <Text style={[styles.title, { color: theme.colors.onSurface }]}>Custom Tags</Text>
+        <Text style={[styles.subtitle, { color: theme.colors.onSurfaceVariant }]}>Create, edit, or remove your own cocktail tags.</Text>
+
+        <Button mode="contained" onPress={openAdd} style={styles.addBtn} icon="plus">
+          Add new tag
+        </Button>
+
+        <Divider />
+
+        <FlatList
+          data={tags}
+          keyExtractor={(item) => String(item.id)}
+          renderItem={renderItem}
+          ListEmptyComponent={
+            !loading && (
+              <View style={styles.emptyBox}>
+                <Text style={[styles.emptyText, { color: theme.colors.onSurfaceVariant }]}>You don't have any custom tags yet.</Text>
+              </View>
+            )
+          }
+          contentContainerStyle={{ paddingBottom: 24 }}
+          style={{ maxHeight: 400 }}
+        />
+      </Modal>
+
+      <Modal
+        visible={dialogVisible}
+        onDismiss={() => setDialogVisible(false)}
+        style={{ justifyContent: "flex-start" }}
+        contentContainerStyle={[
+          styles.dialog,
+          {
+            backgroundColor: theme.colors.surface,
+            borderColor: theme.colors.outline,
+          },
+        ]}
+      >
+        <Text style={[styles.dialogTitle, { color: theme.colors.onSurface }]}>
+          {editingId ? "Edit tag" : "New tag"}
+        </Text>
+
+        <TextInput
+          label="Name"
+          mode="outlined"
+          value={name}
+          onChangeText={setName}
+          error={!!nameError}
+          style={{ marginBottom: 8 }}
+          theme={{
+            colors: {
+              error: theme.colors.error,
+              errorContainer: theme.colors.errorContainer,
+            },
+          }}
+        />
+        {nameError ? (
+          <Text style={[styles.errorText, { color: theme.colors.error }]}>{nameError}</Text>
+        ) : null}
+
+        <Text style={[styles.sectionLabel, { color: theme.colors.onSurface }]}>Color</Text>
+        <View style={styles.palette}>
+          {COLOR_PALETTE.map((c) => {
+            const selected = c.toLowerCase() === (color || "").toLowerCase();
+            return (
+              <TouchableOpacity
+                key={c}
+                style={[
+                  styles.colorDot,
+                  { backgroundColor: c },
+                  selected && { borderColor: theme.colors.onSurface },
+                ]}
+                onPress={() => setColor(c)}
+                accessibilityLabel={`Pick color ${c}`}
+              />
+            );
+          })}
+        </View>
+
+        <Text style={[styles.sectionLabel, { color: theme.colors.onSurface }]}>Or enter hex code</Text>
+        <TextInput
+          mode="outlined"
+          value={color}
+          onChangeText={setColor}
+          error={!isValidHex}
+          style={{ marginBottom: 8 }}
+          autoCapitalize="none"
+          autoCorrect={false}
+          theme={{
+            colors: {
+              error: theme.colors.error,
+              errorContainer: theme.colors.errorContainer,
+            },
+          }}
+        />
+
+        <Button mode="contained" onPress={onSave} disabled={!canSave}>
+          {editingId ? "Save" : "Add"}
+        </Button>
+      </Modal>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 24,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    marginTop: TOP_OFFSET,
+  },
+  title: { fontSize: 18, fontWeight: "700" },
+  subtitle: { marginBottom: 16 },
+  addBtn: { marginVertical: 12 },
+  emptyBox: { paddingVertical: 24, alignItems: "center" },
+  emptyText: { fontStyle: "italic" },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  left: { flexDirection: "row", alignItems: "center" },
+  right: { flexDirection: "row", alignItems: "center" },
+  swatch: {
+    width: 32,
+    height: 32,
+    borderRadius: 6,
+    borderWidth: 1,
+    marginRight: 12,
+  },
+  tagTextBox: { justifyContent: "center" },
+  tagName: { fontWeight: "600" },
+  tagColorCode: { fontSize: 12 },
+  dialog: {
+    marginHorizontal: 24,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    marginTop: TOP_OFFSET,
+  },
+  dialogTitle: { fontSize: 16, fontWeight: "700", marginBottom: 12 },
+  errorText: { marginBottom: 8 },
+  sectionLabel: { marginTop: 8, marginBottom: 4, fontWeight: "500" },
+  palette: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    marginBottom: 8,
+  },
+  colorDot: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    margin: 4,
+    borderWidth: 2,
+    borderColor: "transparent",
+  },
+});

--- a/src/components/CocktailTagsModal.js
+++ b/src/components/CocktailTagsModal.js
@@ -278,7 +278,7 @@ const styles = StyleSheet.create({
   },
   title: { fontSize: 18, fontWeight: "700" },
   subtitle: { marginBottom: 16 },
-  addBtn: { marginVertical: 12 },
+  addBtn: { marginVertical: 12, width: "100%" },
   emptyBox: { paddingVertical: 24, alignItems: "center" },
   emptyText: { fontStyle: "italic" },
   row: {

--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -14,6 +14,7 @@ import { MaterialIcons } from "@expo/vector-icons";
 import IngredientIcon from "../../assets/lemon.svg";
 
 import IngredientTagsModal from "./IngredientTagsModal";
+import CocktailTagsModal from "./CocktailTagsModal";
 import FavoritesRatingModal from "./FavoritesRatingModal";
 
 import {
@@ -37,6 +38,7 @@ export default function GeneralMenu({ visible, onClose }) {
   const [useMetric, setUseMetric] = useState(true);
   const [keepAwake, setKeepAwake] = useState(false);
   const [tagsVisible, setTagsVisible] = useState(false);
+  const [cocktailTagsVisible, setCocktailTagsVisible] = useState(false);
   const [ratingVisible, setRatingVisible] = useState(false);
   const [favRating, setFavRating] = useState(0);
 
@@ -59,6 +61,11 @@ export default function GeneralMenu({ visible, onClose }) {
   const openTagsModal = () => {
     onClose?.();
     setTagsVisible(true);
+  };
+
+  const openCocktailTagsModal = () => {
+    onClose?.();
+    setCocktailTagsVisible(true);
   };
 
   const openRatingModal = () => {
@@ -123,6 +130,7 @@ export default function GeneralMenu({ visible, onClose }) {
   };
 
   const closeTagsModal = () => setTagsVisible(false);
+  const closeCocktailTagsModal = () => setCocktailTagsVisible(false);
 
   return (
     <>
@@ -222,7 +230,7 @@ export default function GeneralMenu({ visible, onClose }) {
               />
             </TouchableOpacity>
 
-            <TouchableOpacity style={styles.linkRow} onPress={() => {}}>
+            <TouchableOpacity style={styles.linkRow} onPress={openCocktailTagsModal}>
               <MaterialIcons
                 name="local-bar"
                 size={22}
@@ -244,6 +252,10 @@ export default function GeneralMenu({ visible, onClose }) {
         </Pressable>
       </Modal>
       <IngredientTagsModal visible={tagsVisible} onClose={closeTagsModal} />
+      <CocktailTagsModal
+        visible={cocktailTagsVisible}
+        onClose={closeCocktailTagsModal}
+      />
       <FavoritesRatingModal
         visible={ratingVisible}
         rating={favRating}

--- a/src/components/IngredientTagsModal.js
+++ b/src/components/IngredientTagsModal.js
@@ -8,7 +8,6 @@ import {
   Portal,
   Modal,
   Divider,
-  Chip,
   useTheme,
 } from "react-native-paper";
 import { getUserTags, saveUserTags } from "../storage/ingredientTagsStorage";
@@ -268,17 +267,6 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
           <Text style={[styles.errorText, { color: theme.colors.error }]}>Enter a valid hex color</Text>
         ) : null}
 
-        <View style={styles.previewBox}>
-          <Text style={{ marginBottom: 8, color: theme.colors.onSurface }}>Preview</Text>
-          <Chip
-            selected
-            style={{ backgroundColor: color || "#ccc" }}
-            textStyle={{ color: "#fff", fontWeight: "700" }}
-          >
-            {name || "Tag name"}
-          </Chip>
-        </View>
-
         <View style={styles.dialogActions}>
           <Button onPress={() => setDialogVisible(false)}>Cancel</Button>
           <Button onPress={onSave} disabled={!canSave}>Save</Button>
@@ -298,7 +286,7 @@ const styles = StyleSheet.create({
   },
   title: { fontSize: 20, fontWeight: "700", marginBottom: 4 },
   subtitle: { marginBottom: 12 },
-  addBtn: { alignSelf: "center", marginBottom: 8 },
+  addBtn: { marginVertical: 12, width: "100%" },
   row: {
     flexDirection: "row",
     alignItems: "center",
@@ -322,7 +310,6 @@ const styles = StyleSheet.create({
   sectionLabel: { fontWeight: "600", marginBottom: 6, marginTop: 4 },
   palette: { flexDirection: "row", flexWrap: "wrap", gap: 10, marginBottom: 8 },
   colorDot: { width: 28, height: 28, borderRadius: 14, borderWidth: 2, borderColor: "transparent" },
-  previewBox: { marginTop: 10, marginBottom: 4 },
   emptyBox: { paddingVertical: 24, alignItems: "center" },
   emptyText: {},
   dialog: {

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -50,8 +50,10 @@ import {
   deleteCocktail,
 } from "../../storage/cocktailsStorage";
 import { BUILTIN_COCKTAIL_TAGS } from "../../constants/cocktailTags";
+import { getAllCocktailTags } from "../../storage/cocktailTagsStorage";
 import { UNIT_ID, getUnitById, formatUnit } from "../../constants/measureUnits";
 import { GLASSWARE, getGlassById } from "../../constants/glassware";
+import CocktailTagsModal from "../../components/CocktailTagsModal";
 
 /* ---------- helpers ---------- */
 const withAlpha = (hex, alpha) => {
@@ -1059,6 +1061,30 @@ export default function EditCocktailScreen() {
   const [name, setName] = useState("");
   const [photoUri, setPhotoUri] = useState(null);
   const [tags, setTags] = useState([]);
+  const [availableTags, setAvailableTags] = useState(BUILTIN_COCKTAIL_TAGS);
+  const [tagsModalVisible, setTagsModalVisible] = useState(false);
+  const [tagsModalAutoAdd, setTagsModalAutoAdd] = useState(false);
+
+  const loadAvailableTags = useCallback(async () => {
+    const all = await getAllCocktailTags();
+    setAvailableTags(Array.isArray(all) ? all : BUILTIN_COCKTAIL_TAGS);
+  }, []);
+
+  const closeTagsModal = () => {
+    setTagsModalVisible(false);
+    setTagsModalAutoAdd(false);
+    loadAvailableTags();
+  };
+
+  const openAddTagModal = () => {
+    setTagsModalAutoAdd(true);
+    setTagsModalVisible(true);
+  };
+
+  useEffect(() => {
+    loadAvailableTags();
+  }, [loadAvailableTags]);
+
   const [description, setDescription] = useState("");
   const [instructions, setInstructions] = useState("");
   const [glassId, setGlassId] = useState("cocktail_glass");
@@ -1299,7 +1325,6 @@ export default function EditCocktailScreen() {
     return list.slice(0, 40);
   }, [allIngredients, debouncedSubQuery, modalExcludedIds]);
 
-  const availableTags = BUILTIN_COCKTAIL_TAGS;
 
   const pickImage = useCallback(async () => {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
@@ -1620,22 +1645,50 @@ export default function EditCocktailScreen() {
             ))}
           </View>
 
-          <Text style={[styles.label, { color: theme.colors.onBackground }]}>
+          <Text style={[styles.label, { color: theme.colors.onBackground }]}> 
             Add Tag
           </Text>
           <View style={styles.tagContainer}>
-            {BUILTIN_COCKTAIL_TAGS.filter(
-              (t) => !tags.some((x) => x.id === t.id)
-            ).map((t) => (
-              <TagPill
-                key={t.id}
-                id={t.id}
-                name={t.name}
-                color={t.color}
-                onToggle={toggleTagById}
-              />
-            ))}
+            {availableTags
+              .filter((t) => !tags.some((x) => x.id === t.id))
+              .map((t) => (
+                <TagPill
+                  key={t.id}
+                  id={t.id}
+                  name={t.name}
+                  color={t.color}
+                  onToggle={toggleTagById}
+                />
+              ))}
+            <Pressable
+              onPress={openAddTagModal}
+              style={[
+                styles.addTagButton,
+                {
+                  borderColor: theme.colors.primary,
+                  backgroundColor: theme.colors.background,
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.addTagButtonText,
+                  { color: theme.colors.primary },
+                ]}
+              >
+                +Add
+              </Text>
+            </Pressable>
           </View>
+
+          <Pressable
+            onPress={() => {
+              setTagsModalAutoAdd(false);
+              setTagsModalVisible(true);
+            }}
+          >
+            <Text style={[styles.manageTagsLink, { color: theme.colors.primary }]}>Manage tags</Text>
+          </Pressable>
 
           {/* Description */}
           <Text style={[styles.label, { color: theme.colors.onBackground }]}>
@@ -1745,6 +1798,12 @@ export default function EditCocktailScreen() {
           </Pressable>
         </ScrollView>
       </View>
+
+      <CocktailTagsModal
+        visible={tagsModalVisible}
+        onClose={closeTagsModal}
+        autoAdd={tagsModalAutoAdd}
+      />
 
       {/* Substitute Picker Modal */}
       <Portal>
@@ -1935,6 +1994,17 @@ const styles = StyleSheet.create({
     margin: 4,
   },
   tagText: { color: "white", fontWeight: "bold" },
+
+  addTagButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 16,
+    margin: 4,
+    borderWidth: 1,
+  },
+  addTagButtonText: { fontWeight: "500" },
+
+  manageTagsLink: { marginTop: 8, marginBottom: 4, fontWeight: "500" },
 
   // ingredient card
   ingCard: {


### PR DESCRIPTION
## Summary
- add CocktailTagsModal component to manage custom cocktail tags
- allow adding and editing cocktail tags in add/edit cocktail screens
- expose cocktail tag management in settings menu

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f1d4789988326a4ef22974d45eee3