### PR TITLE
Fix ingredient detail back navigation in MyCocktails screen

### DIFF
--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -227,10 +227,7 @@ export default function MyCocktailsScreen() {
 
   const handleIngredientPress = useCallback(
     (id) => {
-      navigation.navigate("Ingredients", {
-        screen: "IngredientDetails",
-        params: { id },
-      });
+      navigation.navigate("IngredientDetails", { id });
     },
     [navigation]
   );


### PR DESCRIPTION
## Summary
- fix unhandled POP error when leaving ingredient details from MyCocktails by navigating within same stack

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1ffbed20c8326a7a1dfa7290640a5