### PR TITLE
Maintain ingredient index for faster lookups

### DIFF
--- a/src/context/IngredientUsageContext.js
+++ b/src/context/IngredientUsageContext.js
@@ -1,11 +1,13 @@
 import React, { createContext, useContext, useState, useCallback } from "react";
 import { updateUsageMap as updateUsageMapUtil } from "../utils/ingredientUsage";
+import { buildIndex } from "../storage/ingredientsStorage";
 
 const IngredientUsageContext = createContext({
   usageMap: {},
   setUsageMap: () => {},
   updateUsageMap: () => {},
   ingredients: [],
+  ingredientsById: {},
   setIngredients: () => {},
   cocktails: [],
   setCocktails: () => {},
@@ -15,9 +17,18 @@ const IngredientUsageContext = createContext({
 
 export function IngredientUsageProvider({ children }) {
   const [usageMap, setUsageMap] = useState({});
-  const [ingredients, setIngredients] = useState([]);
+  const [ingredients, setIngredientsState] = useState([]);
+  const [ingredientsById, setIngredientsById] = useState({});
   const [cocktails, setCocktails] = useState([]);
   const [loading, setLoading] = useState(true);
+
+  const setIngredients = useCallback((next) => {
+    setIngredientsState((prev) => {
+      const value = typeof next === "function" ? next(prev) : next;
+      setIngredientsById(buildIndex(value));
+      return value;
+    });
+  }, []);
 
   const updateUsageMap = useCallback(
     (ingredients, cocktails, options) => {
@@ -35,6 +46,7 @@ export function IngredientUsageProvider({ children }) {
         setUsageMap,
         updateUsageMap,
         ingredients,
+        ingredientsById,
         setIngredients,
         cocktails,
         setCocktails,

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -39,7 +39,6 @@ import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import {
   saveIngredient,
   deleteIngredient,
-  getIngredientById,
   getAllIngredients,
 } from "../../storage/ingredientsStorage";
 import { MaterialIcons } from "@expo/vector-icons";
@@ -126,7 +125,7 @@ export default function EditIngredientScreen() {
   const route = useRoute();
   const isFocused = useIsFocused();
   const { setIngredients: setGlobalIngredients } = useIngredientsData();
-  const { setUsageMap } = useIngredientUsage();
+  const { setUsageMap, ingredientsById } = useIngredientUsage();
   const currentId = route.params?.id;
 
   // entity + form state
@@ -271,12 +270,9 @@ export default function EditIngredientScreen() {
 
     (async () => {
       try {
-        const [, data] = await Promise.all([
-          loadAvailableTags(),
-          getIngredientById(currentId),
-        ]);
+        await loadAvailableTags();
         if (cancelled || !isMountedRef.current) return;
-
+        const data = ingredientsById[currentId];
         if (data) {
           setIngredient(data);
           setName(data.name || "");
@@ -303,7 +299,7 @@ export default function EditIngredientScreen() {
     return () => {
       cancelled = true;
     };
-  }, [isFocused, currentId, loadAvailableTags]);
+  }, [isFocused, currentId, loadAvailableTags, ingredientsById]);
 
   // lazy-load bases (exclude current ingredient)
   const loadBases = useCallback(async () => {

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -24,11 +24,7 @@ import {
   useRoute,
   useFocusEffect,
 } from "@react-navigation/native";
-import {
-  getIngredientById,
-  getAllIngredients,
-  saveIngredient,
-} from "../../storage/ingredientsStorage";
+import { getAllIngredients, saveIngredient } from "../../storage/ingredientsStorage";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
 import { mapCocktailsByIngredient } from "../../utils/ingredientUsage";
 import { MaterialIcons } from "@expo/vector-icons";
@@ -39,6 +35,7 @@ import {
   addIgnoreGarnishListener,
 } from "../../storage/settingsStorage";
 import useIngredientsData from "../../hooks/useIngredientsData";
+import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
 
 const PHOTO_SIZE = 200;
@@ -109,6 +106,7 @@ export default function IngredientDetailsScreen() {
   const { id, fromCocktailId, initialIngredient } = route.params;
   const theme = useTheme();
   const { setIngredients } = useIngredientsData();
+  const { ingredientsById } = useIngredientUsage();
 
   const [ingredient, setIngredient] = useState(initialIngredient || null);
   const [brandedChildren, setBrandedChildren] = useState([]);
@@ -223,12 +221,12 @@ export default function IngredientDetailsScreen() {
   );
 
   const load = useCallback(async () => {
-    const [loaded, all, cocktails, ig] = await Promise.all([
-      getIngredientById(id),
+    const [all, cocktails, ig] = await Promise.all([
       getAllIngredients(),
       getAllCocktails(),
       getIgnoreGarnish(),
     ]);
+    const loaded = ingredientsById[id] || all.find((i) => i.id === id);
     setIngredient((prev) => (loaded ? { ...loaded, ...(prev || {}) } : prev));
 
     if (!loaded) {
@@ -321,7 +319,7 @@ export default function IngredientDetailsScreen() {
         };
       });
     setUsedCocktails(list);
-  }, [id, collator]);
+  }, [id, collator, ingredientsById]);
 
   useFocusEffect(
     useCallback(() => {

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -7,6 +7,13 @@ export async function getAllIngredients() {
   return json ? JSON.parse(json) : [];
 }
 
+export function buildIndex(list) {
+  return list.reduce((acc, item) => {
+    acc[item.id] = item;
+    return acc;
+  }, {});
+}
+
 export async function saveAllIngredients(ingredients) {
   await AsyncStorage.setItem(INGREDIENTS_KEY, JSON.stringify(ingredients));
 }
@@ -41,9 +48,8 @@ export async function addIngredient(ingredient) {
   return ingredient.id;
 }
 
-export async function getIngredientById(id) {
-  const all = await getAllIngredients();
-  return all.find((i) => i.id === id);
+export function getIngredientById(id, index) {
+  return index ? index[id] : null;
 }
 
 export async function deleteIngredient(id) {


### PR DESCRIPTION
## Summary
- cache ingredients in context with an `ingredientsById` index
- add `buildIndex` helper and index-based `getIngredientById`
- update ingredient detail/edit screens to use the cached index

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0796af2588326980ad17ca50151a8