### PR TITLE
Reset ingredient selection on query change

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -296,6 +296,13 @@ const IngredientRow = memo(function IngredientRow({
     }
   }, [query, debounced, row.selectedId, allIngredients, collator, onChange]);
 
+  useEffect(() => {
+    if (!row.selectedId) return;
+    if (query.trim() !== row.selectedItem?.name) {
+      onChange({ selectedId: null, selectedItem: null });
+    }
+  }, [query, row.selectedId, row.selectedItem?.name, onChange]);
+
   const hasExactMatch = useMemo(() => {
     const t = query.trim();
     if (!t) return true;


### PR DESCRIPTION
## Summary
- clear selected ingredient when the typed name no longer matches it
- keep exact-match auto-binding only when no ingredient is selected

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a2742660ac8326a72e1e757d510437