### PR TITLE
feat: include images in backup

### DIFF
--- a/src/storage/backupStorage.js
+++ b/src/storage/backupStorage.js
@@ -5,6 +5,40 @@ import * as Sharing from 'expo-sharing';
 import { getAllIngredients, saveAllIngredients } from './ingredientsStorage';
 import { getAllCocktails, replaceAllCocktails } from './cocktailsStorage';
 
+async function embedPhoto(item) {
+  if (!item?.photoUri) return item;
+  try {
+    const base64 = await FileSystem.readAsStringAsync(item.photoUri, {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+    const extMatch = /\.([a-zA-Z0-9]+)$/.exec(item.photoUri);
+    const ext = extMatch ? extMatch[1] : 'jpg';
+    return { ...item, photo: { base64, ext } };
+  } catch (e) {
+    console.warn('Failed to read photo', e);
+    return item;
+  }
+}
+
+async function restorePhoto(item, prefix) {
+  if (!item?.photo?.base64) return item;
+  try {
+    const ext = item.photo.ext || 'jpg';
+    const fileName = `${prefix}-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}.${ext}`;
+    const fileUri = (FileSystem.documentDirectory || FileSystem.cacheDirectory) + fileName;
+    await FileSystem.writeAsStringAsync(fileUri, item.photo.base64, {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+    const { photo, ...rest } = item;
+    return { ...rest, photoUri: fileUri };
+  } catch (e) {
+    console.warn('Failed to write photo', e);
+    return item;
+  }
+}
+
 /**
  * Export all ingredients and cocktails to a JSON file and open share dialog.
  * Returns the URI of the created file.
@@ -14,7 +48,10 @@ export async function exportAllData() {
     getAllIngredients(),
     getAllCocktails(),
   ]);
-  const data = { ingredients, cocktails };
+  const data = {
+    ingredients: await Promise.all(ingredients.map((i) => embedPhoto(i))),
+    cocktails: await Promise.all(cocktails.map((c) => embedPhoto(c))),
+  };
   const json = JSON.stringify(data, null, 2);
   const fileName = `yourbar-backup-${Date.now()}.json`;
   const fileUri = FileSystem.cacheDirectory + fileName;
@@ -51,10 +88,16 @@ export async function importAllData() {
     });
     const data = JSON.parse(contents);
     if (Array.isArray(data.ingredients)) {
-      await saveAllIngredients(data.ingredients);
+      const restoredIngredients = await Promise.all(
+        data.ingredients.map((i) => restorePhoto(i, 'ingredient'))
+      );
+      await saveAllIngredients(restoredIngredients);
     }
     if (Array.isArray(data.cocktails)) {
-      await replaceAllCocktails(data.cocktails);
+      const restoredCocktails = await Promise.all(
+        data.cocktails.map((c) => restorePhoto(c, 'cocktail'))
+      );
+      await replaceAllCocktails(restoredCocktails);
     }
     return true;
   } catch (e) {


### PR DESCRIPTION
## Summary
- embed ingredient and cocktail images in exported backup
- restore images from backup during import

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0e74dd90c8326bee146cbe010636f