### PR TITLE
Add cocktail result screen with show/clear buttons

### DIFF
--- a/App.js
+++ b/App.js
@@ -20,6 +20,7 @@ import IngredientsTabsScreen from "./src/screens/Ingredients/IngredientsTabsScre
 
 import EditCustomTagsScreen from "./src/screens/IngredientsTags/EditCustomTagsScreen";
 import { AppTheme } from "./src/theme";
+import ShakerResultsScreen from "./src/screens/ShakerResultsScreen";
 
 import ShakerIcon from "./assets/shaker.svg";
 import IngredientIcon from "./assets/lemon.svg";
@@ -57,6 +58,11 @@ function ShakerStackScreen() {
         name="EditCocktail"
         component={EditCocktailScreen}
         options={{ title: "Edit Cocktail" }}
+      />
+      <ShakerStack.Screen
+        name="ShakerResults"
+        component={ShakerResultsScreen}
+        options={{ title: "Available Cocktails" }}
       />
     </ShakerStack.Navigator>
   );

--- a/App.js
+++ b/App.js
@@ -62,7 +62,7 @@ function ShakerStackScreen() {
       <ShakerStack.Screen
         name="ShakerResults"
         component={ShakerResultsScreen}
-        options={{ title: "Available Cocktails" }}
+        options={{ headerShown: false }}
       />
     </ShakerStack.Navigator>
   );

--- a/src/screens/ShakerResultsScreen.js
+++ b/src/screens/ShakerResultsScreen.js
@@ -1,0 +1,125 @@
+import React, { useMemo } from "react";
+import { View, StyleSheet, ActivityIndicator } from "react-native";
+import { FlashList } from "@shopify/flash-list";
+import { useTheme } from "react-native-paper";
+
+import CocktailRow, { COCKTAIL_ROW_HEIGHT } from "../components/CocktailRow";
+import useIngredientsData from "../hooks/useIngredientsData";
+
+export default function ShakerResultsScreen({ route, navigation }) {
+  const { ids = [] } = route.params || {};
+  const theme = useTheme();
+  const { cocktails, ingredients, loading } = useIngredientsData();
+
+  const data = useMemo(() => {
+    const ingMap = new Map((ingredients || []).map((i) => [String(i.id), i]));
+    const findBrand = (baseId) =>
+      ingredients.find(
+        (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
+      );
+    return cocktails
+      .filter((c) => ids.includes(c.id))
+      .map((c) => {
+        const required = (c.ingredients || []).filter((r) => !r.optional);
+        const missing = [];
+        const ingredientNames = [];
+        let allAvail = required.length > 0;
+        for (const r of required) {
+          const ing = ingMap.get(String(r.ingredientId));
+          const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
+          let used = null;
+          if (ing?.inBar) {
+            used = ing;
+          } else {
+            if (r.allowBaseSubstitution) {
+              const base = ingMap.get(baseId);
+              if (base?.inBar) used = base;
+            }
+            const isBaseIngredient = ing?.baseIngredientId == null;
+            if (!used && (r.allowBrandedSubstitutes || isBaseIngredient)) {
+              const brand = findBrand(baseId);
+              if (brand) used = brand;
+            }
+            if (!used && Array.isArray(r.substitutes)) {
+              for (const s of r.substitutes) {
+                const candidate = ingMap.get(String(s.id));
+                if (candidate?.inBar) {
+                  used = candidate;
+                  break;
+                }
+              }
+            }
+          }
+          if (used) {
+            ingredientNames.push(used.name);
+          } else {
+            const missingName = ing?.name || r.name || "";
+            if (missingName) missing.push(missingName);
+            allAvail = false;
+          }
+        }
+        const branded = (c.ingredients || []).some((r) => {
+          const ing = ingMap.get(String(r.ingredientId));
+          return ing && ing.baseIngredientId != null;
+        });
+        let ingredientLine = ingredientNames.join(", ");
+        if (!allAvail) {
+          if (missing.length > 0 && missing.length <= 2) {
+            ingredientLine = `Missing: ${missing.join(", ")}`;
+          } else if (missing.length >= 3 || missing.length === 0) {
+            ingredientLine = `Missing: ${
+              missing.length || required.length
+            } ingredients`;
+          }
+        }
+        return {
+          ...c,
+          ingredientLine,
+          isAllAvailable: allAvail,
+          hasBranded: branded,
+        };
+      });
+  }, [cocktails, ingredients, ids]);
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlashList
+        data={data}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={({ item }) => (
+          <CocktailRow
+            id={item.id}
+            name={item.name}
+            photoUri={item.photoUri}
+            glassId={item.glassId}
+            tags={item.tags}
+            ingredientLine={item.ingredientLine}
+            rating={item.rating}
+            isAllAvailable={item.isAllAvailable}
+            hasBranded={item.hasBranded}
+            onPress={(id) => navigation.navigate("CocktailDetails", { id })}
+          />
+        )}
+        estimatedItemSize={COCKTAIL_ROW_HEIGHT}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  loadingContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});
+

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -193,13 +193,14 @@ export default function ShakerScreen({ navigation }) {
           onPress={handleClear}
           style={[
             styles.counterButton,
-            { backgroundColor: theme.colors.secondaryContainer },
+            styles.clearButton,
+            { borderColor: theme.colors.error },
           ]}
         >
           <Text
             style={[
               styles.counterButtonText,
-              { color: theme.colors.onSecondaryContainer },
+              { color: theme.colors.error },
             ]}
           >
             Clear
@@ -254,6 +255,10 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderRadius: 4,
     marginHorizontal: 4,
+  },
+  clearButton: {
+    backgroundColor: "#fff",
+    borderWidth: 1,
   },
   counterButtonText: { fontWeight: "bold" },
   loadingContainer: {

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -85,8 +85,8 @@ export default function ShakerScreen({ navigation }) {
     );
   };
 
-  const cocktailsCount = useMemo(() => {
-    if (selectedIds.length === 0) return 0;
+  const { count: cocktailsCount, ids: availableCocktailIds } = useMemo(() => {
+    if (selectedIds.length === 0) return { count: 0, ids: [] };
 
     // group selected ingredients by tag
     const groups = new Map();
@@ -97,7 +97,7 @@ export default function ShakerScreen({ navigation }) {
       if (selected.length > 0) groups.set(tagId, selected);
     });
 
-    if (groups.size === 0) return 0;
+    if (groups.size === 0) return { count: 0, ids: [] };
 
     let intersection;
     groups.forEach((ids) => {
@@ -114,8 +114,18 @@ export default function ShakerScreen({ navigation }) {
       }
     });
 
-    return intersection ? intersection.size : 0;
+    return {
+      count: intersection ? intersection.size : 0,
+      ids: intersection ? Array.from(intersection) : [],
+    };
   }, [selectedIds, usageMap, grouped]);
+
+  const handleClear = () => setSelectedIds([]);
+
+  const handleShow = () => {
+    if (availableCocktailIds.length === 0) return;
+    navigation.navigate("ShakerResults", { ids: availableCocktailIds });
+  };
 
   if (loading) {
     return (
@@ -179,7 +189,38 @@ export default function ShakerScreen({ navigation }) {
         })}
       </ScrollView>
       <View style={styles.counter}>
-        <Text style={styles.counterText}>Cocktails available: {cocktailsCount}</Text>
+        <TouchableOpacity
+          onPress={handleClear}
+          style={[
+            styles.counterButton,
+            { backgroundColor: theme.colors.secondaryContainer },
+          ]}
+        >
+          <Text
+            style={[
+              styles.counterButtonText,
+              { color: theme.colors.onSecondaryContainer },
+            ]}
+          >
+            Clear
+          </Text>
+        </TouchableOpacity>
+        <Text style={styles.counterText}>
+          Cocktails available: {cocktailsCount}
+        </Text>
+        <TouchableOpacity
+          onPress={handleShow}
+          style={[styles.counterButton, { backgroundColor: theme.colors.primary }]}
+        >
+          <Text
+            style={[
+              styles.counterButtonText,
+              { color: theme.colors.onPrimary },
+            ]}
+          >
+            Show
+          </Text>
+        </TouchableOpacity>
       </View>
     </View>
   );
@@ -204,8 +245,17 @@ const styles = StyleSheet.create({
     borderTopWidth: StyleSheet.hairlineWidth,
     borderColor: "#ccc",
     alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "center",
   },
-  counterText: { fontWeight: "bold" },
+  counterText: { fontWeight: "bold", flex: 1, textAlign: "center" },
+  counterButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 4,
+    marginHorizontal: 4,
+  },
+  counterButtonText: { fontWeight: "bold" },
   loadingContainer: {
     flex: 1,
     alignItems: "center",


### PR DESCRIPTION
## Summary
- Add Show and Clear buttons to the shaker to display available cocktails or reset selections
- Implement ShakerResultsScreen to list cocktails possible with selected ingredients
- Wire new results screen into navigation stack

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0b198eabc832689db59695979b3a7