### PR TITLE
Fix ingredient navigation reset wiping cocktail edits

### DIFF
--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -197,8 +197,12 @@ export default function IngredientDetailsScreen() {
       if (e.data.action.type === "NAVIGATE") return;
       e.preventDefault();
       sub();
-      navigation.dispatch(
-        CommonActions.reset({ index: 0, routes: [{ name: "IngredientsMain" }] })
+      navigation.dispatch((state) =>
+        CommonActions.reset({
+          ...state,
+          routes: [{ name: "IngredientsMain" }],
+          index: 0,
+        })
       );
       navigation.navigate("Cocktails", {
         screen: returnTo,


### PR DESCRIPTION
## Summary
- scope ingredient stack reset to avoid clearing cocktail edit screen

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3536c6fd8832688712a113ef8c772