### PR TITLE
Limit image placeholders to 100px

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1908,7 +1908,7 @@ export default function AddCocktailScreen() {
 }
 
 /* ---------- styles ---------- */
-const IMAGE_SIZE = 150;
+const IMAGE_SIZE = 100;
 
 const styles = StyleSheet.create({
   container: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 40 },

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -528,7 +528,7 @@ const styles = StyleSheet.create({
   loadingContainer: { flex: 1, justifyContent: "center", alignItems: "center" },
   headerBackBtn: { paddingHorizontal: 8, paddingVertical: 4 },
   headerEditBtn: { paddingHorizontal: 8, paddingVertical: 4 },
-  photo: { width: "100%", height: 200, marginTop: 12 },
+  photo: { width: 100, height: 100, marginTop: 12, alignSelf: "center" },
   title: {
     fontSize: 22,
     fontWeight: "bold",

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -2008,7 +2008,7 @@ export default function EditCocktailScreen() {
 }
 
 /* ---------- styles ---------- */
-const IMAGE_SIZE = 150;
+const IMAGE_SIZE = 100;
 
 const styles = StyleSheet.create({
   container: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 40 },

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -56,7 +56,7 @@ const useDebounced = (value, delay = 300) => {
   return v;
 };
 
-const IMAGE_SIZE = 120;
+const IMAGE_SIZE = 100;
 const MENU_ROW_HEIGHT = 56;
 const RIPPLE = { color: "#E3F2FD" };
 

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -58,7 +58,7 @@ const useDebounced = (value, delay = 300) => {
   return v;
 };
 
-const IMAGE_SIZE = 120;
+const IMAGE_SIZE = 100;
 const MENU_ROW_HEIGHT = 56;
 
 // pills for tags (memo, стабільний onPress через id)

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -45,7 +45,7 @@ import useIngredientsData from "../../hooks/useIngredientsData";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
 
-const PHOTO_SIZE = 200;
+const PHOTO_SIZE = 100;
 const THUMB = 40;
 
 /** Gray-square photo (no icon/initials), uses theme */


### PR DESCRIPTION
## Summary
- cap cocktail and ingredient image placeholders at 100px
- restrict detail screen photos to 100px

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0cb797d608326be4d6414e3f43d11