### PR TITLE
feat: move ingredient label into header

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -422,6 +422,14 @@ const IngredientRow = memo(function IngredientRow({
           <Text style={{ fontWeight: "700", color: theme.colors.onSurface }}>
             {index + 1}.
           </Text>
+          <Text
+            style={[
+              styles.labelText,
+              { marginLeft: 8, color: theme.colors.onSurface },
+            ]}
+          >
+            Ingredient:
+          </Text>
 
           {canRemove ? (
             <>
@@ -479,14 +487,6 @@ const IngredientRow = memo(function IngredientRow({
           </Pressable>
         ) : null}
       </View>
-
-      {/* Ingredient */}
-      <View style={styles.labelRow}>
-        <Text style={[styles.labelText, { color: theme.colors.onSurface }]}>
-          Ingredient
-        </Text>
-      </View>
-
       {/* Name input + inline [+Add] */}
       <View style={styles.inputRow}>
         <View
@@ -1974,14 +1974,6 @@ const IMAGE_SIZE = 150;
 const styles = StyleSheet.create({
   container: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 40 },
   label: { fontWeight: "bold", marginTop: 16 },
-
-  // special for Ingredient + [+]
-  labelRow: {
-    marginTop: 16,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
   labelText: { fontWeight: "bold" },
 
   // input + inline add in one row

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -429,6 +429,14 @@ const IngredientRow = memo(function IngredientRow({
           <Text style={{ fontWeight: "700", color: theme.colors.onSurface }}>
             {index + 1}.
           </Text>
+          <Text
+            style={[
+              styles.labelText,
+              { marginLeft: 8, color: theme.colors.onSurface },
+            ]}
+          >
+            Ingredient:
+          </Text>
 
           {canRemove ? (
             <>
@@ -486,14 +494,6 @@ const IngredientRow = memo(function IngredientRow({
           </Pressable>
         ) : null}
       </View>
-
-      {/* Ingredient */}
-      <View style={styles.labelRow}>
-        <Text style={[styles.labelText, { color: theme.colors.onSurface }]}>
-          Ingredient
-        </Text>
-      </View>
-
       {/* Name input + inline [+Add] */}
       <View style={styles.inputRow}>
         <View
@@ -2099,14 +2099,6 @@ const IMAGE_SIZE = 150;
 const styles = StyleSheet.create({
   container: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 40 },
   label: { fontWeight: "bold", marginTop: 16 },
-
-  // special for Ingredient + [+]
-  labelRow: {
-    marginTop: 16,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
   labelText: { fontWeight: "bold" },
 
   // input + inline add in one row


### PR DESCRIPTION
## Summary
- move ingredient label to the top row after step number on add/edit cocktail screens
- add colon and remove extra row

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3b2fe1cc48326858774b12f1ad799