### PR TITLE
Add expandable description for ingredient and cocktail details

### DIFF
--- a/src/components/ExpandableText.js
+++ b/src/components/ExpandableText.js
@@ -1,0 +1,42 @@
+import React, { useCallback, useState } from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { useTheme } from "react-native-paper";
+
+export default function ExpandableText({ text, numberOfLines = 4, style }) {
+  const theme = useTheme();
+  const [expanded, setExpanded] = useState(false);
+  const [showToggle, setShowToggle] = useState(false);
+
+  const onTextLayout = useCallback(
+    (e) => {
+      setShowToggle(e.nativeEvent.lines.length > numberOfLines);
+    },
+    [numberOfLines]
+  );
+
+  const toggle = () => setExpanded((prev) => !prev);
+
+  return (
+    <View>
+      <Text
+        onTextLayout={onTextLayout}
+        numberOfLines={expanded ? undefined : numberOfLines}
+        style={style}
+      >
+        {text}
+      </Text>
+      {showToggle ? (
+        <TouchableOpacity onPress={toggle} hitSlop={{ top: 8, bottom: 8 }}>
+          <Text style={[style, styles.toggle, { color: theme.colors.primary }]}>
+            {expanded ? "Show less" : "Show more"}
+          </Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  toggle: { marginTop: 4 },
+});
+

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -39,6 +39,7 @@ import {
   addKeepAwakeListener,
 } from "../../storage/settingsStorage";
 import { activateKeepAwakeAsync, deactivateKeepAwake } from "expo-keep-awake";
+import ExpandableText from "../../components/ExpandableText";
 
 /* ---------- helpers ---------- */
 const withAlpha = (hex, alpha) => {
@@ -483,14 +484,10 @@ export default function CocktailDetailsScreen() {
 
         {cocktail.description ? (
           <View style={styles.section}>
-            <Text
-              style={[
-                styles.sectionText,
-                { color: theme.colors.onSurfaceVariant },
-              ]}
-            >
-              {cocktail.description}
-            </Text>
+            <ExpandableText
+              text={cocktail.description}
+              style={[styles.sectionText, { color: theme.colors.onSurfaceVariant }]}
+            />
           </View>
         ) : null}
 

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -44,6 +44,7 @@ import {
 import useIngredientsData from "../../hooks/useIngredientsData";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
+import ExpandableText from "../../components/ExpandableText";
 
 const PHOTO_SIZE = 100;
 const THUMB = 40;
@@ -509,14 +510,10 @@ export default function IngredientDetailsScreen() {
 
       {ingredient.description ? (
         <View style={styles.section}>
-          <Text
-            style={[
-              styles.sectionText,
-              { color: theme.colors.onSurfaceVariant },
-            ]}
-          >
-            {ingredient.description}
-          </Text>
+          <ExpandableText
+            text={ingredient.description}
+            style={[styles.sectionText, { color: theme.colors.onSurfaceVariant }]}
+          />
         </View>
       ) : null}
 


### PR DESCRIPTION
## Summary
- add reusable `ExpandableText` component
- limit ingredient description to 4 lines with expand/collapse
- limit cocktail description to 4 lines with expand/collapse

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a20461b8b48326916323d03acde284