### PR TITLE
Ensure cocktail details screen respects keep-awake setting

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -167,8 +167,6 @@ export default function CocktailDetailsScreen() {
   const [loading, setLoading] = useState(true);
   const [showImperial, setShowImperial] = useState(false);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
-  const [keepAwake, setKeepAwake] = useState(false);
-
   const handleGoBack = useCallback(() => {
     goBack(navigation);
   }, [navigation]);
@@ -269,24 +267,24 @@ export default function CocktailDetailsScreen() {
       (async () => {
         try {
           const enabled = await getKeepAwake();
-          setKeepAwake(!!enabled);
+          if (enabled) {
+            activateKeepAwakeAsync();
+          }
         } catch {}
       })();
-      const sub = addKeepAwakeListener(setKeepAwake);
+      const sub = addKeepAwakeListener((enabled) => {
+        if (enabled) {
+          activateKeepAwakeAsync();
+        } else {
+          deactivateKeepAwake();
+        }
+      });
       return () => {
         sub.remove();
         deactivateKeepAwake();
       };
     }, [])
   );
-
-  useEffect(() => {
-    if (keepAwake) {
-      activateKeepAwakeAsync();
-    } else {
-      deactivateKeepAwake();
-    }
-  }, [keepAwake]);
 
   useEffect(() => {
     const sub = addIgnoreGarnishListener(setIgnoreGarnish);


### PR DESCRIPTION
## Summary
- keep the device awake on the cocktail details screen when "Keep screen awake" is enabled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1fb3233b883268c5a47a3399a6fe6