### PR TITLE
Fix returning to cocktail editor after adding new ingredient

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1334,11 +1334,11 @@ export default function AddCocktailScreen() {
         params: {
           initialName,
           targetLocalId: localId,
-          returnTo: "AddCocktail",
+          returnTo: route.name,
         },
       });
     },
-    [navigation]
+    [navigation, route.name]
   );
 
   // Catch created ingredient returned from AddIngredient

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1440,11 +1440,11 @@ export default function EditCocktailScreen() {
         params: {
           initialName,
           targetLocalId: localId,
-          returnTo: "AddCocktail",
+          returnTo: route.name,
         },
       });
     },
-    [navigation]
+    [navigation, route.name]
   );
 
   // Catch created ingredient returned from AddIngredient


### PR DESCRIPTION
## Summary
- Use current route name when launching AddIngredient so it returns to the invoking cocktail screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fbe6ed9c4832683f5906fbd30d684