### PR TITLE
Fix back navigation from ingredient details to Shaker

### DIFF
--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -109,7 +109,7 @@ const RelationRow = memo(function RelationRow({
 export default function IngredientDetailsScreen() {
   const navigation = useNavigation();
   const route = useRoute();
-  const { id, fromCocktailId, initialIngredient } = route.params;
+  const { id, fromCocktailId, initialIngredient, fromShaker } = route.params;
   const theme = useTheme();
   const { setIngredients } = useIngredientsData();
   const { ingredients = [], cocktails: cocktailsCtx = [], ingredientsById } =
@@ -218,6 +218,19 @@ export default function IngredientDetailsScreen() {
     route.params?.createdIngredient,
     route.params?.targetLocalId,
   ]);
+
+  useEffect(() => {
+    if (!fromShaker) return;
+    const beforeRemove = (e) => {
+      if (e.data.action.type === "NAVIGATE") return;
+      e.preventDefault();
+      sub();
+      navigation.dispatch(e.data.action);
+      navigation.navigate("Shaker");
+    };
+    const sub = navigation.addListener("beforeRemove", beforeRemove);
+    return sub;
+  }, [navigation, fromShaker]);
 
   useFocusEffect(
     useCallback(() => {

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -170,7 +170,7 @@ export default function ShakerScreen() {
                       onDetails={(id) =>
                         navigation.navigate("Ingredients", {
                           screen: "IngredientDetails",
-                          params: { id },
+                          params: { id, fromShaker: true },
                         })
                       }
                       highlightColor={


### PR DESCRIPTION
## Summary
- Pass a flag when opening ingredient details from the Shaker so the screen knows where it came from
- Intercept back navigation in IngredientDetailsScreen to pop and return to the Shaker tab when appropriate

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a09880ef648326990eafc0d54dbf87