### PR TITLE
Refactor ingredient saving to avoid repeated storage fetches

### DIFF
--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -13,7 +13,11 @@ import TopTabBar from "../../components/TopTabBar";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
-import { getAllIngredients, saveIngredient } from "../../storage/ingredientsStorage";
+import {
+  getAllIngredients,
+  saveIngredient,
+  updateIngredientById,
+} from "../../storage/ingredientsStorage";
 import {
   getIgnoreGarnish,
   addIgnoreGarnishListener,
@@ -224,25 +228,25 @@ export default function MyCocktailsScreen() {
     [navigation]
   );
 
-  const toggleShoppingList = useCallback((id) => {
-    setIngredients((prev) => {
-      const idx = prev.findIndex((i) => String(i.id) === String(id));
-      if (idx === -1) return prev;
-      const next = [...prev];
-      const item = next[idx];
-      const updated = { ...item, inShoppingList: !item.inShoppingList };
-      next[idx] = updated;
-      saveIngredient(updated).catch(() => {});
-      setGlobalIngredients((list) =>
-        list.map((i) =>
-          String(i.id) === String(id)
-            ? { ...i, inShoppingList: updated.inShoppingList }
-            : i
-        )
-      );
-      return next;
-    });
-  }, [setGlobalIngredients]);
+  const toggleShoppingList = useCallback(
+    (id) => {
+      setIngredients((prev) => {
+        const item = prev.find((i) => String(i.id) === String(id));
+        if (!item) return prev;
+        const updated = { ...item, inShoppingList: !item.inShoppingList };
+        const next = updateIngredientById(prev, updated);
+        saveIngredient(next).catch(() => {});
+        setGlobalIngredients((list) =>
+          updateIngredientById(list, {
+            id,
+            inShoppingList: updated.inShoppingList,
+          })
+        );
+        return next;
+      });
+    },
+    [setGlobalIngredients]
+  );
 
   const renderItem = useCallback(
     ({ item }) => {

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -10,7 +10,7 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { saveIngredient } from "../../storage/ingredientsStorage";
+import { saveIngredient, updateIngredientById } from "../../storage/ingredientsStorage";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -68,13 +68,11 @@ export default function AllIngredientsScreen() {
 
   const toggleInBar = useCallback((id) => {
     setIngredients((prev) => {
-      const idx = prev.findIndex((i) => i.id === id);
-      if (idx === -1) return prev;
-      const next = [...prev];
-      const item = next[idx];
-      const inBar = !item.inBar;
-      next[idx] = { ...item, inBar };
-      saveIngredient({ ...item, inBar }).catch(() => {});
+      const item = prev.find((i) => i.id === id);
+      if (!item) return prev;
+      const updated = { ...item, inBar: !item.inBar };
+      const next = updateIngredientById(prev, updated);
+      saveIngredient(next).catch(() => {});
       return next;
     });
   }, []);

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -41,6 +41,7 @@ import {
   deleteIngredient,
   getIngredientById,
   getAllIngredients,
+  updateIngredientById,
 } from "../../storage/ingredientsStorage";
 import { MaterialIcons } from "@expo/vector-icons";
 import IngredientTagsModal from "../../components/IngredientTagsModal";
@@ -387,17 +388,15 @@ export default function EditIngredientScreen() {
         tags,
         baseIngredientId: baseIngredientId ?? null,
       };
-      // оптимістично оновити глобальний список
+      // оптимістично оновити глобальний список і зберегти оновлені дані
       setGlobalIngredients((list) => {
-        const next = list
-          .map((i) =>
-            i.id === updated.id
-              ? { ...i, ...updated, searchName: updated.name.toLowerCase() }
-              : i
-          )
-          .sort((a, b) =>
-            a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
-          );
+        const next = updateIngredientById(list, {
+          ...updated,
+          searchName: updated.name.toLowerCase(),
+        }).sort((a, b) =>
+          a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
+        );
+        saveIngredient(next).catch(() => {});
         return next;
       });
 
@@ -437,9 +436,6 @@ export default function EditIngredientScreen() {
       } else {
         setIngredient(updated);
       }
-
-      // асинхронно зберегти без важкого перезавантаження
-      saveIngredient(updated).catch(() => {});
 
       return updated;
     },

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -28,6 +28,7 @@ import {
   getIngredientById,
   getAllIngredients,
   saveIngredient,
+  updateIngredientById,
 } from "../../storage/ingredientsStorage";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
 import { mapCocktailsByIngredient } from "../../utils/ingredientUsage";
@@ -349,26 +350,35 @@ export default function IngredientDetailsScreen() {
   const toggleInBar = useCallback(() => {
     setIngredient((prev) => {
       if (!prev) return prev;
-      const next = { ...prev, inBar: !prev.inBar };
-      saveIngredient(next);
-      setIngredients((list) =>
-        list.map((i) => (i.id === next.id ? { ...i, inBar: next.inBar } : i))
-      );
-      return next;
+      const updated = { ...prev, inBar: !prev.inBar };
+      setIngredients((list) => {
+        const nextList = updateIngredientById(list, {
+          id: updated.id,
+          inBar: updated.inBar,
+        });
+        saveIngredient(nextList);
+        return nextList;
+      });
+      return updated;
     });
   }, [setIngredients]);
 
   const toggleInShoppingList = useCallback(() => {
     setIngredient((prev) => {
       if (!prev) return prev;
-      const next = { ...prev, inShoppingList: !prev.inShoppingList };
-      saveIngredient(next);
-      setIngredients((list) =>
-        list.map((i) =>
-          i.id === next.id ? { ...i, inShoppingList: next.inShoppingList } : i
-        )
-      );
-      return next;
+      const updated = {
+        ...prev,
+        inShoppingList: !prev.inShoppingList,
+      };
+      setIngredients((list) => {
+        const nextList = updateIngredientById(list, {
+          id: updated.id,
+          inShoppingList: updated.inShoppingList,
+        });
+        saveIngredient(nextList);
+        return nextList;
+      });
+      return updated;
     });
   }, [setIngredients]);
 
@@ -620,11 +630,13 @@ export default function IngredientDetailsScreen() {
         onConfirm={async () => {
           if (!ingredient) return;
           const updated = { ...ingredient, baseIngredientId: null };
-          await saveIngredient(updated);
+          let nextList;
+          setIngredients((list) => {
+            nextList = updateIngredientById(list, updated);
+            return nextList;
+          });
+          await saveIngredient(nextList);
           setIngredient(updated);
-          setIngredients((list) =>
-            list.map((i) => (i.id === updated.id ? updated : i))
-          );
           setBaseIngredient(null);
           setUnlinkBaseVisible(false);
         }}
@@ -643,10 +655,12 @@ export default function IngredientDetailsScreen() {
           const child = unlinkChildTarget;
           if (!child) return;
           const updatedChild = { ...child, baseIngredientId: null };
-          await saveIngredient(updatedChild);
-          setIngredients((list) =>
-            list.map((i) => (i.id === updatedChild.id ? updatedChild : i))
-          );
+          let nextList;
+          setIngredients((list) => {
+            nextList = updateIngredientById(list, updatedChild);
+            return nextList;
+          });
+          await saveIngredient(nextList);
           setBrandedChildren((prev) => prev.filter((c) => c.id !== child.id));
           setUnlinkChildTarget(null);
         }}

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -10,7 +10,7 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { saveIngredient } from "../../storage/ingredientsStorage";
+import { saveIngredient, updateIngredientById } from "../../storage/ingredientsStorage";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -147,13 +147,11 @@ export default function MyIngredientsScreen() {
 
   const toggleInBar = useCallback((id) => {
     setIngredients((prev) => {
-      const idx = prev.findIndex((i) => i.id === id);
-      if (idx === -1) return prev;
-      const next = [...prev];
-      const item = next[idx];
-      const inBar = !item.inBar;
-      next[idx] = { ...item, inBar };
-      saveIngredient({ ...item, inBar }).catch(() => {});
+      const item = prev.find((i) => i.id === id);
+      if (!item) return prev;
+      const updated = { ...item, inBar: !item.inBar };
+      const next = updateIngredientById(prev, updated);
+      saveIngredient(next).catch(() => {});
       return next;
     });
   }, []);

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -10,7 +10,7 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { saveIngredient } from "../../storage/ingredientsStorage";
+import { saveIngredient, updateIngredientById } from "../../storage/ingredientsStorage";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -68,13 +68,11 @@ export default function ShoppingIngredientsScreen() {
 
   const removeFromList = useCallback((id) => {
     setIngredients((prev) => {
-      const idx = prev.findIndex((i) => i.id === id);
-      if (idx === -1) return prev;
-      const next = [...prev];
-      const item = next[idx];
+      const item = prev.find((i) => i.id === id);
+      if (!item) return prev;
       const updated = { ...item, inShoppingList: false };
-      next[idx] = updated;
-      saveIngredient(updated).catch(() => {});
+      const next = updateIngredientById(prev, updated);
+      saveIngredient(next).catch(() => {});
       return next;
     });
   }, []);

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -11,19 +11,16 @@ export async function saveAllIngredients(ingredients) {
   await AsyncStorage.setItem(INGREDIENTS_KEY, JSON.stringify(ingredients));
 }
 
-export async function saveIngredient(updatedIngredient) {
-  const all = await getAllIngredients();
-  const index = all.findIndex((i) => i.id === updatedIngredient.id);
+export function updateIngredientById(list, updated) {
+  const index = list.findIndex((i) => i.id === updated.id);
+  if (index === -1) return list;
+  const next = [...list];
+  next[index] = { ...next[index], ...updated };
+  return next;
+}
 
-  if (index !== -1) {
-    all[index] = {
-      ...all[index],
-      ...updatedIngredient, // зберігає всі поля, включно з baseIngredientId
-    };
-    await saveAllIngredients(all);
-  } else {
-    console.warn("Ingredient not found:", updatedIngredient.id);
-  }
+export async function saveIngredient(updatedList) {
+  await saveAllIngredients(updatedList);
 }
 
 export async function addIngredient(ingredient) {


### PR DESCRIPTION
## Summary
- add `updateIngredientById` helper and simplify `saveIngredient`
- update ingredient-related screens to pass updated lists to `saveIngredient`
- consolidate state updates to save once after changes

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68a079687c2c8326a4251683d4d367e5