### PR TITLE
Fix ingredient creation flow when editing cocktails

### DIFF
--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -369,22 +369,30 @@ export default function AddIngredientScreen() {
     await saveAllIngredients(updatedList).catch(() => {});
     setUsageMap((prev) => ({ ...prev, [newIng.id]: [] }));
 
+    const createdPayload = {
+      id: newIng.id,
+      name: newIng.name,
+      photoUri: newIng.photoUri || null,
+      baseIngredientId: newIng.baseIngredientId ?? null,
+      tags: newIng.tags || [],
+    };
+
+    if (fromCocktailFlow) {
+      navigation.navigate("Cocktails", {
+        screen: returnTo,
+        params: {
+          createdIngredient: createdPayload,
+          targetLocalId,
+        },
+        merge: true,
+      });
+      return;
+    }
+
     const detailParams = {
       id: newIng.id,
       initialIngredient: newIng,
     };
-
-    if (fromCocktailFlow) {
-      detailParams.returnTo = returnTo;
-      detailParams.createdIngredient = {
-        id: newIng.id,
-        name: newIng.name,
-        photoUri: newIng.photoUri || null,
-        baseIngredientId: newIng.baseIngredientId ?? null,
-        tags: newIng.tags || [],
-      };
-      detailParams.targetLocalId = targetLocalId;
-    }
 
     navigation.dispatch((state) => {
       const routes = state.routes.slice(0, -1);


### PR DESCRIPTION
## Summary
- ensure saving a new ingredient during cocktail editing returns to the existing editor with form preserved

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a358191d688326a8396d55eaa53553