### PR TITLE
Show cocktail details after creation and fix back navigation

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1421,7 +1421,14 @@ export default function AddCocktailScreen() {
     const nextUsage = addCocktailToUsageMap(usageMap, ingredients, created);
     setUsageMap(nextUsage);
     setIngredients(applyUsageMapToIngredients(ingredients, nextUsage, nextCocktails));
-    navigation.replace("CocktailsMain", { screen: lastCocktailsTab });
+    if (fromIngredientFlow) {
+      navigation.replace("CocktailDetails", {
+        id: created.id,
+        backToIngredientId: initialIngredient?.id,
+      });
+    } else {
+      navigation.replace("CocktailDetails", { id: created.id });
+    }
   }, [
     name,
     photoUri,
@@ -1437,7 +1444,8 @@ export default function AddCocktailScreen() {
     setUsageMap,
     setIngredients,
     navigation,
-    lastCocktailsTab,
+    fromIngredientFlow,
+    initialIngredient?.id,
   ]);
 
   const selectedGlass = getGlassById(glassId) || { name: "Cocktail glass" };

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -21,6 +21,7 @@ import {
   useNavigation,
   useRoute,
   useFocusEffect,
+  StackActions,
 } from "@react-navigation/native";
 import { goBack } from "../../utils/navigation";
 import { useTheme } from "react-native-paper";
@@ -168,7 +169,7 @@ const IngredientRow = memo(function IngredientRow({
 
 export default function CocktailDetailsScreen() {
   const navigation = useNavigation();
-  const { id } = useRoute().params;
+  const { id, backToIngredientId } = useRoute().params;
   const theme = useTheme();
   const { ingredients: globalIngredients = [] } = useIngredientUsage();
 
@@ -181,8 +182,16 @@ export default function CocktailDetailsScreen() {
   const [keepAwake, setKeepAwake] = useState(false);
 
   const handleGoBack = useCallback(() => {
-    goBack(navigation);
-  }, [navigation]);
+    if (backToIngredientId != null) {
+      navigation.navigate("Ingredients", {
+        screen: "IngredientDetails",
+        params: { id: backToIngredientId },
+      });
+      navigation.dispatch(StackActions.pop(1));
+    } else {
+      goBack(navigation);
+    }
+  }, [navigation, backToIngredientId]);
 
   const handleEdit = useCallback(() => {
     navigation.navigate("EditCocktail", { id });
@@ -234,12 +243,12 @@ export default function CocktailDetailsScreen() {
   useFocusEffect(
     useCallback(() => {
       const onBack = () => {
-        goBack(navigation);
+        handleGoBack();
         return true;
       };
       const sub = BackHandler.addEventListener("hardwareBackPress", onBack);
       return () => sub.remove();
-    }, [navigation])
+    }, [handleGoBack])
   );
 
   const load = useCallback(


### PR DESCRIPTION
## Summary
- Navigate to cocktail details after saving a new cocktail
- Return from details either to ingredient or cocktails list depending on creation origin

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a21e9c50188326819a282ab7a8326b