### PR TITLE
feat: archive backup with photos

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-status-bar": "~2.2.3",
     "expo-document-picker": "~13.1.6",
     "expo-sharing": "^11.0.0",
+    "jszip": "^3.10.1",
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-draggable-flatlist": "^4.0.3",

--- a/src/storage/backupStorage.js
+++ b/src/storage/backupStorage.js
@@ -1,30 +1,98 @@
 import * as FileSystem from 'expo-file-system';
 import * as DocumentPicker from 'expo-document-picker';
 import * as Sharing from 'expo-sharing';
+import JSZip from 'jszip';
 
 import { getAllIngredients, saveAllIngredients } from './ingredientsStorage';
 import { getAllCocktails, replaceAllCocktails } from './cocktailsStorage';
 
+function getExt(uri) {
+  const m = /\.([a-zA-Z0-9]+)(?:\?.*)?$/.exec(uri || '');
+  return m ? `.${m[1]}` : '.jpg';
+}
+
+async function readFileBase64(uri) {
+  if (/^https?:/.test(uri)) {
+    const tmp = FileSystem.cacheDirectory + `tmp-${Date.now()}`;
+    try {
+      const { uri: downloaded } = await FileSystem.downloadAsync(uri, tmp);
+      const data = await FileSystem.readAsStringAsync(downloaded, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+      await FileSystem.deleteAsync(downloaded, { idempotent: true });
+      return data;
+    } catch (e) {
+      console.warn('Failed to download image', uri, e);
+      return null;
+    }
+  }
+  try {
+    return await FileSystem.readAsStringAsync(uri, {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+  } catch (e) {
+    console.warn('Failed to read image', uri, e);
+    return null;
+  }
+}
+
+function dirName(path) {
+  const idx = path.lastIndexOf('/');
+  return idx === -1 ? '' : path.slice(0, idx);
+}
+
 /**
- * Export all ingredients and cocktails to a JSON file and open share dialog.
- * Returns the URI of the created file.
+ * Export all ingredients and cocktails with photos into a ZIP archive and open
+ * share dialog. Returns the URI of the created archive.
  */
 export async function exportAllData() {
   const [ingredients, cocktails] = await Promise.all([
     getAllIngredients(),
     getAllCocktails(),
   ]);
-  const data = { ingredients, cocktails };
-  const json = JSON.stringify(data, null, 2);
-  const fileName = `yourbar-backup-${Date.now()}.json`;
+
+  const zip = new JSZip();
+  const data = { ingredients: [], cocktails: [] };
+
+  for (const ing of ingredients) {
+    const item = { ...ing };
+    if (ing.photoUri) {
+      const rel = `ingredients/${ing.id}${getExt(ing.photoUri)}`;
+      const img = await readFileBase64(ing.photoUri);
+      if (img) {
+        zip.file(rel, img, { base64: true });
+        item.photoUri = rel;
+      }
+    }
+    data.ingredients.push(item);
+  }
+
+  for (const c of cocktails) {
+    const item = { ...c };
+    if (c.photoUri) {
+      const rel = `cocktails/${c.id}${getExt(c.photoUri)}`;
+      const img = await readFileBase64(c.photoUri);
+      if (img) {
+        zip.file(rel, img, { base64: true });
+        item.photoUri = rel;
+      }
+    }
+    data.cocktails.push(item);
+  }
+
+  zip.file('data.json', JSON.stringify(data, null, 2));
+
+  const base64Zip = await zip.generateAsync({ type: 'base64' });
+  const fileName = `yourbar-backup-${Date.now()}.zip`;
   const fileUri = FileSystem.cacheDirectory + fileName;
-  await FileSystem.writeAsStringAsync(fileUri, json, {
-    encoding: FileSystem.EncodingType.UTF8,
+  await FileSystem.writeAsStringAsync(fileUri, base64Zip, {
+    encoding: FileSystem.EncodingType.Base64,
   });
+
   try {
     if (await Sharing.isAvailableAsync()) {
       await Sharing.shareAsync(fileUri, {
-        mimeType: 'application/json',
+        mimeType: 'application/zip',
         dialogTitle: 'Share yourbar backup',
       });
     }
@@ -35,26 +103,62 @@ export async function exportAllData() {
 }
 
 /**
- * Pick a JSON file and import ingredients and cocktails from it.
+ * Pick a ZIP archive and import ingredients and cocktails with photos from it.
  * Returns true on success, false otherwise.
  */
 export async function importAllData() {
   try {
     const res = await DocumentPicker.getDocumentAsync({
-      type: 'application/json',
+      type: 'application/zip',
       copyToCacheDirectory: true,
     });
     if (res.canceled || res.type === 'cancel') return false;
     const uri = res.assets ? res.assets[0].uri : res.uri;
-    const contents = await FileSystem.readAsStringAsync(uri, {
-      encoding: FileSystem.EncodingType.UTF8,
+    const base64 = await FileSystem.readAsStringAsync(uri, {
+      encoding: FileSystem.EncodingType.Base64,
     });
-    const data = JSON.parse(contents);
+    const zip = await JSZip.loadAsync(base64, { base64: true });
+    const dataStr = await zip.file('data.json').async('string');
+    const data = JSON.parse(dataStr);
+
     if (Array.isArray(data.ingredients)) {
-      await saveAllIngredients(data.ingredients);
+      const list = [];
+      for (const ing of data.ingredients) {
+        let photoUri = null;
+        if (ing.photoUri && zip.file(ing.photoUri)) {
+          const imgBase64 = await zip.file(ing.photoUri).async('base64');
+          const dest = FileSystem.documentDirectory + ing.photoUri;
+          await FileSystem.makeDirectoryAsync(dirName(dest), {
+            intermediates: true,
+          });
+          await FileSystem.writeAsStringAsync(dest, imgBase64, {
+            encoding: FileSystem.EncodingType.Base64,
+          });
+          photoUri = dest;
+        }
+        list.push({ ...ing, photoUri });
+      }
+      await saveAllIngredients(list);
     }
+
     if (Array.isArray(data.cocktails)) {
-      await replaceAllCocktails(data.cocktails);
+      const list = [];
+      for (const c of data.cocktails) {
+        let photoUri = null;
+        if (c.photoUri && zip.file(c.photoUri)) {
+          const imgBase64 = await zip.file(c.photoUri).async('base64');
+          const dest = FileSystem.documentDirectory + c.photoUri;
+          await FileSystem.makeDirectoryAsync(dirName(dest), {
+            intermediates: true,
+          });
+          await FileSystem.writeAsStringAsync(dest, imgBase64, {
+            encoding: FileSystem.EncodingType.Base64,
+          });
+          photoUri = dest;
+        }
+        list.push({ ...c, photoUri });
+      }
+      await replaceAllCocktails(list);
     }
     return true;
   } catch (e) {


### PR DESCRIPTION
## Summary
- export cocktails and ingredients with photos to a ZIP archive
- import archive and restore photos and relationships
- add jszip dependency

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0f7db4d3c832692ae1261fd2b8c5c