### PR TITLE
Use context for ingredient data

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1205,13 +1205,17 @@ export default function AddCocktailScreen() {
   useEffect(() => {
     let cancel = false;
     (async () => {
-      const list = await getAllIngredients();
-      if (!cancel) setAllIngredients(Array.isArray(list) ? list : []);
+      if (ingredients.length) {
+        if (!cancel) setAllIngredients(ingredients);
+      } else {
+        const list = await getAllIngredients();
+        if (!cancel) setAllIngredients(Array.isArray(list) ? list : []);
+      }
     })();
     return () => {
       cancel = true;
     };
-  }, []);
+  }, [ingredients]);
 
   // SUBSTITUTE MODAL STATE
   const [subModal, setSubModal] = useState({

--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -24,6 +24,7 @@ import { getAllCocktailTags } from "../../storage/cocktailTagsStorage";
 import CocktailRow, {
   COCKTAIL_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/CocktailRow";
+import { useIngredientUsage } from "../../context/IngredientUsageContext";
 
 export default function AllCocktailsScreen() {
   const theme = useTheme();
@@ -41,6 +42,8 @@ export default function AllCocktailsScreen() {
   const [selectedTagIds, setSelectedTagIds] = useState([]);
   const [availableTags, setAvailableTags] = useState([]);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
+  const { cocktails: globalCocktails = [], ingredients: globalIngredients = [] } =
+    useIngredientUsage();
 
   useEffect(() => {
     if (isFocused) setTab("cocktails", "All");
@@ -68,9 +71,13 @@ export default function AllCocktailsScreen() {
     if (!isFocused) return;
     (async () => {
       if (firstLoad.current) setLoading(true);
+      const cocktailPromise =
+        globalCocktails.length ? Promise.resolve(globalCocktails) : getAllCocktails();
+      const ingredientPromise =
+        globalIngredients.length ? Promise.resolve(globalIngredients) : getAllIngredients();
       const [cocktailsList, ingredientsList, ig] = await Promise.all([
-        getAllCocktails(),
-        getAllIngredients(),
+        cocktailPromise,
+        ingredientPromise,
         getIgnoreGarnish(),
       ]);
       if (cancel) return;
@@ -87,7 +94,7 @@ export default function AllCocktailsScreen() {
       cancel = true;
       sub.remove();
     };
-  }, [isFocused]);
+  }, [isFocused, globalCocktails, globalIngredients]);
 
   const filtered = useMemo(() => {
     const ingMap = new Map(

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1235,13 +1235,17 @@ export default function EditCocktailScreen() {
   useEffect(() => {
     let mounted = true;
     (async () => {
-      const list = await getAllIngredients();
-      if (mounted) setAllIngredients(Array.isArray(list) ? list : []);
+      if (ingredients.length) {
+        if (mounted) setAllIngredients(ingredients);
+      } else {
+        const list = await getAllIngredients();
+        if (mounted) setAllIngredients(Array.isArray(list) ? list : []);
+      }
     })();
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [ingredients]);
 
   useEffect(() => {
     const hw = BackHandler.addEventListener("hardwareBackPress", () => {

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -14,6 +14,7 @@ import { useTabMemory } from "../../context/TabMemoryContext";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
 import { getAllIngredients } from "../../storage/ingredientsStorage";
+import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import {
   getIgnoreGarnish,
   addIgnoreGarnishListener,
@@ -34,6 +35,8 @@ export default function FavoriteCocktailsScreen() {
   const isFocused = useIsFocused();
   const { setTab } = useTabMemory();
   const tabsOnTop = useTabsOnTop();
+  const { cocktails: globalCocktails = [], ingredients: globalIngredients = [] } =
+    useIngredientUsage();
 
   const [cocktails, setCocktails] = useState([]);
   const [ingredients, setIngredients] = useState([]);
@@ -73,9 +76,13 @@ export default function FavoriteCocktailsScreen() {
     if (!isFocused) return;
     (async () => {
       if (firstLoad.current) setLoading(true);
+      const cocktailPromise =
+        globalCocktails.length ? Promise.resolve(globalCocktails) : getAllCocktails();
+      const ingredientPromise =
+        globalIngredients.length ? Promise.resolve(globalIngredients) : getAllIngredients();
       const [cocktailsList, ingredientsList, ig, favMin] = await Promise.all([
-        getAllCocktails(),
-        getAllIngredients(),
+        cocktailPromise,
+        ingredientPromise,
         getIgnoreGarnish(),
         getFavoritesMinRating(),
       ]);
@@ -96,7 +103,7 @@ export default function FavoriteCocktailsScreen() {
       subIg.remove();
       subFav.remove();
     };
-  }, [isFocused]);
+  }, [isFocused, globalCocktails, globalIngredients]);
 
   const filtered = useMemo(() => {
     const ingMap = new Map(

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -26,7 +26,6 @@ import {
 } from "@react-navigation/native";
 
 import {
-  getIngredientById,
   getAllIngredients,
   saveAllIngredients,
   updateIngredientById,
@@ -113,7 +112,8 @@ export default function IngredientDetailsScreen() {
   const { id, fromCocktailId, initialIngredient } = route.params;
   const theme = useTheme();
   const { setIngredients } = useIngredientsData();
-  const { ingredientsById } = useIngredientUsage();
+  const { ingredients = [], cocktails: cocktailsCtx = [], ingredientsById } =
+    useIngredientUsage();
 
   const [ingredient, setIngredient] = useState(initialIngredient || null);
   const [brandedChildren, setBrandedChildren] = useState([]);
@@ -227,13 +227,14 @@ export default function IngredientDetailsScreen() {
     }, [handleGoBack])
   );
 
-  const load = useCallback(async () => {
-    const [all, cocktails, ig] = await Promise.all([
-      getAllIngredients(),
-      getAllCocktails(),
-      getIgnoreGarnish(),
-    ]);
-    const loaded = ingredientsById[id] || all.find((i) => i.id === id);
+  const load = useCallback(
+    async (refresh = false) => {
+      const [all, cocktails, ig] = await Promise.all([
+        !refresh && ingredients.length ? ingredients : getAllIngredients(),
+        !refresh && cocktailsCtx.length ? cocktailsCtx : getAllCocktails(),
+        getIgnoreGarnish(),
+      ]);
+      const loaded = ingredientsById[id] || all.find((i) => i.id === id);
     setIngredient((prev) => (loaded ? { ...loaded, ...(prev || {}) } : prev));
 
     if (!loaded) {
@@ -326,7 +327,13 @@ export default function IngredientDetailsScreen() {
         };
       });
     setUsedCocktails(list);
-  }, [id, collator, ingredientsById]);
+  }, [
+    id,
+    collator,
+    ingredientsById,
+    ingredients,
+    cocktailsCtx,
+  ]);
 
   useFocusEffect(
     useCallback(() => {


### PR DESCRIPTION
## Summary
- Read ingredients and cocktails from context before falling back to storage
- Drop unused `getIngredientById` imports

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a086e04ce88326bdbd771263b66be4