### PR TITLE
Reset ingredients tab on blur

### DIFF
--- a/App.js
+++ b/App.js
@@ -100,6 +100,7 @@ function Tabs() {
       <Tab.Screen
         name="Ingredients"
         component={IngredientsTabsScreen}
+        options={{ unmountOnBlur: true }}
         listeners={({ navigation }) => ({
           tabPress: () => {
             const saved =

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -23,6 +23,7 @@ import {
   useNavigation,
   useRoute,
   useFocusEffect,
+  CommonActions,
 } from "@react-navigation/native";
 import { goBack } from "../../utils/navigation";
 
@@ -194,7 +195,9 @@ export default function IngredientDetailsScreen() {
       if (e.data.action.type === "NAVIGATE") return;
       e.preventDefault();
       sub();
-      navigation.dispatch(e.data.action);
+      navigation.dispatch(
+        CommonActions.reset({ index: 0, routes: [{ name: "IngredientsMain" }] })
+      );
       navigation.navigate("Cocktails", {
         screen: returnTo,
         params: {


### PR DESCRIPTION
## Summary
- reset the Ingredients tab when switching away so residual screens like EditCocktail don’t persist

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a2111096f08326ac54015db709cbce