### PR TITLE
Enable branded ingredient substitutions when allowed

### DIFF
--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -231,9 +231,9 @@ export default function GeneralMenu({ visible, onClose }) {
     setAllowSubstitutes((v) => {
       const next = !v;
       saveAllowSubstitutes(next);
-      refresh?.();
       return next;
     });
+    refresh?.();
   };
 
   const toggleKeepAwake = () => {

--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -127,6 +127,7 @@ export default function AllCocktailsScreen() {
       const missing = [];
       const ingredientNames = [];
       let allAvail = required.length > 0;
+      let branded = false;
       for (const r of required) {
         const ing = ingMap.get(String(r.ingredientId));
         const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
@@ -158,16 +159,14 @@ export default function AllCocktailsScreen() {
         }
         if (used) {
           ingredientNames.push(used.name);
+          if (used.baseIngredientId != null) branded = true;
         } else {
+          if (ing?.baseIngredientId != null) branded = true;
           const missingName = ing?.name || r.name || "";
           if (missingName) missing.push(missingName);
           allAvail = false;
         }
       }
-      const branded = (c.ingredients || []).some((r) => {
-        const ing = ingMap.get(String(r.ingredientId));
-        return ing && ing.baseIngredientId != null;
-      });
       let ingredientLine = ingredientNames.join(", ");
       if (!allAvail) {
         if (missing.length > 0 && missing.length <= 2) {

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -137,6 +137,7 @@ export default function FavoriteCocktailsScreen() {
       const missing = [];
       const ingredientNames = [];
       let allAvail = required.length > 0;
+      let branded = false;
       for (const r of required) {
         const ing = ingMap.get(String(r.ingredientId));
         const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
@@ -168,16 +169,14 @@ export default function FavoriteCocktailsScreen() {
         }
         if (used) {
           ingredientNames.push(used.name);
+          if (used.baseIngredientId != null) branded = true;
         } else {
+          if (ing?.baseIngredientId != null) branded = true;
           const missingName = ing?.name || r.name || "";
           if (missingName) missing.push(missingName);
           allAvail = false;
         }
       }
-      const branded = (c.ingredients || []).some((r) => {
-        const ing = ingMap.get(String(r.ingredientId));
-        return ing && ing.baseIngredientId != null;
-      });
       let ingredientLine = ingredientNames.join(", ");
       if (!allAvail) {
         if (missing.length > 0 && missing.length <= 2) {

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -133,6 +133,7 @@ export default function MyCocktailsScreen() {
       const missingIds = [];
       const ingredientNames = [];
       let allAvail = required.length > 0;
+      let branded = false;
       for (const r of required) {
         const ing = ingMap.get(String(r.ingredientId));
         const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
@@ -164,17 +165,15 @@ export default function MyCocktailsScreen() {
         }
         if (used) {
           ingredientNames.push(used.name);
+          if (used.baseIngredientId != null) branded = true;
         } else {
+          if (ing?.baseIngredientId != null) branded = true;
           const missingName = ing?.name || r.name || "";
           if (missingName) missingNames.push(missingName);
           missingIds.push(baseId);
           allAvail = false;
         }
       }
-      const branded = (c.ingredients || []).some((r) => {
-        const ing = ingMap.get(String(r.ingredientId));
-        return ing && ing.baseIngredientId != null;
-      });
       let ingredientLine = ingredientNames.join(", ");
       if (!allAvail) {
         if (missingNames.length > 0 && missingNames.length <= 2) {

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -276,6 +276,7 @@ export default function IngredientDetailsScreen() {
         const missing = [];
         const ingredientNames = [];
         let allAvail = required.length > 0;
+        let branded = false;
         for (const r of required) {
           const ing = ingMap.get(String(r.ingredientId));
           const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
@@ -307,16 +308,14 @@ export default function IngredientDetailsScreen() {
           }
           if (used) {
             ingredientNames.push(used.name);
+            if (used.baseIngredientId != null) branded = true;
           } else {
+            if (ing?.baseIngredientId != null) branded = true;
             const missingName = ing?.name || r.name || "";
             if (missingName) missing.push(missingName);
             allAvail = false;
           }
         }
-        const branded = (c.ingredients || []).some((r) => {
-          const ing = ingMap.get(String(r.ingredientId));
-          return ing && ing.baseIngredientId != null;
-        });
         let ingredientLine = ingredientNames.join(", ");
         if (!allAvail) {
           if (missing.length > 0 && missing.length <= 2) {

--- a/src/screens/ShakerResultsScreen.js
+++ b/src/screens/ShakerResultsScreen.js
@@ -66,6 +66,7 @@ export default function ShakerResultsScreen({ route, navigation }) {
         const missing = [];
         const ingredientNames = [];
         let allAvail = required.length > 0;
+        let branded = false;
         for (const r of required) {
           const ing = ingMap.get(String(r.ingredientId));
           const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
@@ -97,16 +98,14 @@ export default function ShakerResultsScreen({ route, navigation }) {
           }
           if (used) {
             ingredientNames.push(used.name);
+            if (used.baseIngredientId != null) branded = true;
           } else {
+            if (ing?.baseIngredientId != null) branded = true;
             const missingName = ing?.name || r.name || "";
             if (missingName) missing.push(missingName);
             allAvail = false;
           }
         }
-        const branded = (c.ingredients || []).some((r) => {
-          const ing = ingMap.get(String(r.ingredientId));
-          return ing && ing.baseIngredientId != null;
-        });
         let ingredientLine = ingredientNames.join(", ");
         if (!allAvail) {
           if (missing.length > 0 && missing.length <= 2) {


### PR DESCRIPTION
## Summary
- Track whether any branded ingredients are used when computing recipe availability
- Mark cocktails as branded when a branded substitute is selected

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a235735da88326ad7c5282e3f6ceb2