### PR TITLE
Add tap feedback to delete buttons

### DIFF
--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1272,6 +1272,13 @@ export default function EditCocktailScreen() {
       headerRight: () => (
         <Pressable
           onPress={handleDelete}
+          android_ripple={{ color: theme.colors.outlineVariant, borderless: true }}
+          style={({ pressed }) => ({
+            paddingHorizontal: 8,
+            paddingVertical: 4,
+            opacity: pressed ? 0.5 : 1,
+            borderRadius: 8,
+          })}
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           accessibilityRole="button"
           accessibilityLabel="Delete cocktail"

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -250,6 +250,13 @@ export default function EditIngredientScreen() {
       headerRight: () => (
         <Pressable
           onPress={handleDelete}
+          android_ripple={{ color: theme.colors.outlineVariant, borderless: true }}
+          style={({ pressed }) => ({
+            paddingHorizontal: 8,
+            paddingVertical: 4,
+            opacity: pressed ? 0.5 : 1,
+            borderRadius: 8,
+          })}
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           accessibilityRole="button"
           accessibilityLabel="Delete ingredient"


### PR DESCRIPTION
## Summary
- add visual press feedback to delete buttons in cocktail and ingredient editors

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3524e7bb083268afb019d58ebbfb7