### PR TITLE
Resize cocktail and ingredient photos to 150px

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1923,7 +1923,7 @@ export default function AddCocktailScreen() {
 }
 
 /* ---------- styles ---------- */
-const IMAGE_SIZE = 100;
+const IMAGE_SIZE = 150;
 
 const styles = StyleSheet.create({
   container: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 40 },

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -561,7 +561,7 @@ const styles = StyleSheet.create({
   loadingContainer: { flex: 1, justifyContent: "center", alignItems: "center" },
   headerBackBtn: { paddingHorizontal: 8, paddingVertical: 4 },
   headerEditBtn: { paddingHorizontal: 8, paddingVertical: 4 },
-  photo: { width: 100, height: 100, marginTop: 12, alignSelf: "center" },
+  photo: { width: 150, height: 150, marginTop: 12, alignSelf: "center" },
   title: {
     fontSize: 22,
     fontWeight: "bold",

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -2018,7 +2018,7 @@ export default function EditCocktailScreen() {
 }
 
 /* ---------- styles ---------- */
-const IMAGE_SIZE = 100;
+const IMAGE_SIZE = 150;
 
 const styles = StyleSheet.create({
   container: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 40 },

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -58,7 +58,7 @@ const useDebounced = (value, delay = 300) => {
   return v;
 };
 
-const IMAGE_SIZE = 100;
+const IMAGE_SIZE = 150;
 const MENU_ROW_HEIGHT = 56;
 
 const withAlpha = (hex, alpha) => {

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -58,7 +58,7 @@ const useDebounced = (value, delay = 300) => {
   return v;
 };
 
-const IMAGE_SIZE = 100;
+const IMAGE_SIZE = 150;
 const MENU_ROW_HEIGHT = 56;
 
 // pills for tags (memo, стабільний onPress через id)

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -49,7 +49,7 @@ import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
 import ExpandableText from "../../components/ExpandableText";
 
-const PHOTO_SIZE = 100;
+const PHOTO_SIZE = 150;
 const THUMB = 40;
 
 /** Gray-square photo (no icon/initials), uses theme */


### PR DESCRIPTION
## Summary
- Enlarge cocktail detail photo to 150×150, matching glass placeholder
- Increase ingredient detail photo size to 150×150
- Upscale add/edit form image placeholders for cocktails and ingredients to 150×150

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a22a21140c8326833e24b96b77c40a