### PR TITLE
Preserve cocktail edit state after adding ingredients

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1364,10 +1364,11 @@ export default function AddCocktailScreen() {
           initialName,
           targetLocalId: localId,
           returnTo: route.name,
+          returnKey: route.key,
         },
       });
     },
-    [navigation, route.name]
+    [navigation, route.name, route.key]
   );
 
   // Catch created ingredient returned from AddIngredient

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1499,10 +1499,11 @@ export default function EditCocktailScreen() {
           initialName,
           targetLocalId: localId,
           returnTo: route.name,
+          returnKey: route.key,
         },
       });
     },
-    [navigation, route.name]
+    [navigation, route.name, route.key]
   );
 
   // Catch created ingredient returned from AddIngredient

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -131,6 +131,7 @@ export default function AddIngredientScreen() {
   const initialNameParam = route.params?.initialName || "";
   const targetLocalId = route.params?.targetLocalId;
   const returnTo = route.params?.returnTo || "AddCocktail";
+  const returnKey = route.params?.returnKey;
   const fromCocktailFlow = targetLocalId != null;
   const lastIngredientsTab =
     (typeof getTab === "function" && getTab("ingredients")) || "All";
@@ -202,7 +203,7 @@ export default function AddIngredientScreen() {
           <HeaderBackButton
             {...props}
             onPress={() =>
-              navigation.navigate("Cocktails", { screen: returnTo })
+              navigation.navigate("Cocktails", { screen: returnTo, key: returnKey })
             }
             labelVisible={false}
           />
@@ -216,7 +217,7 @@ export default function AddIngredientScreen() {
           />
         ),
     });
-  }, [navigation, fromCocktailFlow, returnTo, lastIngredientsTab]);
+  }, [navigation, fromCocktailFlow, returnTo, returnKey, lastIngredientsTab]);
 
   useEffect(() => {
     if (!isFocused) return;
@@ -225,7 +226,7 @@ export default function AddIngredientScreen() {
       if (["NAVIGATE", "REPLACE"].includes(e.data.action.type)) return;
       e.preventDefault();
       if (fromCocktailFlow) {
-        navigation.navigate("Cocktails", { screen: returnTo });
+        navigation.navigate("Cocktails", { screen: returnTo, key: returnKey });
       } else {
         navigation.replace("IngredientsMain", { screen: lastIngredientsTab });
       }
@@ -233,7 +234,7 @@ export default function AddIngredientScreen() {
 
     const hwSub = BackHandler.addEventListener("hardwareBackPress", () => {
       if (fromCocktailFlow) {
-        navigation.navigate("Cocktails", { screen: returnTo });
+        navigation.navigate("Cocktails", { screen: returnTo, key: returnKey });
       } else {
         navigation.replace("IngredientsMain", { screen: lastIngredientsTab });
       }
@@ -244,7 +245,7 @@ export default function AddIngredientScreen() {
       beforeRemoveSub();
       hwSub.remove();
     };
-  }, [isFocused, navigation, fromCocktailFlow, returnTo, lastIngredientsTab]);
+  }, [isFocused, navigation, fromCocktailFlow, returnTo, returnKey, lastIngredientsTab]);
 
   /* ---------- Lifecycle ---------- */
   useEffect(() => {
@@ -376,6 +377,7 @@ export default function AddIngredientScreen() {
 
     if (fromCocktailFlow) {
       detailParams.returnTo = returnTo;
+      detailParams.returnKey = returnKey;
       detailParams.createdIngredient = {
         id: newIng.id,
         name: newIng.name,
@@ -404,6 +406,7 @@ export default function AddIngredientScreen() {
     navigation,
     fromCocktailFlow,
     returnTo,
+    returnKey,
     targetLocalId,
     addIngredient,
     setGlobalIngredients,

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -192,13 +192,18 @@ export default function IngredientDetailsScreen() {
 
   useEffect(() => {
     const returnTo = route.params?.returnTo;
+    const returnKey = route.params?.returnKey;
     if (!returnTo) return;
     const beforeRemove = (e) => {
       if (e.data.action.type === "NAVIGATE") return;
       e.preventDefault();
       sub();
       navigation.dispatch(
-        CommonActions.reset({ index: 0, routes: [{ name: "IngredientsMain" }] })
+        CommonActions.reset({
+          key: navigation.getState().key,
+          index: 0,
+          routes: [{ name: "IngredientsMain" }],
+        })
       );
       navigation.navigate("Cocktails", {
         screen: returnTo,
@@ -207,6 +212,7 @@ export default function IngredientDetailsScreen() {
           targetLocalId: route.params?.targetLocalId,
         },
         merge: true,
+        key: returnKey,
       });
     };
     const sub = navigation.addListener("beforeRemove", beforeRemove);
@@ -214,6 +220,7 @@ export default function IngredientDetailsScreen() {
   }, [
     navigation,
     route.params?.returnTo,
+    route.params?.returnKey,
     route.params?.createdIngredient,
     route.params?.targetLocalId,
   ]);


### PR DESCRIPTION
## Summary
- Pass the cocktail screen key when opening AddIngredient so navigation returns to the same edit page
- Use the key during AddIngredient back navigation and forward it to IngredientDetails
- Reset only the ingredients stack and navigate back using the stored key

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a32df933e88326964eeda22307750e