### PR TITLE
Adjust Shaker tag row height

### DIFF
--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -196,6 +196,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderRadius: 4,
+    height: 56,
   },
   tagTitle: { color: "#fff", fontWeight: "bold", fontSize: 16 },
   counter: {


### PR DESCRIPTION
## Summary
- make tag sections on shaker screen 56px tall for consistent layout

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0abafa70c8326bdc31a7224f24697