### PR TITLE
Fix ingredient save navigation flow

### DIFF
--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -29,6 +29,7 @@ import {
   useNavigation,
   useRoute,
   useIsFocused,
+  CommonActions,
 } from "@react-navigation/native";
 import { useTheme, Menu, Divider, Text as PaperText } from "react-native-paper";
 import { HeaderBackButton } from "@react-navigation/elements";
@@ -326,25 +327,32 @@ export default function AddIngredientScreen() {
     await addIngredient(newIng);
     await refreshIngredientsData();
 
+    const detailParams = {
+      id: newIng.id,
+      initialIngredient: newIng,
+    };
+
     if (fromCocktailFlow) {
-      navigation.navigate("Cocktails", {
-        screen: returnTo,
-        params: {
-          createdIngredient: {
-            id: newIng.id,
-            name: newIng.name,
-            photoUri: newIng.photoUri || null,
-            baseIngredientId: newIng.baseIngredientId ?? null,
-            tags: newIng.tags || [],
-          },
-          targetLocalId,
-        },
-        merge: true,
-      });
-      return;
+      detailParams.returnTo = returnTo;
+      detailParams.createdIngredient = {
+        id: newIng.id,
+        name: newIng.name,
+        photoUri: newIng.photoUri || null,
+        baseIngredientId: newIng.baseIngredientId ?? null,
+        tags: newIng.tags || [],
+      };
+      detailParams.targetLocalId = targetLocalId;
     }
 
-    navigation.replace("IngredientsMain", { screen: lastIngredientsTab });
+    navigation.dispatch((state) => {
+      const routes = state.routes.slice(0, -1);
+      routes.push({ name: "IngredientDetails", params: detailParams });
+      return CommonActions.reset({
+        ...state,
+        routes,
+        index: routes.length - 1,
+      });
+    });
   }, [
     name,
     description,
@@ -355,7 +363,8 @@ export default function AddIngredientScreen() {
     fromCocktailFlow,
     returnTo,
     targetLocalId,
-    lastIngredientsTab,
+    refreshIngredientsData,
+    addIngredient,
   ]);
 
   const openMenu = useCallback(() => {

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -30,6 +30,7 @@ import {
   useNavigation,
   useRoute,
   useIsFocused,
+  CommonActions,
 } from "@react-navigation/native";
 import { useTheme, Menu, Divider, Text as PaperText } from "react-native-paper";
 
@@ -396,9 +397,32 @@ export default function EditIngredientScreen() {
 
       if (!stay) {
         skipPromptRef.current = true;
-        navigation.replace("IngredientDetails", {
+        const detailParams = {
           id: updated.id,
           initialIngredient: updated,
+        };
+        if (route.params?.returnTo) {
+          detailParams.returnTo = route.params.returnTo;
+          detailParams.createdIngredient = {
+            id: updated.id,
+            name: updated.name,
+            photoUri: updated.photoUri || null,
+            baseIngredientId: updated.baseIngredientId ?? null,
+            tags: updated.tags || [],
+          };
+          detailParams.targetLocalId = route.params.targetLocalId;
+        }
+        navigation.dispatch((state) => {
+          const routes = state.routes.filter((r) => r.name !== "IngredientDetails");
+          routes[routes.length - 1] = {
+            name: "IngredientDetails",
+            params: detailParams,
+          };
+          return CommonActions.reset({
+            ...state,
+            routes,
+            index: routes.length - 1,
+          });
         });
       } else {
         setIngredient(updated);
@@ -419,6 +443,8 @@ export default function EditIngredientScreen() {
       tags,
       baseIngredientId,
       navigation,
+      route.params?.returnTo,
+      route.params?.targetLocalId,
       serialize,
       setGlobalIngredients,
       refreshIngredientsData,

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -129,17 +129,44 @@ export default function IngredientDetailsScreen() {
   );
 
   const handleGoBack = useCallback(() => {
-    if (fromCocktailId)
+    const returnTo = route.params?.returnTo;
+    if (returnTo) {
+      navigation.navigate("Cocktails", {
+        screen: returnTo,
+        params: {
+          createdIngredient: route.params?.createdIngredient,
+          targetLocalId: route.params?.targetLocalId,
+        },
+        merge: true,
+      });
+    } else if (fromCocktailId) {
       navigation.navigate("Cocktails", {
         screen: "CocktailDetails",
         params: { id: fromCocktailId },
       });
-    else navigation.goBack();
-  }, [navigation, fromCocktailId]);
+    } else navigation.goBack();
+  }, [
+    navigation,
+    fromCocktailId,
+    route.params?.returnTo,
+    route.params?.createdIngredient,
+    route.params?.targetLocalId,
+  ]);
 
   const handleEdit = useCallback(() => {
-    navigation.navigate("EditIngredient", { id });
-  }, [navigation, id]);
+    navigation.navigate("EditIngredient", {
+      id,
+      returnTo: route.params?.returnTo,
+      createdIngredient: route.params?.createdIngredient,
+      targetLocalId: route.params?.targetLocalId,
+    });
+  }, [
+    navigation,
+    id,
+    route.params?.returnTo,
+    route.params?.createdIngredient,
+    route.params?.targetLocalId,
+  ]);
 
   // Always show custom back button
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary
- After saving an ingredient, redirect to refreshed ingredient details
- Remove duplicate ingredient detail screens on edit and preserve return navigation
- Route ingredient details back to the originating cocktail or ingredient screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a070cf64bc83269b59d64953b85c9a