### PR TITLE
Highlight available garnishes in cocktail details

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -333,8 +333,8 @@ export default function CocktailDetailsScreen() {
     return list.map((r) => {
       const ing = r.ingredientId ? ingMap.get(r.ingredientId) : null;
       const originalName = ing?.name || r.name;
-      const ignored = ignoreGarnish && r.garnish;
-      const inBar = ignored ? false : ing?.inBar;
+      const inBar = ing?.inBar;
+      const ignored = ignoreGarnish && r.garnish && !inBar;
       let substitute = null;
       if (!inBar && ing && !ignored) {
         const baseId = ing.baseIngredientId ?? ing.id;


### PR DESCRIPTION
## Summary
- Ensure cocktail detail screen highlights garnishes when they are in stock
- Treat only missing garnishes as optional when the ignore setting is enabled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a25d9030d48326b8b3e608284c2b11