### PR TITLE
Wrap + Add button inside ingredient input

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -523,27 +523,27 @@ const IngredientRow = memo(function IngredientRow({
             ]}
             returnKeyType="done"
           />
-        </View>
 
-        {showAddNewBtn ? (
-          <Pressable
-            onPress={() => onAddNewIngredient(query.trim())}
-            android_ripple={{
-              color: withAlpha(theme.colors.tertiary, 0.2),
-              borderless: true,
-            }}
-            style={styles.addInlineBtn}
-            accessibilityLabel="Add new ingredient"
-          >
-            <MaterialIcons name="add" size={18} color={theme.colors.primary} />
-            <Text
-              numberOfLines={1}
-              style={{ color: theme.colors.primary, fontWeight: "600" }}
+          {showAddNewBtn ? (
+            <Pressable
+              onPress={() => onAddNewIngredient(query.trim())}
+              android_ripple={{
+                color: withAlpha(theme.colors.tertiary, 0.2),
+                borderless: true,
+              }}
+              style={styles.addInlineBtn}
+              accessibilityLabel="Add new ingredient"
             >
-              Add
-            </Text>
-          </Pressable>
-        ) : null}
+              <MaterialIcons name="add" size={18} color={theme.colors.primary} />
+              <Text
+                numberOfLines={1}
+                style={{ color: theme.colors.primary, fontWeight: "600" }}
+              >
+                Add
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
       </View>
 
       {/* Suggest dropdown */}
@@ -1997,6 +1997,7 @@ const styles = StyleSheet.create({
   nameInputWrap: {
     flex: 1,
     minWidth: 0,
+    position: "relative",
   },
 
   input: {
@@ -2007,7 +2008,9 @@ const styles = StyleSheet.create({
     marginTop: 8,
   },
 
-  nameInput: {},
+  nameInput: {
+    paddingRight: 72,
+  },
 
   multiline: { minHeight: 80, textAlignVertical: "top" },
 
@@ -2142,6 +2145,10 @@ const styles = StyleSheet.create({
   },
 
   addInlineBtn: {
+    position: "absolute",
+    right: 8,
+    top: "50%",
+    transform: [{ translateY: "-50%" }],
     flexDirection: "row",
     alignItems: "center",
     gap: 6,

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -525,27 +525,27 @@ const IngredientRow = memo(function IngredientRow({
             ]}
             returnKeyType="done"
           />
-        </View>
 
-        {showAddNewBtn ? (
-          <Pressable
-            onPress={() => onAddNewIngredient(query.trim())}
-            android_ripple={{
-              color: withAlpha(theme.colors.tertiary, 0.2),
-              borderless: true,
-            }}
-            style={styles.addInlineBtn}
-            accessibilityLabel="Add new ingredient"
-          >
-            <MaterialIcons name="add" size={18} color={theme.colors.primary} />
-            <Text
-              numberOfLines={1}
-              style={{ color: theme.colors.primary, fontWeight: "600" }}
+          {showAddNewBtn ? (
+            <Pressable
+              onPress={() => onAddNewIngredient(query.trim())}
+              android_ripple={{
+                color: withAlpha(theme.colors.tertiary, 0.2),
+                borderless: true,
+              }}
+              style={styles.addInlineBtn}
+              accessibilityLabel="Add new ingredient"
             >
-              Add
-            </Text>
-          </Pressable>
-        ) : null}
+              <MaterialIcons name="add" size={18} color={theme.colors.primary} />
+              <Text
+                numberOfLines={1}
+                style={{ color: theme.colors.primary, fontWeight: "600" }}
+              >
+                Add
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
       </View>
 
       {/* Suggest dropdown */}
@@ -2091,6 +2091,7 @@ const styles = StyleSheet.create({
   nameInputWrap: {
     flex: 1,
     minWidth: 0,
+    position: "relative",
   },
 
   input: {
@@ -2101,7 +2102,9 @@ const styles = StyleSheet.create({
     marginTop: 8,
   },
 
-  nameInput: {},
+  nameInput: {
+    paddingRight: 72,
+  },
 
   multiline: { minHeight: 80, textAlignVertical: "top" },
 
@@ -2237,6 +2240,10 @@ const styles = StyleSheet.create({
   },
 
   addInlineBtn: {
+    position: "absolute",
+    right: 8,
+    top: "50%",
+    transform: [{ translateY: "-50%" }],
     flexDirection: "row",
     alignItems: "center",
     gap: 6,


### PR DESCRIPTION
## Summary
- Keep ingredient name fields width fixed by nesting '+ Add' button inside a relative wrapper
- Position inline add button absolutely and pad text inputs to avoid overlap

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a31bcbc51c8326b91376d8fae51f92