### PR TITLE
Batch ingredient updates

### DIFF
--- a/src/hooks/useBatchedIngredientSaver.js
+++ b/src/hooks/useBatchedIngredientSaver.js
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getAllIngredients, saveAllIngredients } from "../storage/ingredientsStorage";
+
+export default function useBatchedIngredientSaver(delay = 400) {
+  const [pending, setPending] = useState([]);
+  const timerRef = useRef(null);
+  const pendingRef = useRef([]);
+
+  const applyUpdates = useCallback(async (updates) => {
+    if (updates.length === 0) return;
+    const all = await getAllIngredients();
+    const map = new Map(all.map((i) => [i.id, i]));
+    updates.forEach((u) => {
+      const existing = map.get(u.id);
+      if (existing) map.set(u.id, { ...existing, ...u });
+    });
+    await saveAllIngredients(Array.from(map.values()));
+  }, []);
+
+  const flushPendingUpdates = useCallback(async () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const updates = pendingRef.current;
+    if (updates.length === 0) return;
+    pendingRef.current = [];
+    setPending([]);
+    await applyUpdates(updates);
+  }, [applyUpdates]);
+
+  useEffect(() => {
+    pendingRef.current = pending;
+    if (pending.length === 0) return;
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(async () => {
+      const updates = pendingRef.current;
+      pendingRef.current = [];
+      setPending([]);
+      await applyUpdates(updates);
+    }, delay);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [pending, delay, applyUpdates]);
+
+  const queueIngredientUpdate = useCallback((update) => {
+    setPending((prev) => [...prev, update]);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      flushPendingUpdates();
+    };
+  }, [flushPendingUpdates]);
+
+  return { queueIngredientUpdate, flushPendingUpdates };
+}

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -13,7 +13,8 @@ import TopTabBar from "../../components/TopTabBar";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
-import { getAllIngredients, saveIngredient } from "../../storage/ingredientsStorage";
+import { getAllIngredients } from "../../storage/ingredientsStorage";
+import useBatchedIngredientSaver from "../../hooks/useBatchedIngredientSaver";
 import {
   getIgnoreGarnish,
   addIgnoreGarnishListener,
@@ -44,6 +45,7 @@ export default function MyCocktailsScreen() {
   const [availableTags, setAvailableTags] = useState([]);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
   const { setIngredients: setGlobalIngredients } = useIngredientsData();
+  const { queueIngredientUpdate } = useBatchedIngredientSaver();
 
   useEffect(() => {
     if (isFocused) setTab("cocktails", "My");
@@ -232,7 +234,7 @@ export default function MyCocktailsScreen() {
       const item = next[idx];
       const updated = { ...item, inShoppingList: !item.inShoppingList };
       next[idx] = updated;
-      saveIngredient(updated).catch(() => {});
+      queueIngredientUpdate(updated);
       setGlobalIngredients((list) =>
         list.map((i) =>
           String(i.id) === String(id)
@@ -242,7 +244,7 @@ export default function MyCocktailsScreen() {
       );
       return next;
     });
-  }, [setGlobalIngredients]);
+  }, [queueIngredientUpdate, setGlobalIngredients]);
 
   const renderItem = useCallback(
     ({ item }) => {

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -10,7 +10,7 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { saveIngredient } from "../../storage/ingredientsStorage";
+import useBatchedIngredientSaver from "../../hooks/useBatchedIngredientSaver";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -22,6 +22,7 @@ export default function AllIngredientsScreen() {
   const isFocused = useIsFocused();
   const { setTab } = useTabMemory();
   const tabsOnTop = useTabsOnTop();
+  const { queueIngredientUpdate } = useBatchedIngredientSaver();
 
   const { ingredients, loading, setIngredients } = useIngredientsData();
   const [search, setSearch] = useState("");
@@ -74,10 +75,10 @@ export default function AllIngredientsScreen() {
       const item = next[idx];
       const inBar = !item.inBar;
       next[idx] = { ...item, inBar };
-      saveIngredient({ ...item, inBar }).catch(() => {});
+      queueIngredientUpdate({ ...item, inBar });
       return next;
     });
-  }, []);
+  }, [queueIngredientUpdate]);
 
   const onItemPress = useCallback(
     (id) => {

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -37,11 +37,11 @@ import { useTheme, Menu, Divider, Text as PaperText } from "react-native-paper";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import {
-  saveIngredient,
   deleteIngredient,
   getIngredientById,
   getAllIngredients,
 } from "../../storage/ingredientsStorage";
+import useBatchedIngredientSaver from "../../hooks/useBatchedIngredientSaver";
 import { MaterialIcons } from "@expo/vector-icons";
 import IngredientTagsModal from "../../components/IngredientTagsModal";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
@@ -127,6 +127,8 @@ export default function EditIngredientScreen() {
   const isFocused = useIsFocused();
   const { setIngredients: setGlobalIngredients } = useIngredientsData();
   const { setUsageMap } = useIngredientUsage();
+  const { queueIngredientUpdate, flushPendingUpdates } =
+    useBatchedIngredientSaver();
   const currentId = route.params?.id;
 
   // entity + form state
@@ -439,7 +441,8 @@ export default function EditIngredientScreen() {
       }
 
       // асинхронно зберегти без важкого перезавантаження
-      saveIngredient(updated).catch(() => {});
+      queueIngredientUpdate(updated);
+      flushPendingUpdates();
 
       return updated;
     },
@@ -455,6 +458,8 @@ export default function EditIngredientScreen() {
       route.params?.targetLocalId,
       serialize,
       setGlobalIngredients,
+      queueIngredientUpdate,
+      flushPendingUpdates,
     ]
   );
 

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -10,7 +10,7 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { saveIngredient } from "../../storage/ingredientsStorage";
+import useBatchedIngredientSaver from "../../hooks/useBatchedIngredientSaver";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -26,6 +26,7 @@ export default function MyIngredientsScreen() {
   const isFocused = useIsFocused();
   const { setTab } = useTabMemory();
   const tabsOnTop = useTabsOnTop();
+  const { queueIngredientUpdate } = useBatchedIngredientSaver();
 
   const { ingredients, loading, setIngredients, cocktails, usageMap } =
     useIngredientsData();
@@ -153,10 +154,10 @@ export default function MyIngredientsScreen() {
       const item = next[idx];
       const inBar = !item.inBar;
       next[idx] = { ...item, inBar };
-      saveIngredient({ ...item, inBar }).catch(() => {});
+      queueIngredientUpdate({ ...item, inBar });
       return next;
     });
-  }, []);
+  }, [queueIngredientUpdate]);
 
   const onItemPress = useCallback(
     (id) => {

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -10,7 +10,7 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { saveIngredient } from "../../storage/ingredientsStorage";
+import useBatchedIngredientSaver from "../../hooks/useBatchedIngredientSaver";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -22,6 +22,7 @@ export default function ShoppingIngredientsScreen() {
   const isFocused = useIsFocused();
   const { setTab } = useTabMemory();
   const tabsOnTop = useTabsOnTop();
+  const { queueIngredientUpdate } = useBatchedIngredientSaver();
 
   const { ingredients, loading, setIngredients } = useIngredientsData();
   const [search, setSearch] = useState("");
@@ -74,10 +75,10 @@ export default function ShoppingIngredientsScreen() {
       const item = next[idx];
       const updated = { ...item, inShoppingList: false };
       next[idx] = updated;
-      saveIngredient(updated).catch(() => {});
+      queueIngredientUpdate(updated);
       return next;
     });
-  }, []);
+  }, [queueIngredientUpdate]);
 
   const onItemPress = useCallback(
     (id) => {


### PR DESCRIPTION
## Summary
- batch ingredient mutations using a pending queue and debounced flush
- replace direct saveIngredient calls with queue usage across screens

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a07980ddc08326a9d84e510be65c11