### PR TITLE
Add details icon to shaker ingredient rows

### DIFF
--- a/src/components/IngredientRow.js
+++ b/src/components/IngredientRow.js
@@ -29,6 +29,7 @@ function IngredientRow({
   inShoppingList,
   baseIngredientId,
   onPress,
+  onDetails,
   onToggleInBar,
   onToggleShoppingList,
   onRemove,
@@ -139,6 +140,21 @@ function IngredientRow({
               />
             ))}
           </View>
+        )}
+
+        {onDetails && (
+          <Pressable
+            onPress={() => onDetails(id)}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            android_ripple={{ ...ripple, borderless: true }}
+            style={({ pressed }) => [styles.checkButton, pressed && styles.pressedCheck]}
+          >
+            <MaterialIcons
+              name="info"
+              size={22}
+              color={theme.colors.onSurfaceVariant}
+            />
+          </Pressable>
         )}
 
         {onRemove ? (

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
+import { useNavigation } from "@react-navigation/native";
 
 import HeaderWithSearch from "../components/HeaderWithSearch";
 import IngredientRow from "../components/IngredientRow";
@@ -19,6 +20,7 @@ import { getAllTags } from "../storage/ingredientTagsStorage";
 
 export default function ShakerScreen() {
   const theme = useTheme();
+  const navigation = useNavigation();
   const { ingredients, usageMap, loading } = useIngredientsData();
   const [allTags, setAllTags] = useState([]);
   const [expanded, setExpanded] = useState({});
@@ -165,6 +167,12 @@ export default function ShakerScreen() {
                       inBar={ing.inBar}
                       inShoppingList={ing.inShoppingList}
                       onPress={toggleIngredient}
+                      onDetails={(id) =>
+                        navigation.navigate("Ingredients", {
+                          screen: "IngredientDetails",
+                          params: { id },
+                        })
+                      }
                       highlightColor={
                         active ? theme.colors.secondaryContainer : undefined
                       }


### PR DESCRIPTION
## Summary
- add optional details icon to IngredientRow
- show details icon on ShakerScreen ingredient rows to open IngredientDetails

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a08275d67083268451dfe96eff5b47