### PR TITLE
feat: unify confirmation dialogs

### DIFF
--- a/src/components/CocktailTagsModal.js
+++ b/src/components/CocktailTagsModal.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { View, StyleSheet, FlatList, TouchableOpacity, Alert } from "react-native";
+import { View, StyleSheet, FlatList, TouchableOpacity } from "react-native";
 import {
   Text,
   TextInput,
@@ -15,6 +15,7 @@ import {
   upsertCocktailTag,
   deleteCocktailTag,
 } from "../storage/cocktailTagsStorage";
+import ConfirmationDialog from "./ConfirmationDialog";
 
 const COLOR_PALETTE = [
   "#FF6B6B",
@@ -42,6 +43,7 @@ export default function CocktailTagsModal({ visible, onClose, autoAdd = false })
   const [editingId, setEditingId] = useState(null);
   const [name, setName] = useState("");
   const [color, setColor] = useState(COLOR_PALETTE[0]);
+  const [deleteTag, setDeleteTag] = useState(null);
 
   useEffect(() => {
     if (!visible) return;
@@ -78,21 +80,7 @@ export default function CocktailTagsModal({ visible, onClose, autoAdd = false })
   };
 
   const onDelete = (tag) => {
-    Alert.alert(
-      "Delete tag",
-      `Are you sure you want to delete “${tag.name}”?`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: async () => {
-            setTags((prev) => prev.filter((t) => t.id !== tag.id));
-            await deleteCocktailTag(tag.id);
-          },
-        },
-      ]
-    );
+    setDeleteTag(tag);
   };
 
   const isValidHex = useMemo(() => {
@@ -264,6 +252,19 @@ export default function CocktailTagsModal({ visible, onClose, autoAdd = false })
           {editingId ? "Save" : "Add"}
         </Button>
       </Modal>
+
+      <ConfirmationDialog
+        visible={!!deleteTag}
+        title="Delete tag"
+        message={`Are you sure you want to delete “${deleteTag?.name}”?`}
+        confirmLabel="Delete"
+        onCancel={() => setDeleteTag(null)}
+        onConfirm={async () => {
+          setTags((prev) => prev.filter((t) => t.id !== deleteTag.id));
+          await deleteCocktailTag(deleteTag.id);
+          setDeleteTag(null);
+        }}
+      />
     </Portal>
   );
 }

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -1,0 +1,71 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { Portal, Modal, Text, Button, useTheme } from "react-native-paper";
+
+export default function ConfirmationDialog({
+  visible,
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  confirmLabel = "OK",
+  cancelLabel = "Cancel",
+  actions,
+}) {
+  const theme = useTheme();
+  const btns =
+    actions || [
+      { label: cancelLabel, mode: "outlined", onPress: onCancel },
+      { label: confirmLabel, mode: "contained", onPress: onConfirm },
+    ];
+
+  return (
+    <Portal>
+      <Modal
+        visible={visible}
+        onDismiss={onCancel}
+        style={{ justifyContent: "flex-start" }}
+        contentContainerStyle={[
+          styles.container,
+          { backgroundColor: theme.colors.surface, borderColor: theme.colors.outline },
+        ]}
+      >
+        {title ? (
+          <Text style={[styles.title, { color: theme.colors.onSurface }]}>{title}</Text>
+        ) : null}
+        {message ? (
+          <Text style={[styles.message, { color: theme.colors.onSurfaceVariant }]}>
+            {message}
+          </Text>
+        ) : null}
+        <View style={styles.buttons}>
+          {btns.map((b, i) => (
+            <Button
+              key={i}
+              mode={b.mode || "contained"}
+              onPress={b.onPress}
+              style={styles.button}
+            >
+              {b.label}
+            </Button>
+          ))}
+        </View>
+      </Modal>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 24,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    marginTop: 0,
+  },
+  title: { fontSize: 16, fontWeight: "700", marginBottom: 8 },
+  message: { marginBottom: 16 },
+  buttons: { flexDirection: "row", justifyContent: "flex-end" },
+  button: { marginLeft: 8 },
+});
+

--- a/src/components/IngredientTagsModal.js
+++ b/src/components/IngredientTagsModal.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { View, StyleSheet, FlatList, TouchableOpacity, Alert } from "react-native";
+import { View, StyleSheet, FlatList, TouchableOpacity } from "react-native";
 import {
   Text,
   TextInput,
@@ -11,6 +11,7 @@ import {
   useTheme,
 } from "react-native-paper";
 import { getUserTags, saveUserTags } from "../storage/ingredientTagsStorage";
+import ConfirmationDialog from "./ConfirmationDialog";
 
 const COLOR_PALETTE = [
   "#FF6B6B",
@@ -38,6 +39,7 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
   const [editingId, setEditingId] = useState(null);
   const [name, setName] = useState("");
   const [color, setColor] = useState(COLOR_PALETTE[0]);
+  const [deleteTag, setDeleteTag] = useState(null);
 
   useEffect(() => {
     if (!visible) return;
@@ -75,22 +77,7 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
   };
 
   const onDelete = (tag) => {
-    Alert.alert(
-      "Delete tag",
-      `Are you sure you want to delete “${tag.name}”?`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: async () => {
-            const next = tags.filter((t) => t.id !== tag.id);
-            setTags(next);
-            await saveUserTags(next);
-          },
-        },
-      ]
-    );
+    setDeleteTag(tag);
   };
 
   const isValidHex = useMemo(() => {
@@ -272,6 +259,20 @@ export default function IngredientTagsModal({ visible, onClose, autoAdd = false 
           <Button onPress={onSave} disabled={!canSave}>Save</Button>
         </View>
       </Modal>
+
+      <ConfirmationDialog
+        visible={!!deleteTag}
+        title="Delete tag"
+        message={`Are you sure you want to delete “${deleteTag?.name}”?`}
+        confirmLabel="Delete"
+        onCancel={() => setDeleteTag(null)}
+        onConfirm={async () => {
+          const next = tags.filter((t) => t.id !== deleteTag.id);
+          setTags(next);
+          await saveUserTags(next);
+          setDeleteTag(null);
+        }}
+      />
     </Portal>
   );
 }

--- a/src/screens/IngredientsTags/EditCustomTagsScreen.js
+++ b/src/screens/IngredientsTags/EditCustomTagsScreen.js
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   FlatList,
   TouchableOpacity,
-  Alert,
 } from "react-native";
 import {
   Provider as PaperProvider,
@@ -18,10 +17,10 @@ import {
   Divider,
   Chip,
   MD3LightTheme as BaseTheme,
-  useTheme,
 } from "react-native-paper";
 
 import { getUserTags, saveUserTags } from "../../storage/ingredientTagsStorage";
+import ConfirmationDialog from "../../components/ConfirmationDialog";
 
 // ====== ТЕМА (MD3) — твої кольори ======
 const theme = {
@@ -86,6 +85,7 @@ export default function EditCustomTagsScreen() {
   const [editingId, setEditingId] = useState(null);
   const [name, setName] = useState("");
   const [color, setColor] = useState(COLOR_PALETTE[0]);
+  const [deleteTag, setDeleteTag] = useState(null);
 
   useEffect(() => {
     const load = async () => {
@@ -115,22 +115,7 @@ export default function EditCustomTagsScreen() {
   };
 
   const onDelete = (tag) => {
-    Alert.alert(
-      "Delete tag",
-      `Are you sure you want to delete “${tag.name}”?`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: async () => {
-            const next = tags.filter((t) => t.id !== tag.id);
-            setTags(next);
-            await saveUserTags(next);
-          },
-        },
-      ]
-    );
+    setDeleteTag(tag);
   };
 
   // simple HEX check #RRGGBB / #RRGGBBAA
@@ -325,6 +310,19 @@ export default function EditCustomTagsScreen() {
           </Dialog.Actions>
         </Dialog>
       </Portal>
+      <ConfirmationDialog
+        visible={!!deleteTag}
+        title="Delete tag"
+        message={`Are you sure you want to delete “${deleteTag?.name}”?`}
+        confirmLabel="Delete"
+        onCancel={() => setDeleteTag(null)}
+        onConfirm={async () => {
+          const next = tags.filter((t) => t.id !== deleteTag.id);
+          setTags(next);
+          await saveUserTags(next);
+          setDeleteTag(null);
+        }}
+      />
     </PaperProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable ConfirmationDialog component
- replace native alerts with styled confirmation modals across tags and ingredient/cocktail screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f337556a88326ac96379916a92cf8