### PR TITLE
Fix ingredient detail navigation from shaker

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,7 +3,7 @@ import React, { useEffect } from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { TabMemoryProvider } from "./src/context/TabMemoryContext";
+import { TabMemoryProvider, useTabMemory } from "./src/context/TabMemoryContext";
 import { IngredientUsageProvider } from "./src/context/IngredientUsageContext";
 import { MaterialIcons } from "@expo/vector-icons";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -12,6 +12,7 @@ import { MenuProvider } from "react-native-popup-menu";
 
 import CocktailsTabsScreen from "./src/screens/Cocktails/CocktailsTabsScreen";
 import ShakerScreen from "./src/screens/ShakerScreen";
+import IngredientDetailsScreen from "./src/screens/Ingredients/IngredientDetailsScreen";
 import IngredientsTabsScreen from "./src/screens/Ingredients/IngredientsTabsScreen";
 
 import EditCustomTagsScreen from "./src/screens/IngredientsTags/EditCustomTagsScreen";
@@ -24,9 +25,28 @@ import { importCocktailsAndIngredients } from "./scripts/importCocktailsAndIngre
 
 const Tab = createBottomTabNavigator();
 const RootStack = createNativeStackNavigator();
+const ShakerStack = createNativeStackNavigator();
+
+function ShakerStackScreen() {
+  return (
+    <ShakerStack.Navigator>
+      <ShakerStack.Screen
+        name="ShakerMain"
+        component={ShakerScreen}
+        options={{ headerShown: false }}
+      />
+      <ShakerStack.Screen
+        name="IngredientDetails"
+        component={IngredientDetailsScreen}
+        options={{ title: "Ingredient Details" }}
+      />
+    </ShakerStack.Navigator>
+  );
+}
 
 function Tabs() {
   const theme = useTheme();
+  const { getTab } = useTabMemory();
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
@@ -52,8 +72,21 @@ function Tabs() {
     >
       {/* ⬇️ Тут напряму твій екран з внутрішніми табами коктейлів */}
       <Tab.Screen name="Cocktails" component={CocktailsTabsScreen} />
-      <Tab.Screen name="Shaker" component={ShakerScreen} />
-      <Tab.Screen name="Ingredients" component={IngredientsTabsScreen} />
+      <Tab.Screen name="Shaker" component={ShakerStackScreen} />
+      <Tab.Screen
+        name="Ingredients"
+        component={IngredientsTabsScreen}
+        listeners={({ navigation }) => ({
+          tabPress: () => {
+            const saved =
+              typeof getTab === "function" && getTab("ingredients");
+            navigation.navigate("Ingredients", {
+              screen: "IngredientsMain",
+              params: { screen: saved || "All" },
+            });
+          },
+        })}
+      />
     </Tab.Navigator>
   );
 }

--- a/App.js
+++ b/App.js
@@ -13,6 +13,9 @@ import { MenuProvider } from "react-native-popup-menu";
 import CocktailsTabsScreen from "./src/screens/Cocktails/CocktailsTabsScreen";
 import ShakerScreen from "./src/screens/ShakerScreen";
 import IngredientDetailsScreen from "./src/screens/Ingredients/IngredientDetailsScreen";
+import EditIngredientScreen from "./src/screens/Ingredients/EditIngredientScreen";
+import CocktailDetailsScreen from "./src/screens/Cocktails/CocktailDetailsScreen";
+import EditCocktailScreen from "./src/screens/Cocktails/EditCocktailScreen";
 import IngredientsTabsScreen from "./src/screens/Ingredients/IngredientsTabsScreen";
 
 import EditCustomTagsScreen from "./src/screens/IngredientsTags/EditCustomTagsScreen";
@@ -39,6 +42,21 @@ function ShakerStackScreen() {
         name="IngredientDetails"
         component={IngredientDetailsScreen}
         options={{ title: "Ingredient Details" }}
+      />
+      <ShakerStack.Screen
+        name="EditIngredient"
+        component={EditIngredientScreen}
+        options={{ title: "Edit Ingredient" }}
+      />
+      <ShakerStack.Screen
+        name="CocktailDetails"
+        component={CocktailDetailsScreen}
+        options={{ title: "Cocktail Details" }}
+      />
+      <ShakerStack.Screen
+        name="EditCocktail"
+        component={EditCocktailScreen}
+        options={{ title: "Edit Cocktail" }}
       />
     </ShakerStack.Navigator>
   );

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -15,12 +15,14 @@ import {
   ScrollView,
   Image,
   ActivityIndicator,
+  BackHandler,
 } from "react-native";
 import {
   useNavigation,
   useRoute,
   useFocusEffect,
 } from "@react-navigation/native";
+import { goBack } from "../../utils/navigation";
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import { getCocktailById, saveCocktail } from "../../storage/cocktailsStorage";
@@ -168,7 +170,7 @@ export default function CocktailDetailsScreen() {
   const [keepAwake, setKeepAwake] = useState(false);
 
   const handleGoBack = useCallback(() => {
-    navigation.goBack();
+    goBack(navigation);
   }, [navigation]);
 
   const handleEdit = useCallback(() => {
@@ -217,6 +219,17 @@ export default function CocktailDetailsScreen() {
       ),
     });
   }, [navigation, handleGoBack, handleEdit, theme.colors.onSurface]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const onBack = () => {
+        goBack(navigation);
+        return true;
+      };
+      const sub = BackHandler.addEventListener("hardwareBackPress", onBack);
+      return () => sub.remove();
+    }, [navigation])
+  );
 
   const load = useCallback(
     async (refresh = false) => {
@@ -497,11 +510,7 @@ export default function CocktailDetailsScreen() {
                   {...props}
                   onPress={
                     ingredientId
-                      ? () =>
-                          navigation.navigate("Ingredients", {
-                            screen: "IngredientDetails",
-                            params: { id: ingredientId, fromCocktailId: id },
-                          })
+                      ? () => navigation.push("IngredientDetails", { id: ingredientId })
                       : undefined
                   }
                 />

--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -14,6 +14,8 @@ import FavoriteCocktailsScreen from "./FavoriteCocktailsScreen";
 import CocktailDetailsScreen from "./CocktailDetailsScreen";
 import EditCocktailScreen from "./EditCocktailScreen";
 import AddCocktailScreen from "./AddCocktailScreen";
+import IngredientDetailsScreen from "../Ingredients/IngredientDetailsScreen";
+import EditIngredientScreen from "../Ingredients/EditIngredientScreen";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 
 const Tab = createBottomTabNavigator();
@@ -92,6 +94,16 @@ export default function CocktailsTabsScreen() {
         name="AddCocktail"
         component={AddCocktailScreen}
         options={{ title: "Add Cocktail" }}
+      />
+      <Stack.Screen
+        name="IngredientDetails"
+        component={IngredientDetailsScreen}
+        options={{ title: "Ingredient Details" }}
+      />
+      <Stack.Screen
+        name="EditIngredient"
+        component={EditIngredientScreen}
+        options={{ title: "Edit Ingredient" }}
       />
     </Stack.Navigator>
   );

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -24,6 +24,7 @@ import {
   useRoute,
   useFocusEffect,
 } from "@react-navigation/native";
+import { goBack } from "../../utils/navigation";
 
 import {
   getAllIngredients,
@@ -109,7 +110,7 @@ const RelationRow = memo(function RelationRow({
 export default function IngredientDetailsScreen() {
   const navigation = useNavigation();
   const route = useRoute();
-  const { id, fromCocktailId, initialIngredient } = route.params;
+  const { id, initialIngredient } = route.params;
   const theme = useTheme();
   const { setIngredients } = useIngredientsData();
   const { ingredients = [], cocktails: cocktailsCtx = [], ingredientsById } =
@@ -134,7 +135,7 @@ export default function IngredientDetailsScreen() {
   );
 
   const handleGoBack = useCallback(() => {
-    navigation.goBack();
+    goBack(navigation);
   }, [navigation]);
 
   const handleEdit = useCallback(() => {
@@ -187,33 +188,25 @@ export default function IngredientDetailsScreen() {
 
   useEffect(() => {
     const returnTo = route.params?.returnTo;
-    if (!fromCocktailId && !returnTo) return;
+    if (!returnTo) return;
     const beforeRemove = (e) => {
       if (e.data.action.type === "NAVIGATE") return;
       e.preventDefault();
       sub();
       navigation.dispatch(e.data.action);
-      if (returnTo) {
-        navigation.navigate("Cocktails", {
-          screen: returnTo,
-          params: {
-            createdIngredient: route.params?.createdIngredient,
-            targetLocalId: route.params?.targetLocalId,
-          },
-          merge: true,
-        });
-      } else {
-        navigation.navigate("Cocktails", {
-          screen: "CocktailDetails",
-          params: { id: fromCocktailId },
-        });
-      }
+      navigation.navigate("Cocktails", {
+        screen: returnTo,
+        params: {
+          createdIngredient: route.params?.createdIngredient,
+          targetLocalId: route.params?.targetLocalId,
+        },
+        merge: true,
+      });
     };
     const sub = navigation.addListener("beforeRemove", beforeRemove);
     return sub;
   }, [
     navigation,
-    fromCocktailId,
     route.params?.returnTo,
     route.params?.createdIngredient,
     route.params?.targetLocalId,
@@ -414,10 +407,7 @@ export default function IngredientDetailsScreen() {
 
   const goToCocktail = useCallback(
     (goId) => {
-      navigation.navigate("Cocktails", {
-        screen: "CocktailDetails",
-        params: { id: goId },
-      });
+      navigation.push("CocktailDetails", { id: goId });
     },
     [navigation]
   );

--- a/src/screens/Ingredients/IngredientsTabsScreen.js
+++ b/src/screens/Ingredients/IngredientsTabsScreen.js
@@ -14,6 +14,8 @@ import ShoppingIngredientsScreen from "./ShoppingIngredientsScreen";
 import IngredientDetailsScreen from "./IngredientDetailsScreen";
 import EditIngredientScreen from "./EditIngredientScreen";
 import AddIngredientScreen from "./AddIngredientScreen";
+import CocktailDetailsScreen from "../Cocktails/CocktailDetailsScreen";
+import EditCocktailScreen from "../Cocktails/EditCocktailScreen";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 
 const Tab = createBottomTabNavigator();
@@ -92,6 +94,16 @@ export default function IngredientsTabsScreen() {
         name="AddIngredient"
         component={AddIngredientScreen}
         options={{ title: "Add Ingredient" }}
+      />
+      <Stack.Screen
+        name="CocktailDetails"
+        component={CocktailDetailsScreen}
+        options={{ title: "Cocktail Details" }}
+      />
+      <Stack.Screen
+        name="EditCocktail"
+        component={EditCocktailScreen}
+        options={{ title: "Edit Cocktail" }}
       />
     </Stack.Navigator>
   );

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -10,7 +10,6 @@ import {
 } from "react-native";
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
-import { useNavigation } from "@react-navigation/native";
 
 import HeaderWithSearch from "../components/HeaderWithSearch";
 import IngredientRow from "../components/IngredientRow";
@@ -18,9 +17,8 @@ import useIngredientsData from "../hooks/useIngredientsData";
 import { BUILTIN_INGREDIENT_TAGS } from "../constants/ingredientTags";
 import { getAllTags } from "../storage/ingredientTagsStorage";
 
-export default function ShakerScreen() {
+export default function ShakerScreen({ navigation }) {
   const theme = useTheme();
-  const navigation = useNavigation();
   const { ingredients, usageMap, loading } = useIngredientsData();
   const [allTags, setAllTags] = useState([]);
   const [expanded, setExpanded] = useState({});
@@ -168,7 +166,7 @@ export default function ShakerScreen() {
                       inShoppingList={ing.inShoppingList}
                       onPress={toggleIngredient}
                       onDetails={(id) =>
-                        navigation.navigate("IngredientDetails", { id })
+                        navigation.push("IngredientDetails", { id })
                       }
                       highlightColor={
                         active ? theme.colors.secondaryContainer : undefined

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -168,10 +168,7 @@ export default function ShakerScreen() {
                       inShoppingList={ing.inShoppingList}
                       onPress={toggleIngredient}
                       onDetails={(id) =>
-                        navigation.navigate("Ingredients", {
-                          screen: "IngredientDetails",
-                          params: { id },
-                        })
+                        navigation.navigate("IngredientDetails", { id })
                       }
                       highlightColor={
                         active ? theme.colors.secondaryContainer : undefined

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -1,0 +1,21 @@
+import { StackActions } from '@react-navigation/native';
+
+const EDIT_SCREENS = new Set(['EditCocktail', 'EditIngredient']);
+
+export function goBack(navigation) {
+  try {
+    const state = navigation.getState();
+    let toPop = 1;
+    for (let i = state.index - 1; i >= 0; i--) {
+      const name = state.routes[i]?.name;
+      if (EDIT_SCREENS.has(name)) {
+        toPop += 1;
+      } else {
+        break;
+      }
+    }
+    navigation.dispatch(StackActions.pop(toPop));
+  } catch {
+    navigation.goBack();
+  }
+}


### PR DESCRIPTION
## Summary
- ensure IngredientDetails opened from Shaker returns back to Shaker
- reset Ingredients tab presses to show All/My/Shopping lists

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a09d00665883268c117bb027840ab6