### PR TITLE
Add data import/export buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "expo": "~53.0.20",
     "expo-image-picker": "^16.1.4",
     "expo-status-bar": "~2.2.3",
+    "expo-document-picker": "^11.0.0",
+    "expo-sharing": "^11.0.0",
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-draggable-flatlist": "^4.0.3",

--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -8,6 +8,7 @@ import {
   View,
   Text,
   TouchableOpacity,
+  Alert,
 } from "react-native";
 import { Checkbox } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
@@ -16,6 +17,8 @@ import IngredientIcon from "../../assets/lemon.svg";
 import IngredientTagsModal from "./IngredientTagsModal";
 import CocktailTagsModal from "./CocktailTagsModal";
 import FavoritesRatingModal from "./FavoritesRatingModal";
+import useIngredientsData from "../hooks/useIngredientsData";
+import { exportAllData, importAllData } from "../storage/backupStorage";
 
 import {
   getUseMetric,
@@ -46,6 +49,8 @@ export default function GeneralMenu({ visible, onClose }) {
   const [ratingVisible, setRatingVisible] = useState(false);
   const [favRating, setFavRating] = useState(0);
 
+  const { refresh } = useIngredientsData();
+
   useEffect(() => {
     if (visible) {
       Animated.timing(slideAnim, {
@@ -75,6 +80,29 @@ export default function GeneralMenu({ visible, onClose }) {
   const openRatingModal = () => {
     onClose?.();
     setTimeout(() => setRatingVisible(true), 0);
+  };
+
+  const handleExport = async () => {
+    onClose?.();
+    try {
+      await exportAllData();
+      Alert.alert("Export", "Data exported successfully");
+    } catch (e) {
+      Alert.alert("Export", "Failed to export data");
+    }
+  };
+
+  const handleImport = async () => {
+    onClose?.();
+    try {
+      const ok = await importAllData();
+      if (ok) {
+        await refresh?.();
+        Alert.alert("Import", "Data imported successfully");
+      }
+    } catch (e) {
+      Alert.alert("Import", "Failed to import data");
+    }
   };
 
   useEffect(() => {
@@ -275,6 +303,44 @@ export default function GeneralMenu({ visible, onClose }) {
               <View style={styles.itemText}>
                 <Text style={styles.itemTitle}>Cocktail tags</Text>
                 <Text style={styles.itemSub}>Create, edit or remove cocktail tags</Text>
+              </View>
+              <MaterialIcons
+                name="chevron-right"
+                size={24}
+                color="#999"
+                style={styles.chevron}
+              />
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.linkRow} onPress={handleExport}>
+              <MaterialIcons
+                name="file-download"
+                size={22}
+                color="#4DABF7"
+                style={styles.linkIcon}
+              />
+              <View style={styles.itemText}>
+                <Text style={styles.itemTitle}>Export data</Text>
+                <Text style={styles.itemSub}>Export all ingredients and cocktails</Text>
+              </View>
+              <MaterialIcons
+                name="chevron-right"
+                size={24}
+                color="#999"
+                style={styles.chevron}
+              />
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.linkRow} onPress={handleImport}>
+              <MaterialIcons
+                name="file-upload"
+                size={22}
+                color="#4DABF7"
+                style={styles.linkIcon}
+              />
+              <View style={styles.itemText}>
+                <Text style={styles.itemTitle}>Import data</Text>
+                <Text style={styles.itemSub}>Import ingredients and cocktails</Text>
               </View>
               <MaterialIcons
                 name="chevron-right"

--- a/src/storage/backupStorage.js
+++ b/src/storage/backupStorage.js
@@ -1,0 +1,65 @@
+import * as FileSystem from 'expo-file-system';
+import * as DocumentPicker from 'expo-document-picker';
+import * as Sharing from 'expo-sharing';
+
+import { getAllIngredients, saveAllIngredients } from './ingredientsStorage';
+import { getAllCocktails, replaceAllCocktails } from './cocktailsStorage';
+
+/**
+ * Export all ingredients and cocktails to a JSON file and open share dialog.
+ * Returns the URI of the created file.
+ */
+export async function exportAllData() {
+  const [ingredients, cocktails] = await Promise.all([
+    getAllIngredients(),
+    getAllCocktails(),
+  ]);
+  const data = { ingredients, cocktails };
+  const json = JSON.stringify(data, null, 2);
+  const fileName = `yourbar-backup-${Date.now()}.json`;
+  const fileUri = FileSystem.cacheDirectory + fileName;
+  await FileSystem.writeAsStringAsync(fileUri, json, {
+    encoding: FileSystem.EncodingType.UTF8,
+  });
+  try {
+    if (await Sharing.isAvailableAsync()) {
+      await Sharing.shareAsync(fileUri, {
+        mimeType: 'application/json',
+        dialogTitle: 'Share yourbar backup',
+      });
+    }
+  } catch (e) {
+    console.warn('Sharing failed', e);
+  }
+  return fileUri;
+}
+
+/**
+ * Pick a JSON file and import ingredients and cocktails from it.
+ * Returns true on success, false otherwise.
+ */
+export async function importAllData() {
+  try {
+    const res = await DocumentPicker.getDocumentAsync({
+      type: 'application/json',
+      copyToCacheDirectory: true,
+    });
+    if (res.canceled || res.type === 'cancel') return false;
+    const uri = res.assets ? res.assets[0].uri : res.uri;
+    const contents = await FileSystem.readAsStringAsync(uri, {
+      encoding: FileSystem.EncodingType.UTF8,
+    });
+    const data = JSON.parse(contents);
+    if (Array.isArray(data.ingredients)) {
+      await saveAllIngredients(data.ingredients);
+    }
+    if (Array.isArray(data.cocktails)) {
+      await replaceAllCocktails(data.cocktails);
+    }
+    return true;
+  } catch (e) {
+    console.error('Import failed', e);
+    return false;
+  }
+}
+


### PR DESCRIPTION
## Summary
- export all ingredients and cocktails to JSON preserving relationships
- import backup JSON and refresh app data
- hook up export/import options in general menu

## Testing
- `npm install expo-file-system expo-document-picker expo-sharing` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f915aae7c8326b13b4e02ecb0cba6