### PR TITLE
Move cocktail and ingredient tabs to top with floating action button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/bottom-tabs": "^7.4.5",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.24",
+        "@react-navigation/material-top-tabs": "^7.1.2",
         "@shopify/flash-list": "1.7.6",
         "expo": "~53.0.20",
         "expo-image-picker": "^16.1.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-navigation/bottom-tabs": "^7.4.5",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.24",
+    "@react-navigation/material-top-tabs": "^7.1.2",
     "@shopify/flash-list": "1.7.6",
     "expo": "~53.0.20",
     "expo-image-picker": "^16.1.4",

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1072,14 +1072,11 @@ export default function AddCocktailScreen() {
           onPress={() => {
             if (fromIngredientFlow) {
               navigation.navigate("Ingredients", {
-                screen: "Create",
-                params: {
-                  screen: "IngredientDetails",
-                  params: { id: initialIngredient?.id },
-                },
+                screen: "IngredientDetails",
+                params: { id: initialIngredient?.id },
               });
             } else {
-              navigation.navigate("Cocktails", { screen: lastCocktailsTab });
+              navigation.navigate("CocktailsMain", { screen: lastCocktailsTab });
             }
           }}
           labelVisible={false}
@@ -1096,28 +1093,22 @@ export default function AddCocktailScreen() {
       e.preventDefault();
       if (fromIngredientFlow) {
         navigation.navigate("Ingredients", {
-          screen: "Create",
-          params: {
-            screen: "IngredientDetails",
-            params: { id: initialIngredient?.id },
-          },
+          screen: "IngredientDetails",
+          params: { id: initialIngredient?.id },
         });
       } else {
-        navigation.navigate("Cocktails", { screen: lastCocktailsTab });
+        navigation.navigate("CocktailsMain", { screen: lastCocktailsTab });
       }
     });
 
     const hwSub = BackHandler.addEventListener("hardwareBackPress", () => {
       if (fromIngredientFlow) {
         navigation.navigate("Ingredients", {
-          screen: "Create",
-          params: {
-            screen: "IngredientDetails",
-            params: { id: initialIngredient?.id },
-          },
+          screen: "IngredientDetails",
+          params: { id: initialIngredient?.id },
         });
       } else {
-        navigation.navigate("Cocktails", { screen: lastCocktailsTab });
+        navigation.navigate("CocktailsMain", { screen: lastCocktailsTab });
       }
       return true;
     });
@@ -1329,14 +1320,11 @@ export default function AddCocktailScreen() {
   const openAddIngredient = useCallback(
     (initialName, localId) => {
       navigation.navigate("Ingredients", {
-        screen: "Create",
+        screen: "AddIngredient",
         params: {
-          screen: "AddIngredient",
-          params: {
-            initialName,
-            targetLocalId: localId,
-            returnTo: "AddCocktail",
-          },
+          initialName,
+          targetLocalId: localId,
+          returnTo: "AddCocktail",
         },
       });
     },

--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -168,10 +168,7 @@ export default function AllCocktailsScreen() {
   const handlePress = useCallback(
     (id) => {
       setNavigatingId(id);
-      navigation.navigate("Create", {
-        screen: "CocktailDetails",
-        params: { id },
-      });
+      navigation.navigate("CocktailDetails", { id });
       setTimeout(() => setNavigatingId(null), 500);
     },
     [navigation]

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -222,7 +222,7 @@ export default function CocktailDetailsScreen() {
   useEffect(() => {
     const unsub = navigation.addListener("beforeRemove", (e) => {
       if (e.data.action.type === "NAVIGATE" || !previousTab) return;
-      navigation.navigate(previousTab);
+      navigation.navigate("CocktailsMain", { screen: previousTab });
     });
     return unsub;
   }, [navigation, previousTab]);
@@ -501,11 +501,8 @@ export default function CocktailDetailsScreen() {
                     ingredientId
                       ? () =>
                           navigation.navigate("Ingredients", {
-                            screen: "Create",
-                            params: {
-                              screen: "IngredientDetails",
-                              params: { id: ingredientId, fromCocktailId: id },
-                            },
+                            screen: "IngredientDetails",
+                            params: { id: ingredientId, fromCocktailId: id },
                           })
                       : undefined
                   }

--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -1,38 +1,62 @@
 import React from "react";
-import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { useFocusEffect } from "@react-navigation/native";
-import { MaterialIcons } from "@expo/vector-icons";
-import { useTheme } from "react-native-paper";
-import { Pressable } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { FAB, useTheme } from "react-native-paper";
+import { View } from "react-native";
 
 import AllCocktailsScreen from "./AllCocktailsScreen";
-import CocktailDetailsScreen from "./CocktailDetailsScreen";
-import EditCocktailScreen from "./EditCocktailScreen";
 import MyCocktailsScreen from "./MyCocktailsScreen";
 import FavoriteCocktailsScreen from "./FavoriteCocktailsScreen";
 import AddCocktailScreen from "./AddCocktailScreen";
+import CocktailDetailsScreen from "./CocktailDetailsScreen";
+import EditCocktailScreen from "./EditCocktailScreen";
 
-const Tab = createBottomTabNavigator();
+const Tab = createMaterialTopTabNavigator();
 const Stack = createNativeStackNavigator();
 
-function TabBarButton({ style, ...props }) {
+function CocktailTabs() {
+  const theme = useTheme();
+  const navigation = useNavigation();
   return (
-    <Pressable
-      {...props}
-      android_ripple={{ color: "rgba(0,0,0,0.05)" }}
-      style={({ pressed }) => [
-        typeof style === "function" ? style({ pressed }) : style,
-        pressed && { opacity: 0.7 },
-      ]}
-    />
+    <View style={{ flex: 1 }}>
+      <Tab.Navigator
+        screenOptions={{
+          tabBarActiveTintColor: theme.colors.primary,
+          tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
+          tabBarIndicatorStyle: { backgroundColor: theme.colors.primary },
+        }}
+      >
+        <Tab.Screen name="All" component={AllCocktailsScreen} />
+        <Tab.Screen name="My" component={MyCocktailsScreen} />
+        <Tab.Screen name="Favorite" component={FavoriteCocktailsScreen} />
+      </Tab.Navigator>
+      <FAB
+        icon="plus"
+        style={{
+          position: "absolute",
+          right: 16,
+          bottom: 16,
+          backgroundColor: theme.colors.primaryContainer,
+        }}
+        color={theme.colors.onPrimaryContainer}
+        onPress={() => navigation.navigate("AddCocktail")}
+      />
+    </View>
   );
 }
 
-// Stack for Create tab
-function CreateCocktailStack() {
+export default function CocktailsTabsScreen() {
   return (
-    <Stack.Navigator initialRouteName="AddCocktail">
+    <Stack.Navigator>
+      <Stack.Screen
+        name="CocktailsMain"
+        component={CocktailTabs}
+        options={{
+          title: "Cocktails",
+          headerShown: true,
+        }}
+      />
       <Stack.Screen
         name="AddCocktail"
         component={AddCocktailScreen}
@@ -49,55 +73,5 @@ function CreateCocktailStack() {
         options={{ title: "Edit Cocktail" }}
       />
     </Stack.Navigator>
-  );
-}
-
-export default function CocktailsTabsScreen() {
-  const theme = useTheme();
-  // ключ, який примусово перемонтовує стек "Create"
-  const [createKey, setCreateKey] = React.useState(0);
-
-  // Коли ВСЯ вкладка "Cocktails" втрачає фокус (перейшли на Shaker/Ingredients),
-  // збільшуємо ключ — при поверненні "Create" буде чистим.
-  useFocusEffect(
-    React.useCallback(() => {
-      return () => setCreateKey((k) => k + 1);
-    }, [])
-  );
-  return (
-    <Tab.Navigator
-      screenOptions={({ route }) => ({
-        headerShown: false,
-        tabBarButton: (props) => <TabBarButton {...props} />,
-        tabBarIcon: ({ color, size }) => {
-          let iconName;
-          if (route.name === "All") iconName = "list";
-          else if (route.name === "My") iconName = "check-circle";
-          else if (route.name === "Favorite") iconName = "star";
-          else if (route.name === "Create") iconName = "add-circle-outline";
-          return <MaterialIcons name={iconName} size={size} color={color} />;
-        },
-        tabBarActiveTintColor: theme.colors.primary,
-        tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
-      })}
-    >
-      <Tab.Screen name="All" component={AllCocktailsScreen} />
-      <Tab.Screen name="My" component={MyCocktailsScreen} />
-      <Tab.Screen name="Favorite" component={FavoriteCocktailsScreen} />
-      <Tab.Screen
-        name="Create"
-        // Через render-prop ми можемо підставити key для примусового ремоунта
-        children={() => <CreateCocktailStack key={createKey} />}
-        listeners={({ navigation }) => ({
-          // При перемиканні з Create на інші саб-таби (All/My/Favorite)
-          blur: () => setCreateKey((k) => k + 1),
-          // І залишаємо авто-перехід на корінь створення по тапу на таб
-          tabPress: (e) => {
-            e.preventDefault();
-            navigation.navigate("Create", { screen: "AddCocktail" });
-          },
-        })}
-      />
-    </Tab.Navigator>
   );
 }

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1395,14 +1395,11 @@ export default function EditCocktailScreen() {
   const openAddIngredient = useCallback(
     (initialName, localId) => {
       navigation.navigate("Ingredients", {
-        screen: "Create",
+        screen: "AddIngredient",
         params: {
-          screen: "AddIngredient",
-          params: {
-            initialName,
-            targetLocalId: localId,
-            returnTo: "AddCocktail",
-          },
+          initialName,
+          targetLocalId: localId,
+          returnTo: "EditCocktail",
         },
       });
     },
@@ -1912,7 +1909,7 @@ export default function EditCocktailScreen() {
           skipPromptRef.current = true;
           await deleteCocktail(cocktailId);
           await refreshIngredientsData();
-          navigation.navigate(previousTab);
+          navigation.navigate("CocktailsMain", { screen: previousTab });
           setConfirmDelete(false);
         }}
       />

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -192,10 +192,7 @@ export default function FavoriteCocktailsScreen() {
   const handlePress = useCallback(
     (id) => {
       setNavigatingId(id);
-      navigation.navigate("Create", {
-        screen: "CocktailDetails",
-        params: { id },
-      });
+      navigation.navigate("CocktailDetails", { id });
       setTimeout(() => setNavigatingId(null), 500);
     },
     [navigation]

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -203,10 +203,7 @@ export default function MyCocktailsScreen() {
   const handlePress = useCallback(
     (id) => {
       setNavigatingId(id);
-      navigation.navigate("Create", {
-        screen: "CocktailDetails",
-        params: { id },
-      });
+      navigation.navigate("CocktailDetails", { id });
       setTimeout(() => setNavigatingId(null), 500);
     },
     [navigation]
@@ -215,8 +212,8 @@ export default function MyCocktailsScreen() {
   const handleIngredientPress = useCallback(
     (id) => {
       navigation.navigate("Ingredients", {
-        screen: "Create",
-        params: { screen: "IngredientDetails", params: { id } },
+        screen: "IngredientDetails",
+        params: { id },
       });
     },
     [navigation]

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -188,7 +188,7 @@ export default function AddIngredientScreen() {
           <HeaderBackButton
             {...props}
             onPress={() =>
-              navigation.navigate("Ingredients", { screen: lastIngredientsTab })
+              navigation.navigate("IngredientsMain", { screen: lastIngredientsTab })
             }
             labelVisible={false}
           />
@@ -205,7 +205,7 @@ export default function AddIngredientScreen() {
       if (fromCocktailFlow) {
         navigation.navigate("Cocktails", { screen: returnTo });
       } else {
-        navigation.navigate("Ingredients", { screen: lastIngredientsTab });
+        navigation.navigate("IngredientsMain", { screen: lastIngredientsTab });
       }
     });
 
@@ -213,7 +213,7 @@ export default function AddIngredientScreen() {
       if (fromCocktailFlow) {
         navigation.navigate("Cocktails", { screen: returnTo });
       } else {
-        navigation.navigate("Ingredients", { screen: lastIngredientsTab });
+        navigation.navigate("IngredientsMain", { screen: lastIngredientsTab });
       }
       return true;
     });

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -79,10 +79,7 @@ export default function AllIngredientsScreen() {
   const onItemPress = useCallback(
     (id) => {
       setNavigatingId(id);
-      navigation.navigate("Create", {
-        screen: "IngredientDetails",
-        params: { id },
-      });
+      navigation.navigate("IngredientDetails", { id });
       setTimeout(() => setNavigatingId(null), 600);
     },
     [navigation]

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -756,7 +756,8 @@ export default function EditIngredientScreen() {
           skipPromptRef.current = true;
           await deleteIngredient(ingredient.id);
           await refreshIngredientsData();
-          if (previousTab) navigation.navigate(previousTab);
+          if (previousTab)
+            navigation.navigate("IngredientsMain", { screen: previousTab });
           else navigation.goBack();
           setConfirmDelete(false);
         }}

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -127,10 +127,11 @@ export default function IngredientDetailsScreen() {
   const handleGoBack = useCallback(() => {
     if (fromCocktailId)
       navigation.navigate("Cocktails", {
-        screen: "Create",
-        params: { screen: "CocktailDetails", params: { id: fromCocktailId } },
+        screen: "CocktailDetails",
+        params: { id: fromCocktailId },
       });
-    else if (previousTab) navigation.navigate(previousTab);
+    else if (previousTab)
+      navigation.navigate("IngredientsMain", { screen: previousTab });
     else navigation.goBack();
   }, [navigation, previousTab, fromCocktailId]);
 
@@ -360,8 +361,8 @@ export default function IngredientDetailsScreen() {
   const goToCocktail = useCallback(
     (goId) => {
       navigation.navigate("Cocktails", {
-        screen: "Create",
-        params: { screen: "CocktailDetails", params: { id: goId } },
+        screen: "CocktailDetails",
+        params: { id: goId },
       });
     },
     [navigation]
@@ -568,11 +569,8 @@ export default function IngredientDetailsScreen() {
         ]}
         onPress={() =>
           navigation.navigate("Cocktails", {
-            screen: "Create",
-            params: {
-              screen: "AddCocktail",
-              params: { initialIngredient: ingredient },
-            },
+            screen: "AddCocktail",
+            params: { initialIngredient: ingredient },
           })
         }
       >

--- a/src/screens/Ingredients/IngredientsTabsScreen.js
+++ b/src/screens/Ingredients/IngredientsTabsScreen.js
@@ -1,26 +1,59 @@
 import React from "react";
-import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { MaterialIcons } from "@expo/vector-icons";
-import { useTheme } from "react-native-paper";
+import { useNavigation } from "@react-navigation/native";
+import { FAB, useTheme } from "react-native-paper";
+import { View } from "react-native";
 
 import AllIngredientsScreen from "./AllIngredientsScreen";
-
 import MyIngredientsScreen from "./MyIngredientsScreen";
-
 import ShoppingIngredientsScreen from "./ShoppingIngredientsScreen";
-
+import AddIngredientScreen from "./AddIngredientScreen";
 import IngredientDetailsScreen from "./IngredientDetailsScreen";
 import EditIngredientScreen from "./EditIngredientScreen";
-import AddIngredientScreen from "./AddIngredientScreen";
 
-const Tab = createBottomTabNavigator();
+const Tab = createMaterialTopTabNavigator();
 const Stack = createNativeStackNavigator();
 
-// Стек для вкладки Create
-function CreateIngredientStack() {
+function IngredientTabs() {
+  const theme = useTheme();
+  const navigation = useNavigation();
   return (
-    <Stack.Navigator initialRouteName="AddIngredient">
+    <View style={{ flex: 1 }}>
+      <Tab.Navigator
+        screenOptions={{
+          tabBarActiveTintColor: theme.colors.primary,
+          tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
+          tabBarIndicatorStyle: { backgroundColor: theme.colors.primary },
+        }}
+      >
+        <Tab.Screen name="All" component={AllIngredientsScreen} />
+        <Tab.Screen name="My" component={MyIngredientsScreen} />
+        <Tab.Screen name="Shopping" component={ShoppingIngredientsScreen} />
+      </Tab.Navigator>
+      <FAB
+        icon="plus"
+        style={{
+          position: "absolute",
+          right: 16,
+          bottom: 16,
+          backgroundColor: theme.colors.primaryContainer,
+        }}
+        color={theme.colors.onPrimaryContainer}
+        onPress={() => navigation.navigate("AddIngredient")}
+      />
+    </View>
+  );
+}
+
+export default function IngredientsTabsScreen() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="IngredientsMain"
+        component={IngredientTabs}
+        options={{ title: "Ingredients", headerShown: true }}
+      />
       <Stack.Screen
         name="AddIngredient"
         component={AddIngredientScreen}
@@ -37,45 +70,5 @@ function CreateIngredientStack() {
         options={{ title: "Edit Ingredient" }}
       />
     </Stack.Navigator>
-  );
-}
-
-export default function IngredientsTabsScreen() {
-  const theme = useTheme();
-  return (
-    <Tab.Navigator
-      screenOptions={({ route }) => ({
-        headerShown: false,
-        tabBarIcon: ({ color, size }) => {
-          let iconName;
-          if (route.name === "All") iconName = "list";
-          else if (route.name === "My") iconName = "check-circle";
-          else if (route.name === "Shopping") iconName = "shopping-cart";
-          else if (route.name === "Create") iconName = "add-circle-outline";
-          return <MaterialIcons name={iconName} size={size} color={color} />;
-        },
-        tabBarActiveTintColor: theme.colors.primary,
-        tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
-      })}
-    >
-      <Tab.Screen name="All" component={AllIngredientsScreen} />
-      <Tab.Screen name="My" component={MyIngredientsScreen} />
-      <Tab.Screen name="Shopping" component={ShoppingIngredientsScreen} />
-      <Tab.Screen
-        name="Create"
-        component={CreateIngredientStack}
-        listeners={({ navigation }) => ({
-          tabPress: (e) => {
-            // Запобігає стандартній поведінці
-            e.preventDefault();
-
-            // Скидає стек до початкового екрану AddIngredient
-            navigation.navigate("Create", {
-              screen: "AddIngredient",
-            });
-          },
-        })}
-      />
-    </Tab.Navigator>
   );
 }

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -158,10 +158,7 @@ export default function MyIngredientsScreen() {
   const onItemPress = useCallback(
     (id) => {
       setNavigatingId(id);
-      navigation.navigate("Create", {
-        screen: "IngredientDetails",
-        params: { id },
-      });
+      navigation.navigate("IngredientDetails", { id });
       setTimeout(() => setNavigatingId(null), 600);
     },
     [navigation]

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -79,10 +79,7 @@ export default function ShoppingIngredientsScreen() {
   const onItemPress = useCallback(
     (id) => {
       setNavigatingId(id);
-      navigation.navigate("Create", {
-        screen: "IngredientDetails",
-        params: { id },
-      });
+      navigation.navigate("IngredientDetails", { id });
       setTimeout(() => setNavigatingId(null), 600);
     },
     [navigation]

--- a/src/theme.js
+++ b/src/theme.js
@@ -10,6 +10,8 @@ export const AppTheme = {
     secondary: "#74C0FC",
     tertiary: "#A5D8FF",
 
+    primaryContainer: "#D0EBFF",
+    onPrimaryContainer: "#00243D",
     secondaryContainer: "#E9F7DF",
 
     background: "#FFFFFF",


### PR DESCRIPTION
## Summary
- Replace bottom tabs for cocktails and ingredients with top tabs beneath headers
- Add floating + action button using new primaryContainer color and hide it on edit flows
- Wire back navigation to restore last active tab

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@react-navigation%2fmaterial-top-tabs)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f5616d89883269dbaa954b909c680