### PR TITLE
Improve tag addition speed on edit screens

### DIFF
--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1077,6 +1077,7 @@ export default function EditCocktailScreen() {
   const [name, setName] = useState("");
   const [photoUri, setPhotoUri] = useState(null);
   const [tags, setTags] = useState([]);
+  const selectedTagIds = useMemo(() => new Set(tags.map((t) => t.id)), [tags]);
   const [availableTags, setAvailableTags] = useState(BUILTIN_COCKTAIL_TAGS);
   const [tagsModalVisible, setTagsModalVisible] = useState(false);
   const [tagsModalAutoAdd, setTagsModalAutoAdd] = useState(false);
@@ -1680,7 +1681,7 @@ export default function EditCocktailScreen() {
           </Text>
           <View style={styles.tagContainer}>
             {availableTags
-              .filter((t) => !tags.some((x) => x.id === t.id))
+              .filter((t) => !selectedTagIds.has(t.id))
               .map((t) => (
                 <TagPill
                   key={t.id}

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -139,6 +139,7 @@ export default function EditIngredientScreen() {
   const [description, setDescription] = useState("");
   const [photoUri, setPhotoUri] = useState(null);
   const [tags, setTags] = useState([]);
+  const selectedTagIds = useMemo(() => new Set(tags.map((t) => t.id)), [tags]);
 
   // reference lists
   const [availableTags, setAvailableTags] = useState([]); // builtin + custom
@@ -576,7 +577,7 @@ export default function EditIngredientScreen() {
         </Text>
         <View style={styles.tagContainer}>
           {availableTags
-            .filter((t) => !tags.some((x) => x.id === t.id))
+            .filter((t) => !selectedTagIds.has(t.id))
             .map((t) => (
               <TagPill
                 key={t.id}


### PR DESCRIPTION
## Summary
- Optimize tag filtering on ingredient and cocktail edit screens using a memoized Set of selected tag IDs
- Reduce UI lag when toggling tags

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0c24bb5ac83268d0ff11e13c8e737