### PR TITLE
feat: add global ingredient substitutions option

### DIFF
--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -34,6 +34,8 @@ import {
   getTabsOnTop,
   setTabsOnTop as saveTabsOnTop,
   addTabsOnTopListener,
+  getAllowSubstitutes,
+  setAllowSubstitutes as saveAllowSubstitutes,
 } from "../storage/settingsStorage";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
@@ -101,6 +103,7 @@ export default function GeneralMenu({ visible, onClose }) {
   const [useMetric, setUseMetric] = useState(true);
   const [keepAwake, setKeepAwake] = useState(false);
   const [tabsOnTop, setTabsOnTop] = useState(true);
+  const [allowSubstitutes, setAllowSubstitutes] = useState(false);
   const [tagsVisible, setTagsVisible] = useState(false);
   const [cocktailTagsVisible, setCocktailTagsVisible] = useState(false);
   const [ratingVisible, setRatingVisible] = useState(false);
@@ -178,6 +181,12 @@ export default function GeneralMenu({ visible, onClose }) {
     })();
     (async () => {
       try {
+        const stored = await getAllowSubstitutes();
+        setAllowSubstitutes(!!stored);
+      } catch {}
+    })();
+    (async () => {
+      try {
         const stored = await getKeepAwake();
         setKeepAwake(!!stored);
       } catch {}
@@ -214,6 +223,15 @@ export default function GeneralMenu({ visible, onClose }) {
     setIgnoreGarnish((v) => {
       const next = !v;
       saveIgnoreGarnish(next);
+      return next;
+    });
+  };
+
+  const toggleAllowSubstitutes = () => {
+    setAllowSubstitutes((v) => {
+      const next = !v;
+      saveAllowSubstitutes(next);
+      refresh?.();
       return next;
     });
   };
@@ -267,6 +285,22 @@ export default function GeneralMenu({ visible, onClose }) {
                 <Pressable style={styles.itemText} onPress={toggleIgnoreGarnish}>
                   <Text style={styles.itemTitle}>Ignore garnishes</Text>
                   <Text style={styles.itemSub}>All garnishes are optional</Text>
+                </Pressable>
+              </View>
+
+              <View style={styles.itemRow}>
+                <Checkbox
+                  status={allowSubstitutes ? "checked" : "unchecked"}
+                  onPress={toggleAllowSubstitutes}
+                />
+                <Pressable
+                  style={styles.itemText}
+                  onPress={toggleAllowSubstitutes}
+                >
+                  <Text style={styles.itemTitle}>Allow ingredient substitutes</Text>
+                  <Text style={styles.itemSub}>
+                    Use base or branded alternatives regardless of recipe
+                  </Text>
                 </Pressable>
               </View>
 

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -63,6 +63,7 @@ import {
   addCocktailToUsageMap,
   applyUsageMapToIngredients,
 } from "../../utils/ingredientUsage";
+import { getAllowSubstitutes } from "../../storage/settingsStorage";
 
 
 /* ---------- helpers ---------- */
@@ -1418,7 +1419,10 @@ export default function AddCocktailScreen() {
     const created = await addCocktail(cocktail);
     const nextCocktails = [...cocktails, created];
     setCocktails(nextCocktails);
-    const nextUsage = addCocktailToUsageMap(usageMap, ingredients, created);
+    const allowSubs = await getAllowSubstitutes();
+    const nextUsage = addCocktailToUsageMap(usageMap, ingredients, created, {
+      allowSubstitutes: !!allowSubs,
+    });
     setUsageMap(nextUsage);
     setIngredients(applyUsageMapToIngredients(ingredients, nextUsage, nextCocktails));
     navigation.replace("CocktailsMain", { screen: lastCocktailsTab });

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -62,6 +62,7 @@ import {
   removeCocktailFromUsageMap,
   applyUsageMapToIngredients,
 } from "../../utils/ingredientUsage";
+import { getAllowSubstitutes } from "../../storage/settingsStorage";
 
 
 /* ---------- helpers ---------- */
@@ -1174,8 +1175,13 @@ export default function EditCocktailScreen() {
         c.id === updated.id ? updated : c
       );
       setCocktails(nextCocktails);
-      let nextUsage = removeCocktailFromUsageMap(usageMap, ingredients, prev);
-      nextUsage = addCocktailToUsageMap(nextUsage, ingredients, updated);
+      const allowSubs = await getAllowSubstitutes();
+      let nextUsage = removeCocktailFromUsageMap(usageMap, ingredients, prev, {
+        allowSubstitutes: !!allowSubs,
+      });
+      nextUsage = addCocktailToUsageMap(nextUsage, ingredients, updated, {
+        allowSubstitutes: !!allowSubs,
+      });
       setUsageMap(nextUsage);
       setIngredients(
         applyUsageMapToIngredients(ingredients, nextUsage, nextCocktails)
@@ -1960,10 +1966,12 @@ export default function EditCocktailScreen() {
           await deleteCocktail(cocktailId);
           const nextCocktails = cocktails.filter((c) => c.id !== cocktailId);
           setCocktails(nextCocktails);
+          const allowSubs = await getAllowSubstitutes();
           const nextUsage = removeCocktailFromUsageMap(
             usageMap,
             ingredients,
-            prev
+            prev,
+            { allowSubstitutes: !!allowSubs }
           );
           setUsageMap(nextUsage);
           setIngredients(

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -21,6 +21,8 @@ import {
 import {
   getIgnoreGarnish,
   addIgnoreGarnishListener,
+  getAllowSubstitutes,
+  addAllowSubstitutesListener,
 } from "../../storage/settingsStorage";
 import { useTheme } from "react-native-paper";
 import TagFilterMenu from "../../components/TagFilterMenu";
@@ -48,6 +50,7 @@ export default function MyCocktailsScreen() {
   const [selectedTagIds, setSelectedTagIds] = useState([]);
   const [availableTags, setAvailableTags] = useState([]);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
+  const [allowSubstitutes, setAllowSubstitutes] = useState(false);
   const { setIngredients: setGlobalIngredients } = useIngredientsData();
   const { cocktails: globalCocktails = [], ingredients: globalIngredients = [] } =
     useIngredientUsage();
@@ -82,24 +85,28 @@ export default function MyCocktailsScreen() {
         globalCocktails.length ? Promise.resolve(globalCocktails) : getAllCocktails();
       const ingredientPromise =
         globalIngredients.length ? Promise.resolve(globalIngredients) : getAllIngredients();
-      const [cocktailsList, ingredientsList, ig] = await Promise.all([
+      const [cocktailsList, ingredientsList, ig, allowSubs] = await Promise.all([
         cocktailPromise,
         ingredientPromise,
         getIgnoreGarnish(),
+        getAllowSubstitutes(),
       ]);
       if (cancel) return;
       setCocktails(Array.isArray(cocktailsList) ? cocktailsList : []);
       setIngredients(Array.isArray(ingredientsList) ? ingredientsList : []);
       setIgnoreGarnish(!!ig);
+      setAllowSubstitutes(!!allowSubs);
       if (firstLoad.current) {
         setLoading(false);
         firstLoad.current = false;
       }
     })();
-    const sub = addIgnoreGarnishListener(setIgnoreGarnish);
+    const subIg = addIgnoreGarnishListener(setIgnoreGarnish);
+    const subAs = addAllowSubstitutesListener(setAllowSubstitutes);
     return () => {
       cancel = true;
-      sub.remove();
+      subIg.remove();
+      subAs.remove();
     };
   }, [isFocused, globalCocktails, globalIngredients]);
 
@@ -133,12 +140,15 @@ export default function MyCocktailsScreen() {
         if (ing?.inBar) {
           used = ing;
         } else {
-          if (r.allowBaseSubstitution) {
+          if (allowSubstitutes || r.allowBaseSubstitution) {
             const base = ingMap.get(baseId);
             if (base?.inBar) used = base;
           }
           const isBaseIngredient = ing?.baseIngredientId == null;
-          if (!used && (r.allowBrandedSubstitutes || isBaseIngredient)) {
+          if (
+            !used &&
+            (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient)
+          ) {
             const brand = findBrand(baseId);
             if (brand) used = brand;
           }
@@ -181,7 +191,14 @@ export default function MyCocktailsScreen() {
         missingIngredientIds: missingIds,
       };
     });
-  }, [cocktails, ingredients, searchDebounced, selectedTagIds, ignoreGarnish]);
+  }, [
+    cocktails,
+    ingredients,
+    searchDebounced,
+    selectedTagIds,
+    ignoreGarnish,
+    allowSubstitutes,
+  ]);
 
   const { available, suggestions } = useMemo(() => {
     const avail = processed.filter((c) => c.isAllAvailable);

--- a/src/storage/settingsStorage.js
+++ b/src/storage/settingsStorage.js
@@ -6,11 +6,13 @@ const IGNORE_GARNISH_KEY = "ignoreGarnish";
 const KEEP_AWAKE_KEY = "keepAwake";
 const FAVORITES_MIN_RATING_KEY = "favoritesMinRating";
 const TABS_ON_TOP_KEY = "tabsOnTop";
+const ALLOW_SUBSTITUTES_KEY = "allowSubstitutes";
 
 export const IGNORE_GARNISH_EVENT = "ignoreGarnishChanged";
 export const KEEP_AWAKE_EVENT = "keepAwakeChanged";
 export const FAVORITES_MIN_RATING_EVENT = "favoritesMinRatingChanged";
 export const TABS_ON_TOP_EVENT = "tabsOnTopChanged";
+export const ALLOW_SUBSTITUTES_EVENT = "allowSubstitutesChanged";
 
 export async function getUseMetric() {
   try {
@@ -47,6 +49,27 @@ export async function setIgnoreGarnish(value) {
 
 export function addIgnoreGarnishListener(listener) {
   return DeviceEventEmitter.addListener(IGNORE_GARNISH_EVENT, listener);
+}
+
+export async function getAllowSubstitutes() {
+  try {
+    const value = await AsyncStorage.getItem(ALLOW_SUBSTITUTES_KEY);
+    if (value === null) return false;
+    return value === "true";
+  } catch {
+    return false;
+  }
+}
+
+export async function setAllowSubstitutes(value) {
+  try {
+    await AsyncStorage.setItem(ALLOW_SUBSTITUTES_KEY, value ? "true" : "false");
+  } catch {}
+  DeviceEventEmitter.emit(ALLOW_SUBSTITUTES_EVENT, value);
+}
+
+export function addAllowSubstitutesListener(listener) {
+  return DeviceEventEmitter.addListener(ALLOW_SUBSTITUTES_EVENT, listener);
 }
 
 export async function getKeepAwake() {

--- a/src/utils/ingredientUsage.js
+++ b/src/utils/ingredientUsage.js
@@ -1,4 +1,5 @@
-export function mapCocktailsByIngredient(ingredients, cocktails) {
+export function mapCocktailsByIngredient(ingredients, cocktails, options = {}) {
+  const { allowSubstitutes = false } = options;
   const byId = new Map(ingredients.map((i) => [i.id, i]));
   const byBase = new Map();
   ingredients.forEach((i) => {
@@ -38,7 +39,7 @@ export function mapCocktailsByIngredient(ingredients, cocktails) {
       } else {
         // branded ingredient used: base ingredient always counts
         add(baseId, c.id);
-        if (r.allowBrandedSubstitutes) {
+        if (allowSubstitutes || r.allowBrandedSubstitutes) {
           group.forEach((item) => {
             if (item.id !== ing.id && item.id !== baseId) add(item.id, c.id);
           });
@@ -60,8 +61,8 @@ export function mapCocktailsByIngredient(ingredients, cocktails) {
   return result;
 }
 
-export function calculateIngredientUsage(ingredients, cocktails) {
-  const map = mapCocktailsByIngredient(ingredients, cocktails);
+export function calculateIngredientUsage(ingredients, cocktails, options = {}) {
+  const map = mapCocktailsByIngredient(ingredients, cocktails, options);
   const result = {};
   ingredients.forEach((i) => {
     const arr = map[i.id];
@@ -71,8 +72,8 @@ export function calculateIngredientUsage(ingredients, cocktails) {
 }
 
 export function updateUsageMap(prevMap, ingredients, cocktails, options = {}) {
-  const { changedIngredientIds = [], changedCocktailIds = [] } = options;
-  const fullMap = mapCocktailsByIngredient(ingredients, cocktails);
+  const { changedIngredientIds = [], changedCocktailIds = [], allowSubstitutes = false } = options;
+  const fullMap = mapCocktailsByIngredient(ingredients, cocktails, { allowSubstitutes });
   if (
     changedIngredientIds.length === 0 &&
     changedCocktailIds.length === 0
@@ -95,7 +96,8 @@ export function updateUsageMap(prevMap, ingredients, cocktails, options = {}) {
   return next;
 }
 
-export function addCocktailToUsageMap(prevMap, ingredients, cocktail) {
+export function addCocktailToUsageMap(prevMap, ingredients, cocktail, options = {}) {
+  const { allowSubstitutes = false } = options;
   const map = { ...prevMap };
   const byId = new Map(ingredients.map((i) => [i.id, i]));
   const byBase = new Map();
@@ -128,7 +130,7 @@ export function addCocktailToUsageMap(prevMap, ingredients, cocktail) {
         });
       } else {
         add(baseId);
-        if (r.allowBrandedSubstitutes) {
+        if (allowSubstitutes || r.allowBrandedSubstitutes) {
           group.forEach((item) => {
             if (item.id !== ing.id && item.id !== baseId) add(item.id);
           });
@@ -143,7 +145,8 @@ export function addCocktailToUsageMap(prevMap, ingredients, cocktail) {
   return map;
 }
 
-export function removeCocktailFromUsageMap(prevMap, ingredients, cocktail) {
+export function removeCocktailFromUsageMap(prevMap, ingredients, cocktail, options = {}) {
+  const { allowSubstitutes = false } = options;
   const map = { ...prevMap };
   if (!cocktail) return map;
   const byId = new Map(ingredients.map((i) => [i.id, i]));
@@ -177,7 +180,7 @@ export function removeCocktailFromUsageMap(prevMap, ingredients, cocktail) {
         });
       } else {
         remove(baseId);
-        if (r.allowBrandedSubstitutes) {
+        if (allowSubstitutes || r.allowBrandedSubstitutes) {
           group.forEach((item) => {
             if (item.id !== ing.id && item.id !== baseId) remove(item.id);
           });


### PR DESCRIPTION
## Summary
- add "Allow ingredient substitutes" setting to main menu
- persist and broadcast substitute preference in settings storage
- consider global base/brand substitutes when checking cocktail availability

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a21f891b5c8326bf6e91c4fe2e16fc