### PR TITLE
Fix navigation back to shaker from ingredient details

### DIFF
--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -187,7 +187,8 @@ export default function IngredientDetailsScreen() {
 
   useEffect(() => {
     const returnTo = route.params?.returnTo;
-    if (!fromCocktailId && !returnTo) return;
+    const returnToTab = route.params?.returnToTab;
+    if (!fromCocktailId && !returnTo && !returnToTab) return;
     const beforeRemove = (e) => {
       if (e.data.action.type === "NAVIGATE") return;
       e.preventDefault();
@@ -202,6 +203,8 @@ export default function IngredientDetailsScreen() {
           },
           merge: true,
         });
+      } else if (returnToTab) {
+        navigation.navigate(returnToTab);
       } else {
         navigation.navigate("Cocktails", {
           screen: "CocktailDetails",
@@ -215,6 +218,7 @@ export default function IngredientDetailsScreen() {
     navigation,
     fromCocktailId,
     route.params?.returnTo,
+    route.params?.returnToTab,
     route.params?.createdIngredient,
     route.params?.targetLocalId,
   ]);

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -170,7 +170,7 @@ export default function ShakerScreen() {
                       onDetails={(id) =>
                         navigation.navigate("Ingredients", {
                           screen: "IngredientDetails",
-                          params: { id },
+                          params: { id, returnToTab: "Shaker" },
                         })
                       }
                       highlightColor={


### PR DESCRIPTION
## Summary
- ensure ingredients opened from Shaker return to Shaker when going back
- add special-case navigation handling in ingredient details

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0961f5e848326900228d0a9a67714