### PR TITLE
Group ingredients by tags for cocktail count

### DIFF
--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -87,12 +87,35 @@ export default function ShakerScreen() {
 
   const cocktailsCount = useMemo(() => {
     if (selectedIds.length === 0) return 0;
-    const [first, ...rest] = selectedIds.map((id) => usageMap[id] || []);
-    return rest.reduce(
-      (acc, arr) => acc.filter((x) => arr.includes(x)),
-      [...first]
-    ).length;
-  }, [selectedIds, usageMap]);
+
+    // group selected ingredients by tag
+    const groups = new Map();
+    grouped.forEach((items, tagId) => {
+      const selected = items
+        .filter((ing) => selectedIds.includes(ing.id))
+        .map((ing) => ing.id);
+      if (selected.length > 0) groups.set(tagId, selected);
+    });
+
+    if (groups.size === 0) return 0;
+
+    let intersection;
+    groups.forEach((ids) => {
+      const union = new Set();
+      ids.forEach((id) => {
+        (usageMap[id] || []).forEach((cid) => union.add(cid));
+      });
+      if (!intersection) {
+        intersection = union;
+      } else {
+        intersection = new Set(
+          [...intersection].filter((cid) => union.has(cid))
+        );
+      }
+    });
+
+    return intersection ? intersection.size : 0;
+  }, [selectedIds, usageMap, grouped]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- update shaker screen cocktail counter to treat ingredients of same tag as OR and different tags as AND

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a07255d8608326a343a108e7b51b35