### PR TITLE
Move ingredient reorder arrows beside card number

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -404,6 +404,10 @@ const IngredientRow = memo(function IngredientRow({
       {/* Header: reorder controls + index + remove */}
       <View style={styles.ingHeader}>
         <View style={styles.headerLeft}>
+          <Text style={{ fontWeight: "700", color: theme.colors.onSurface }}>
+            {index + 1}.
+          </Text>
+
           {canRemove ? (
             <>
               {/* Move up */}
@@ -441,10 +445,6 @@ const IngredientRow = memo(function IngredientRow({
               </Pressable>
             </>
           ) : null}
-
-          <Text style={{ fontWeight: "700", color: theme.colors.onSurface }}>
-            {index + 1}.
-          </Text>
         </View>
 
         {canRemove ? (
@@ -2006,7 +2006,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
   },
-  iconBtn: { padding: 4, marginRight: 4 },
+  iconBtn: { padding: 4, marginLeft: 4 },
   removeBtn: { padding: 4, marginLeft: 4 },
 
   row2: {

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -407,6 +407,10 @@ const IngredientRow = memo(function IngredientRow({
       {/* Header: reorder controls + index + remove */}
       <View style={styles.ingHeader}>
         <View style={styles.headerLeft}>
+          <Text style={{ fontWeight: "700", color: theme.colors.onSurface }}>
+            {index + 1}.
+          </Text>
+
           {canRemove ? (
             <>
               {/* Move up */}
@@ -444,10 +448,6 @@ const IngredientRow = memo(function IngredientRow({
               </Pressable>
             </>
           ) : null}
-
-          <Text style={{ fontWeight: "700", color: theme.colors.onSurface }}>
-            {index + 1}.
-          </Text>
         </View>
 
         {canRemove ? (
@@ -2106,7 +2106,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
   },
-  iconBtn: { padding: 4, marginRight: 4 },
+  iconBtn: { padding: 4, marginLeft: 4 },
   removeBtn: { padding: 4, marginLeft: 4 },
 
   row2: {


### PR DESCRIPTION
## Summary
- Move ingredient reorder arrows next to the card index for clearer layout
- Adjust ingredient card header styles in add and edit cocktail screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a078cb516883268505b9aa2e5c2b3f