### PR TITLE
Keep ingredient suggestions visible after auto-match

### DIFF
--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -213,7 +213,7 @@ const IngredientRow = memo(function IngredientRow({
   });
   const [openedFor, setOpenedFor] = useState(null);
 
-  const showSuggest = debounced.trim().length >= MIN_CHARS && !row.selectedId;
+  const showSuggest = debounced.trim().length >= MIN_CHARS;
 
   const suggestions = useMemo(() => {
     if (!showSuggest) return [];
@@ -294,6 +294,13 @@ const IngredientRow = memo(function IngredientRow({
       });
     }
   }, [query, debounced, row.selectedId, allIngredients, collator, onChange]);
+
+  useEffect(() => {
+    if (!row.selectedId) return;
+    const q = query.trim();
+    if (q === (row.selectedItem?.name || '').trim()) return;
+    onChange({ selectedId: null, selectedItem: null });
+  }, [query, row.selectedId, row.selectedItem?.name, onChange]);
 
   const hasExactMatch = useMemo(() => {
     const t = query.trim();
@@ -1145,17 +1152,19 @@ export default function EditCocktailScreen() {
         return;
       }
 
-      const cocktail = {
-        id: cocktailId,
-        name: title,
-        photoUri: photoUri || null,
-        tags,
-        description: description.trim(),
-        instructions: instructions.trim(),
-        glassId,
-        ingredients: nonEmptyIngredients.map((r, idx) => ({
+      const collator = new Intl.Collator("uk", { sensitivity: "base" });
+      const mappedIngredients = nonEmptyIngredients.map((r, idx) => {
+        let ingredientId = r.selectedId;
+        if (!ingredientId) {
+          const match = allIngredients.find(
+            (i) =>
+              collator.compare((i.name || "").trim(), r.name.trim()) === 0
+          );
+          if (match) ingredientId = match.id;
+        }
+        return {
           order: idx + 1,
-          ingredientId: r.selectedId,
+          ingredientId,
           name: r.name.trim(),
           quantity: r.quantity.trim(),
           unitId: r.unitId,
@@ -1164,7 +1173,18 @@ export default function EditCocktailScreen() {
           allowBaseSubstitute: !!r.allowBaseSubstitute,
           allowBrandedSubstitutes: !!r.allowBrandedSubstitutes,
           substitutes: r.substitutes || [],
-        })),
+        };
+      });
+
+      const cocktail = {
+        id: cocktailId,
+        name: title,
+        photoUri: photoUri || null,
+        tags,
+        description: description.trim(),
+        instructions: instructions.trim(),
+        glassId,
+        ingredients: mappedIngredients,
         rating: ratingRef.current,
         createdAt: createdAtRef.current,
       };


### PR DESCRIPTION
## Summary
- Show ingredient suggestions even when an ingredient is auto-selected
- Clear `selectedId` when user edits after an auto-match
- Auto-link ingredients by name on save if an exact match exists

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a26fbcef5c832694066f440498fbbf