### PR TITLE
Batch ingredient updates with debounced saving

### DIFF
--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -10,7 +10,7 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { saveIngredient, updateIngredientById } from "../../storage/ingredientsStorage";
+import { saveAllIngredients, updateIngredientById } from "../../storage/ingredientsStorage";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -29,6 +29,7 @@ export default function AllIngredientsScreen() {
   const [navigatingId, setNavigatingId] = useState(null);
   const [selectedTagIds, setSelectedTagIds] = useState([]);
   const [availableTags, setAvailableTags] = useState([]);
+  const [pendingUpdates, setPendingUpdates] = useState([]);
 
   useEffect(() => {
     if (isFocused) setTab("ingredients", "All");
@@ -53,6 +54,33 @@ export default function AllIngredientsScreen() {
     return () => clearTimeout(h);
   }, [search]);
 
+  const flushPending = useCallback(() => {
+    if (pendingUpdates.length) {
+      saveAllIngredients(ingredients).catch(() => {});
+      setPendingUpdates([]);
+    }
+  }, [pendingUpdates, ingredients]);
+
+  useEffect(() => {
+    if (!pendingUpdates.length) return;
+    const handle = setTimeout(() => {
+      flushPending();
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [pendingUpdates, flushPending]);
+
+  useEffect(() => {
+    if (!isFocused) {
+      flushPending();
+    }
+  }, [isFocused, flushPending]);
+
+  useEffect(() => {
+    return () => {
+      flushPending();
+    };
+  }, [flushPending]);
+
   const filtered = useMemo(() => {
     const q = searchDebounced.trim().toLowerCase();
     let data = ingredients;
@@ -66,16 +94,19 @@ export default function AllIngredientsScreen() {
     return data;
   }, [ingredients, searchDebounced, selectedTagIds]);
 
-  const toggleInBar = useCallback((id) => {
-    setIngredients((prev) => {
-      const item = prev.find((i) => i.id === id);
-      if (!item) return prev;
-      const updated = { ...item, inBar: !item.inBar };
-      const next = updateIngredientById(prev, updated);
-      saveIngredient(next).catch(() => {});
-      return next;
-    });
-  }, []);
+  const toggleInBar = useCallback(
+    (id) => {
+      let updated;
+      setIngredients((prev) => {
+        const item = prev.find((i) => i.id === id);
+        if (!item) return prev;
+        updated = { ...item, inBar: !item.inBar };
+        return updateIngredientById(prev, updated);
+      });
+      if (updated) setPendingUpdates((p) => [...p, updated]);
+    },
+    [setIngredients]
+  );
 
   const onItemPress = useCallback(
     (id) => {


### PR DESCRIPTION
## Summary
- queue pending ingredient changes in list screens
- debounce and batch saves to storage via saveAllIngredients
- flush pending ingredient updates when leaving screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a080188f6083269f6365bacafeacf3