### PR TITLE
fix ripple reference in AddIngredientScreen

### DIFF
--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -72,7 +72,6 @@ const withAlpha = (hex, alpha) => {
 /* -------------- pills for tags (memo) -------------- */
 const TagPill = memo(function TagPill({ id, name, color, onToggle }) {
   const theme = useTheme();
-  const RIPPLE = { color: withAlpha(theme.colors.onSurface, 0.12) };
   return (
     <Pressable
       onPress={() => onToggle(id)}
@@ -119,6 +118,7 @@ const BaseRow = memo(function BaseRow({ id, name, photoUri, onSelect }) {
 
 export default function AddIngredientScreen() {
   const theme = useTheme();
+  const RIPPLE = { color: withAlpha(theme.colors.onSurface, 0.12) };
   const navigation = useNavigation();
   const route = useRoute();
   const isFocused = useIsFocused();


### PR DESCRIPTION
## Summary
- define RIPPLE constant inside AddIngredientScreen to avoid ReferenceError when opening ingredient addition screen
- clean up unused constant in TagPill

## Testing
- `npm test` *(fails: missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a208328c808326972829ee7174420e