### PR TITLE
Refactor ingredient add/delete to work with in-memory lists

### DIFF
--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -39,6 +39,7 @@ import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import {
   addIngredient,
   getAllIngredients,
+  saveAllIngredients,
 } from "../../storage/ingredientsStorage";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
@@ -326,20 +327,21 @@ export default function AddIngredientScreen() {
       createdAt: Date.now(),
       inBar: false,
     };
-
-    addIngredient(newIng).catch(() => {});
     const enriched = {
       ...newIng,
       searchName: newIng.name.toLowerCase(),
       usageCount: 0,
       singleCocktailName: null,
     };
+    let updatedList;
     setGlobalIngredients((list) => {
-      const next = [...list, enriched].sort((a, b) =>
+      const next = addIngredient(list, enriched).sort((a, b) =>
         a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
       );
+      updatedList = next;
       return next;
     });
+    await saveAllIngredients(updatedList).catch(() => {});
     setUsageMap((prev) => ({ ...prev, [newIng.id]: [] }));
 
     const detailParams = {
@@ -381,6 +383,7 @@ export default function AddIngredientScreen() {
     addIngredient,
     setGlobalIngredients,
     setUsageMap,
+    saveAllIngredients,
   ]);
 
   const openMenu = useCallback(() => {

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -37,10 +37,10 @@ import { useTheme, Menu, Divider, Text as PaperText } from "react-native-paper";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import {
-  saveIngredient,
   deleteIngredient,
   getAllIngredients,
   updateIngredientById,
+  saveAllIngredients,
 } from "../../storage/ingredientsStorage";
 import { MaterialIcons } from "@expo/vector-icons";
 import IngredientTagsModal from "../../components/IngredientTagsModal";
@@ -392,7 +392,7 @@ export default function EditIngredientScreen() {
         }).sort((a, b) =>
           a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
         );
-        saveIngredient(next).catch(() => {});
+        saveAllIngredients(next).catch(() => {});
         return next;
       });
 
@@ -447,6 +447,7 @@ export default function EditIngredientScreen() {
       route.params?.targetLocalId,
       serialize,
       setGlobalIngredients,
+      saveAllIngredients,
     ]
   );
 
@@ -789,15 +790,17 @@ export default function EditIngredientScreen() {
         onConfirm={async () => {
           if (!ingredient) return;
           skipPromptRef.current = true;
-          await deleteIngredient(ingredient.id);
-          setGlobalIngredients((list) =>
-            list.filter((i) => i.id !== ingredient.id)
-          );
+          let updatedList;
+          setGlobalIngredients((list) => {
+            updatedList = deleteIngredient(list, ingredient.id);
+            return updatedList;
+          });
           setUsageMap((prev) => {
             const next = { ...prev };
             delete next[ingredient.id];
             return next;
           });
+          await saveAllIngredients(updatedList);
           navigation.popToTop();
           setConfirmDelete(false);
         }}

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -28,7 +28,7 @@ import {
 import {
   getIngredientById,
   getAllIngredients,
-  saveIngredient,
+  saveAllIngredients,
   updateIngredientById,
 } from "../../storage/ingredientsStorage";
 
@@ -360,12 +360,12 @@ export default function IngredientDetailsScreen() {
           id: updated.id,
           inBar: updated.inBar,
         });
-        saveIngredient(nextList);
+        saveAllIngredients(nextList);
         return nextList;
       });
       return updated;
     });
-  }, [setIngredients]);
+  }, [setIngredients, saveAllIngredients]);
 
   const toggleInShoppingList = useCallback(() => {
     setIngredient((prev) => {
@@ -379,12 +379,12 @@ export default function IngredientDetailsScreen() {
           id: updated.id,
           inShoppingList: updated.inShoppingList,
         });
-        saveIngredient(nextList);
+        saveAllIngredients(nextList);
         return nextList;
       });
       return updated;
     });
-  }, [setIngredients]);
+  }, [setIngredients, saveAllIngredients]);
 
   const unlinkFromBase = useCallback(() => {
     if (ingredient?.baseIngredientId == null) return;
@@ -639,7 +639,7 @@ export default function IngredientDetailsScreen() {
             nextList = updateIngredientById(list, updated);
             return nextList;
           });
-          await saveIngredient(nextList);
+          await saveAllIngredients(nextList);
           setIngredient(updated);
           setBaseIngredient(null);
           setUnlinkBaseVisible(false);
@@ -664,7 +664,7 @@ export default function IngredientDetailsScreen() {
             nextList = updateIngredientById(list, updatedChild);
             return nextList;
           });
-          await saveIngredient(nextList);
+          await saveAllIngredients(nextList);
           setBrandedChildren((prev) => prev.filter((c) => c.id !== child.id));
           setUnlinkChildTarget(null);
         }}

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -30,10 +30,9 @@ export async function saveIngredient(updatedList) {
   await saveAllIngredients(updatedList);
 }
 
-export async function addIngredient(ingredient) {
-  const current = await getAllIngredients();
-  const newList = [
-    ...current,
+export function addIngredient(list, ingredient) {
+  return [
+    ...list,
     {
       ...ingredient,
       inBar: false,
@@ -41,21 +40,12 @@ export async function addIngredient(ingredient) {
       baseIngredientId: ingredient.baseIngredientId ?? null,
     },
   ];
-  await saveAllIngredients(newList);
-  return ingredient.id;
 }
 
 export function getIngredientById(id, index) {
   return index ? index[id] : null;
 }
 
-export async function deleteIngredient(id) {
-  try {
-    const json = await AsyncStorage.getItem(INGREDIENTS_KEY);
-    const list = json ? JSON.parse(json) : [];
-    const updated = list.filter((item) => item.id !== id);
-    await AsyncStorage.setItem(INGREDIENTS_KEY, JSON.stringify(updated));
-  } catch (e) {
-    console.error("Failed to delete ingredient", e);
-  }
+export function deleteIngredient(list, id) {
+  return list.filter((item) => item.id !== id);
 }


### PR DESCRIPTION
## Summary
- Refactor `addIngredient`/`deleteIngredient` to operate on provided lists instead of storage
- Persist ingredient changes via single `saveAllIngredients` call from screens
- Update ingredient screens to pass local state to storage helpers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a081d8b1088326b703ca96dc0e7f1e