### PR TITLE
Keep ingredient suggestions visible until selection

### DIFF
--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -213,7 +213,7 @@ const IngredientRow = memo(function IngredientRow({
   });
   const [openedFor, setOpenedFor] = useState(null);
 
-  const showSuggest = debounced.trim().length >= MIN_CHARS && !row.selectedId;
+  const showSuggest = debounced.trim().length >= MIN_CHARS;
 
   const suggestions = useMemo(() => {
     if (!showSuggest) return [];
@@ -275,25 +275,6 @@ const IngredientRow = memo(function IngredientRow({
     return () => sub?.remove?.();
   }, [suggestState.visible, recalcPlacement]);
 
-  // авто-бінд по exact match
-  useEffect(() => {
-    const raw = query;
-    const stable = debounced;
-    if (!raw || row.selectedId) return;
-    if (raw !== stable) return;
-    const q = raw.trim();
-    if (!q) return;
-    const match = allIngredients.find(
-      (i) => collator.compare((i.name || "").trim(), q) === 0
-    );
-    if (match) {
-      onChange({
-        selectedId: match.id,
-        selectedItem: match,
-        name: match.name,
-      });
-    }
-  }, [query, debounced, row.selectedId, allIngredients, collator, onChange]);
 
   const hasExactMatch = useMemo(() => {
     const t = query.trim();
@@ -1139,7 +1120,19 @@ export default function EditCocktailScreen() {
         Alert.alert("Validation", "Please enter a cocktail name.");
         return;
       }
-      const nonEmptyIngredients = ings.filter((r) => r.name.trim().length > 0);
+      const nonEmptyIngredients = ings
+        .filter((r) => r.name.trim().length > 0)
+        .map((r) => {
+          if (!r.selectedId) {
+            const match = allIngredients.find(
+              (i) => normalizeUk(i.name).trim() === normalizeUk(r.name).trim()
+            );
+            if (match) {
+              return { ...r, selectedId: match.id };
+            }
+          }
+          return r;
+        });
       if (nonEmptyIngredients.length === 0) {
         Alert.alert("Validation", "Please add at least one ingredient.");
         return;


### PR DESCRIPTION
## Summary
- Keep ingredient suggestions open until user picks an item by removing automatic selection on exact match
- Auto-resolve ingredient IDs on save when the typed name exactly matches an existing ingredient

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a278bc6a64832691b0760591648f78