### PR TITLE
Reset tab stacks and remember last subtabs

### DIFF
--- a/App.js
+++ b/App.js
@@ -100,7 +100,8 @@ function Tabs() {
         component={CocktailsTabsScreen}
         options={{ unmountOnBlur: true }}
         listeners={({ navigation }) => ({
-          tabPress: () => {
+          tabPress: (e) => {
+            e.preventDefault();
             const saved = typeof getTab === "function" && getTab("cocktails");
             navigation.navigate("Cocktails", {
               screen: "CocktailsMain",
@@ -114,7 +115,8 @@ function Tabs() {
         component={ShakerStackScreen}
         options={{ unmountOnBlur: true }}
         listeners={({ navigation }) => ({
-          tabPress: () => {
+          tabPress: (e) => {
+            e.preventDefault();
             navigation.navigate("Shaker", { screen: "ShakerMain" });
           },
         })}
@@ -124,7 +126,8 @@ function Tabs() {
         component={IngredientsTabsScreen}
         options={{ unmountOnBlur: true }}
         listeners={({ navigation }) => ({
-          tabPress: () => {
+          tabPress: (e) => {
+            e.preventDefault();
             const saved =
               typeof getTab === "function" && getTab("ingredients");
             navigation.navigate("Ingredients", {


### PR DESCRIPTION
## Summary
- ensure Cocktails, Ingredients and Shaker tabs reset to their root screens
- remember last visited subtab for Cocktails and Ingredients

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a38a73961c8326a27bc16604c7a048