### PR TITLE
Fix previous screen state after saving via back dialog

### DIFF
--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -29,7 +29,12 @@ import Animated, {
   LinearTransition,
 } from "react-native-reanimated";
 import * as ImagePicker from "expo-image-picker";
-import { useNavigation, useRoute, useFocusEffect } from "@react-navigation/native";
+import {
+  useNavigation,
+  useRoute,
+  useFocusEffect,
+  CommonActions,
+} from "@react-navigation/native";
 import { useTheme, Portal, Modal } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import { HeaderBackButton } from "@react-navigation/elements";
@@ -2071,7 +2076,11 @@ export default function EditCocktailScreen() {
                     },
                   };
                 }
-                return { ...state, routes };
+                return CommonActions.reset({
+                  ...state,
+                  routes,
+                  index: state.index,
+                });
               });
               navigation.dispatch(pendingNav);
               setPendingNav(null);

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -861,7 +861,11 @@ export default function EditIngredientScreen() {
                     },
                   };
                 }
-                return { ...state, routes };
+                return CommonActions.reset({
+                  ...state,
+                  routes,
+                  index: state.index,
+                });
               });
               navigation.dispatch(pendingNav);
               setPendingNav(null);


### PR DESCRIPTION
## Summary
- ensure ingredient and cocktail detail screens receive updated params when saving from back confirmation dialog

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3a9bd62d48326b9c5baffb2ebc88c