### PR TITLE
Keep ingredient suggestions open when exact match

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -287,14 +287,22 @@ const IngredientRow = memo(function IngredientRow({
     const match = allIngredients.find(
       (i) => collator.compare((i.name || "").trim(), q) === 0
     );
-    if (match) {
+    if (match && suggestions.length <= 1) {
       onChange({
         selectedId: match.id,
         selectedItem: match,
         name: match.name,
       });
     }
-  }, [query, debounced, row.selectedId, allIngredients, collator, onChange]);
+  }, [
+    query,
+    debounced,
+    row.selectedId,
+    allIngredients,
+    collator,
+    suggestions.length,
+    onChange,
+  ]);
 
   const hasExactMatch = useMemo(() => {
     const t = query.trim();

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -286,14 +286,22 @@ const IngredientRow = memo(function IngredientRow({
     const match = allIngredients.find(
       (i) => collator.compare((i.name || "").trim(), q) === 0
     );
-    if (match) {
+    if (match && suggestions.length <= 1) {
       onChange({
         selectedId: match.id,
         selectedItem: match,
         name: match.name,
       });
     }
-  }, [query, debounced, row.selectedId, allIngredients, collator, onChange]);
+  }, [
+    query,
+    debounced,
+    row.selectedId,
+    allIngredients,
+    collator,
+    suggestions.length,
+    onChange,
+  ]);
 
   const hasExactMatch = useMemo(() => {
     const t = query.trim();


### PR DESCRIPTION
## Summary
- Avoid auto-selecting an ingredient when the query has an exact match but also longer ingredient names, keeping the dropdown open
- Apply the same behavior on cocktail add and edit screens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")

------
https://chatgpt.com/codex/tasks/task_e_68a257a59dd48326b4961a7b7c55cee5