### PR TITLE
Cache ingredient usage and share data across ingredient tabs

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,7 @@ import { NavigationContainer } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { TabMemoryProvider } from "./src/context/TabMemoryContext";
+import { IngredientUsageProvider } from "./src/context/IngredientUsageContext";
 import { MaterialIcons } from "@expo/vector-icons";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider as PaperProvider, useTheme } from "react-native-paper";
@@ -62,22 +63,24 @@ export default function App() {
     <PaperProvider theme={AppTheme}>
       <MenuProvider>
         <SafeAreaProvider>
-          <TabMemoryProvider>
-            <NavigationContainer>
-              <RootStack.Navigator>
-                <RootStack.Screen
-                  name="Tabs"
-                  component={Tabs}
-                  options={{ headerShown: false }}
-                />
-                <RootStack.Screen
-                  name="EditCustomTags"
-                  component={EditCustomTagsScreen}
-                  options={{ title: "Custom tags" }}
-                />
-              </RootStack.Navigator>
-            </NavigationContainer>
-          </TabMemoryProvider>
+          <IngredientUsageProvider>
+            <TabMemoryProvider>
+              <NavigationContainer>
+                <RootStack.Navigator>
+                  <RootStack.Screen
+                    name="Tabs"
+                    component={Tabs}
+                    options={{ headerShown: false }}
+                  />
+                  <RootStack.Screen
+                    name="EditCustomTags"
+                    component={EditCustomTagsScreen}
+                    options={{ title: "Custom tags" }}
+                  />
+                </RootStack.Navigator>
+              </NavigationContainer>
+            </TabMemoryProvider>
+          </IngredientUsageProvider>
         </SafeAreaProvider>
       </MenuProvider>
     </PaperProvider>

--- a/src/context/IngredientUsageContext.js
+++ b/src/context/IngredientUsageContext.js
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useState, useCallback } from "react";
+import { updateUsageMap as updateUsageMapUtil } from "../utils/ingredientUsage";
+
+const IngredientUsageContext = createContext({
+  usageMap: {},
+  setUsageMap: () => {},
+  updateUsageMap: () => {},
+  ingredients: [],
+  setIngredients: () => {},
+  cocktails: [],
+  setCocktails: () => {},
+  loading: true,
+  setLoading: () => {},
+});
+
+export function IngredientUsageProvider({ children }) {
+  const [usageMap, setUsageMap] = useState({});
+  const [ingredients, setIngredients] = useState([]);
+  const [cocktails, setCocktails] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const updateUsageMap = useCallback(
+    (ingredients, cocktails, options) => {
+      setUsageMap((prev) =>
+        updateUsageMapUtil(prev, ingredients, cocktails, options)
+      );
+    },
+    []
+  );
+
+  return (
+    <IngredientUsageContext.Provider
+      value={{
+        usageMap,
+        setUsageMap,
+        updateUsageMap,
+        ingredients,
+        setIngredients,
+        cocktails,
+        setCocktails,
+        loading,
+        setLoading,
+      }}
+    >
+      {children}
+    </IngredientUsageContext.Provider>
+  );
+}
+
+export function useIngredientUsage() {
+  return useContext(IngredientUsageContext);
+}
+
+export default IngredientUsageContext;

--- a/src/hooks/useIngredientsData.js
+++ b/src/hooks/useIngredientsData.js
@@ -1,0 +1,58 @@
+import { useCallback, useContext, useEffect } from "react";
+import { getAllIngredients } from "../storage/ingredientsStorage";
+import { getAllCocktails } from "../storage/cocktailsStorage";
+import { mapCocktailsByIngredient } from "../utils/ingredientUsage";
+import IngredientUsageContext from "../context/IngredientUsageContext";
+
+export default function useIngredientsData() {
+  const {
+    ingredients,
+    setIngredients,
+    cocktails,
+    setCocktails,
+    usageMap,
+    setUsageMap,
+    loading,
+    setLoading,
+  } = useContext(IngredientUsageContext);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const [ing, cocks] = await Promise.all([
+      getAllIngredients(),
+      getAllCocktails(),
+    ]);
+    const sorted = [...ing].sort((a, b) =>
+      a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
+    );
+    const map = mapCocktailsByIngredient(sorted, cocks);
+    const cocktailMap = new Map(cocks.map((c) => [c.id, c.name]));
+    const withUsage = sorted.map((item) => {
+      const ids = map[item.id] || [];
+      const usageCount = ids.length;
+      const singleCocktailName = usageCount === 1 ? cocktailMap.get(ids[0]) : null;
+      return {
+        ...item,
+        searchName: item.name.toLowerCase(),
+        usageCount,
+        singleCocktailName,
+      };
+    });
+    setIngredients(withUsage);
+    setCocktails(cocks);
+    setUsageMap(map);
+    setLoading(false);
+  }, [setIngredients, setCocktails, setUsageMap, setLoading]);
+
+  useEffect(() => {
+    if (loading) {
+      load();
+    }
+  }, [loading, load]);
+
+  const refresh = useCallback(async () => {
+    await load();
+  }, [load]);
+
+  return { ingredients, cocktails, usageMap, refresh, loading, setIngredients };
+}

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -54,6 +54,7 @@ import { addCocktail } from "../../storage/cocktailsStorage";
 import { BUILTIN_COCKTAIL_TAGS } from "../../constants/cocktailTags";
 import { UNIT_ID, getUnitById, formatUnit } from "../../constants/measureUnits";
 import { GLASSWARE, getGlassById } from "../../constants/glassware";
+import useIngredientsData from "../../hooks/useIngredientsData";
 
 /* ---------- helpers ---------- */
 const withAlpha = (hex, alpha) => {
@@ -1052,6 +1053,7 @@ export default function AddCocktailScreen() {
   const route = useRoute();
   const isFocused = useIsFocused();
   const { getTab } = useTabMemory();
+  const { refresh: refreshIngredientsData } = useIngredientsData();
   const initialIngredient = route.params?.initialIngredient;
   const fromIngredientFlow = initialIngredient != null;
   const lastCocktailsTab =
@@ -1380,6 +1382,7 @@ export default function AddCocktailScreen() {
     };
 
     await addCocktail(cocktail);
+    await refreshIngredientsData();
     navigation.navigate("CocktailDetails", { id: cocktail.id });
   }, [
     name,
@@ -1390,6 +1393,7 @@ export default function AddCocktailScreen() {
     glassId,
     ings,
     navigation,
+    refreshIngredientsData,
   ]);
 
   const selectedGlass = getGlassById(glassId) || { name: "Cocktail glass" };

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -52,6 +52,7 @@ import {
 import { BUILTIN_COCKTAIL_TAGS } from "../../constants/cocktailTags";
 import { UNIT_ID, getUnitById, formatUnit } from "../../constants/measureUnits";
 import { GLASSWARE, getGlassById } from "../../constants/glassware";
+import useIngredientsData from "../../hooks/useIngredientsData";
 
 /* ---------- helpers ---------- */
 const withAlpha = (hex, alpha) => {
@@ -1054,6 +1055,7 @@ export default function EditCocktailScreen() {
   const { getTab } = useTabMemory();
   const previousTab = (typeof getTab === "function" && getTab("cocktails")) || "All";
   const cocktailId = params?.id;
+  const { refresh: refreshIngredientsData } = useIngredientsData();
 
   const [loading, setLoading] = useState(true);
   const [name, setName] = useState("");
@@ -1122,6 +1124,7 @@ export default function EditCocktailScreen() {
       };
 
       await saveCocktail(cocktail);
+      await refreshIngredientsData();
       initialHashRef.current = serialize();
       setDirty(false);
       if (!stay) {
@@ -1153,11 +1156,12 @@ export default function EditCocktailScreen() {
         onPress: async () => {
           skipPromptRef.current = true;
           await deleteCocktail(cocktailId);
+          await refreshIngredientsData();
           navigation.navigate(previousTab);
         },
       },
     ]);
-  }, [navigation, cocktailId, previousTab]);
+  }, [navigation, cocktailId, previousTab, refreshIngredientsData]);
 
   useLayoutEffect(() => {
     navigation.setOptions({

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -42,6 +42,7 @@ import {
 } from "../../storage/ingredientsStorage";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import IngredientTagsModal from "../../components/IngredientTagsModal";
+import useIngredientsData from "../../hooks/useIngredientsData";
 
 /* ---------------- helpers ---------------- */
 const useDebounced = (value, delay = 300) => {
@@ -103,6 +104,7 @@ export default function AddIngredientScreen() {
   const route = useRoute();
   const isFocused = useIsFocused();
   const { getTab } = useTabMemory();
+  const { refresh: refreshIngredientsData } = useIngredientsData();
 
   // read incoming params
   const initialNameParam = route.params?.initialName || "";
@@ -323,6 +325,7 @@ export default function AddIngredientScreen() {
     };
 
     await addIngredient(newIng);
+    await refreshIngredientsData();
 
     if (fromCocktailFlow) {
       navigation.navigate("Cocktails", {

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
@@ -14,14 +9,10 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import {
-  getAllIngredients,
-  saveIngredient,
-} from "../../storage/ingredientsStorage";
+import { saveIngredient } from "../../storage/ingredientsStorage";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
-import { getAllCocktails } from "../../storage/cocktailsStorage";
-import { mapCocktailsByIngredient } from "../../utils/ingredientUsage";
+import useIngredientsData from "../../hooks/useIngredientsData";
 
 export default function AllIngredientsScreen() {
   const theme = useTheme();
@@ -29,8 +20,7 @@ export default function AllIngredientsScreen() {
   const isFocused = useIsFocused();
   const { setTab } = useTabMemory();
 
-  const [ingredients, setIngredients] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const { ingredients, loading, setIngredients } = useIngredientsData();
   const [search, setSearch] = useState("");
   const [searchDebounced, setSearchDebounced] = useState("");
   const [navigatingId, setNavigatingId] = useState(null);
@@ -53,43 +43,7 @@ export default function AllIngredientsScreen() {
     };
   }, []);
 
-  const loadData = useCallback(async () => {
-    const [base, cocktails] = await Promise.all([
-      getAllIngredients(),
-      getAllCocktails(),
-    ]);
-    const sorted = [...base].sort((a, b) =>
-      a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
-    );
-    const usageMap = mapCocktailsByIngredient(sorted, cocktails);
-    const cocktailMap = new Map(cocktails.map((c) => [c.id, c.name]));
-    return sorted.map((item) => {
-      const ids = usageMap[item.id] || [];
-      const usageCount = ids.length;
-      const singleCocktailName =
-        usageCount === 1 ? cocktailMap.get(ids[0]) : null;
-      return {
-        ...item,
-        searchName: item.name.toLowerCase(),
-        usageCount,
-        singleCocktailName,
-      };
-    });
-  }, []);
-
-  useEffect(() => {
-    let cancel = false;
-    if (!isFocused) return;
-    (async () => {
-      const data = await loadData();
-      if (cancel) return;
-      setIngredients(data);
-      setLoading(false);
-    })();
-    return () => {
-      cancel = true;
-    };
-  }, [isFocused, loadData]);
+  // data is loaded via useIngredientsData
 
   useEffect(() => {
     const h = setTimeout(() => setSearchDebounced(search), 300);

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -44,6 +44,7 @@ import {
 import { useTabMemory } from "../../context/TabMemoryContext";
 import { MaterialIcons } from "@expo/vector-icons";
 import IngredientTagsModal from "../../components/IngredientTagsModal";
+import useIngredientsData from "../../hooks/useIngredientsData";
 
 // ----------- helpers -----------
 const useDebounced = (value, delay = 300) => {
@@ -123,6 +124,7 @@ export default function EditIngredientScreen() {
   const route = useRoute();
   const isFocused = useIsFocused();
   const { getTab } = useTabMemory();
+  const { refresh: refreshIngredientsData } = useIngredientsData();
   const previousTab = getTab("ingredients");
   const currentId = route.params?.id;
 
@@ -224,6 +226,7 @@ export default function EditIngredientScreen() {
         onPress: async () => {
           skipPromptRef.current = true; // не питати про збереження
           await deleteIngredient(ingredient.id);
+          await refreshIngredientsData();
           if (previousTab) navigation.navigate(previousTab);
           else navigation.goBack();
         },
@@ -386,6 +389,7 @@ export default function EditIngredientScreen() {
         baseIngredientId: baseIngredientId ?? null,
       };
       await saveIngredient(updated);
+      await refreshIngredientsData();
 
       // оновити baseline і зняти dirty
       initialHashRef.current = serialize();

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -38,6 +38,7 @@ import {
   getIgnoreGarnish,
   addIgnoreGarnishListener,
 } from "../../storage/settingsStorage";
+import useIngredientsData from "../../hooks/useIngredientsData";
 
 const PHOTO_SIZE = 200;
 const THUMB = 40;
@@ -105,6 +106,7 @@ export default function IngredientDetailsScreen() {
   const navigation = useNavigation();
   const { id, fromCocktailId } = useRoute().params;
   const theme = useTheme();
+  const { setIngredients } = useIngredientsData();
 
   const [ingredient, setIngredient] = useState(null);
   const [brandedChildren, setBrandedChildren] = useState([]);
@@ -315,18 +317,26 @@ export default function IngredientDetailsScreen() {
       if (!prev) return prev;
       const next = { ...prev, inBar: !prev.inBar };
       saveIngredient(next);
+      setIngredients((list) =>
+        list.map((i) => (i.id === next.id ? { ...i, inBar: next.inBar } : i))
+      );
       return next;
     });
-  }, []);
+  }, [setIngredients]);
 
   const toggleInShoppingList = useCallback(() => {
     setIngredient((prev) => {
       if (!prev) return prev;
       const next = { ...prev, inShoppingList: !prev.inShoppingList };
       saveIngredient(next);
+      setIngredients((list) =>
+        list.map((i) =>
+          i.id === next.id ? { ...i, inShoppingList: next.inShoppingList } : i
+        )
+      );
       return next;
     });
-  }, []);
+  }, [setIngredients]);
 
   const unlinkFromBase = useCallback(() => {
     if (ingredient?.baseIngredientId == null) return;
@@ -335,12 +345,15 @@ export default function IngredientDetailsScreen() {
       {
         text: "Unlink",
         style: "destructive",
-        onPress: async () => {
-          const updated = { ...ingredient, baseIngredientId: null };
-          await saveIngredient(updated);
-          setIngredient(updated);
-          setBaseIngredient(null);
-        },
+          onPress: async () => {
+            const updated = { ...ingredient, baseIngredientId: null };
+            await saveIngredient(updated);
+            setIngredient(updated);
+            setIngredients((list) =>
+              list.map((i) => (i.id === updated.id ? updated : i))
+            );
+            setBaseIngredient(null);
+          },
       },
     ]);
   }, [ingredient]);
@@ -357,6 +370,9 @@ export default function IngredientDetailsScreen() {
           onPress: async () => {
             const updatedChild = { ...child, baseIngredientId: null };
             await saveIngredient(updatedChild);
+            setIngredients((list) =>
+              list.map((i) => (i.id === updatedChild.id ? updatedChild : i))
+            );
             setBrandedChildren((prev) => prev.filter((c) => c.id !== child.id));
           },
         },

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
@@ -14,14 +9,10 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import {
-  getAllIngredients,
-  saveIngredient,
-} from "../../storage/ingredientsStorage";
+import { saveIngredient } from "../../storage/ingredientsStorage";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
-import { getAllCocktails } from "../../storage/cocktailsStorage";
-import { mapCocktailsByIngredient } from "../../utils/ingredientUsage";
+import useIngredientsData from "../../hooks/useIngredientsData";
 
 export default function ShoppingIngredientsScreen() {
   const theme = useTheme();
@@ -29,8 +20,7 @@ export default function ShoppingIngredientsScreen() {
   const isFocused = useIsFocused();
   const { setTab } = useTabMemory();
 
-  const [ingredients, setIngredients] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const { ingredients, loading, setIngredients } = useIngredientsData();
   const [search, setSearch] = useState("");
   const [searchDebounced, setSearchDebounced] = useState("");
   const [navigatingId, setNavigatingId] = useState(null);
@@ -53,43 +43,7 @@ export default function ShoppingIngredientsScreen() {
     };
   }, []);
 
-  const loadData = useCallback(async () => {
-    const [base, cocktails] = await Promise.all([
-      getAllIngredients(),
-      getAllCocktails(),
-    ]);
-    const sorted = [...base].sort((a, b) =>
-      a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
-    );
-    const usageMap = mapCocktailsByIngredient(sorted, cocktails);
-    const cocktailMap = new Map(cocktails.map((c) => [c.id, c.name]));
-    return sorted.map((item) => {
-      const ids = usageMap[item.id] || [];
-      const usageCount = ids.length;
-      const singleCocktailName =
-        usageCount === 1 ? cocktailMap.get(ids[0]) : null;
-      return {
-        ...item,
-        searchName: item.name.toLowerCase(),
-        usageCount,
-        singleCocktailName,
-      };
-    });
-  }, []);
-
-  useEffect(() => {
-    let cancel = false;
-    if (!isFocused) return;
-    (async () => {
-      const data = await loadData();
-      if (cancel) return;
-      setIngredients(data);
-      setLoading(false);
-    })();
-    return () => {
-      cancel = true;
-    };
-  }, [isFocused, loadData]);
+  // data loading handled by hook
 
   useEffect(() => {
     const h = setTimeout(() => setSearchDebounced(search), 300);

--- a/src/utils/ingredientUsage.js
+++ b/src/utils/ingredientUsage.js
@@ -69,3 +69,28 @@ export function calculateIngredientUsage(ingredients, cocktails) {
   });
   return result;
 }
+
+export function updateUsageMap(prevMap, ingredients, cocktails, options = {}) {
+  const { changedIngredientIds = [], changedCocktailIds = [] } = options;
+  const fullMap = mapCocktailsByIngredient(ingredients, cocktails);
+  if (
+    changedIngredientIds.length === 0 &&
+    changedCocktailIds.length === 0
+  ) {
+    return fullMap;
+  }
+  const affected = new Set(changedIngredientIds);
+  if (changedCocktailIds.length > 0) {
+    for (const [ingId, ids] of Object.entries(fullMap)) {
+      if (ids.some((id) => changedCocktailIds.includes(id))) {
+        affected.add(Number(ingId));
+      }
+    }
+  }
+  const next = { ...prevMap };
+  affected.forEach((id) => {
+    if (fullMap[id]) next[id] = fullMap[id];
+    else delete next[id];
+  });
+  return next;
+}


### PR DESCRIPTION
## Summary
- add IngredientUsageContext to cache ingredients, cocktails and usage map
- introduce useIngredientsData hook and use it across ingredient list tabs
- refresh usage data after cocktail and ingredient edits so usage counts stay in sync

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f1ce34370832683240ff1e3dd4019