### PR TITLE
Center text inputs on focus

### DIFF
--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1573,7 +1573,7 @@ export default function EditCocktailScreen() {
     [subModal.forLocalId, closeSubstituteModal]
   );
 
-  /* ---------- Простий scroll-алгоритм (z + 16) ---------- */
+  /* ---------- Центрування інпута при focus ---------- */
   const scrollRef = useRef(null);
   const viewportRef = useRef(null);
   const [viewportH, setViewportH] = useState(0);
@@ -1597,22 +1597,21 @@ export default function EditCocktailScreen() {
       if (!nodeRef?.current || !scrollRef.current) return;
       if (contentH <= viewportH) return; // нема що скролити
 
-      const x = viewportH || Dimensions.get("window").height; // висота в’юпорта
-      const y = kbHeight; // висота клавіатури
+      const viewportHeight =
+        viewportH || Dimensions.get("window").height; // висота в’юпорта
+      const visibleHeight = viewportHeight - kbHeight; // видиме поле над клавіатурою
+      const targetCenter = visibleHeight / 2; // бажаний центр інпуту
       const DEAD = 10; // додатковий відступ
+
       const tryOnce = () => {
         if (!nodeRef?.current) return;
         nodeRef.current.measureInWindow((ix, iy, iw, ih) => {
-          const inputBottom = iy + ih;
-          const visibleLimit = x - y; // межа видимої області над клавіатурою
-
-          // 3) якщо нижній край під клавіатурою — скролимо
-          if (inputBottom - DEAD > visibleLimit || y == 0) {
-            const z = inputBottom - visibleLimit; // 4)
-            const delta = z + DEAD; // 5)
+          const inputCenter = iy + ih / 2;
+          const delta = inputCenter - targetCenter; // наскільки нижче центра
+          if (delta > DEAD || kbHeight === 0) {
             const maxY = Math.max(0, contentH - viewportH);
-            // cкролимо лише вниз: забороняємо зменшення y
-            const targetY = Math.min(scrollY + delta, maxY) + 100; // бажана позиція
+            // Скролимо лише вниз (піднімаємо контент), не опускаємо
+            const targetY = Math.min(scrollY + delta + DEAD, maxY);
             if (targetY > scrollY) {
               scrollRef.current.scrollTo({ y: targetY, animated: true });
             }
@@ -1621,7 +1620,7 @@ export default function EditCocktailScreen() {
       };
 
       // одразу + повтор після відкриття клавіатури
-      tryOnce(120);
+      tryOnce();
       setTimeout(tryOnce, 80);
     },
     [viewportH, kbHeight, contentH, scrollY]

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -17,12 +17,12 @@ import {
   StyleSheet,
   ScrollView,
   Alert,
-  KeyboardAvoidingView,
-  Platform,
   InteractionManager,
   ActivityIndicator,
   Pressable,
   BackHandler,
+  Dimensions,
+  Keyboard,
 } from "react-native";
 import * as ImagePicker from "expo-image-picker";
 import {
@@ -193,6 +193,58 @@ export default function AddIngredientScreen() {
   const anchorRef = useRef(null);
   const searchInputRef = useRef(null);
   const isMountedRef = useRef(true);
+
+  // scrolling helpers
+  const scrollRef = useRef(null);
+  const viewportRef = useRef(null);
+  const descRef = useRef(null);
+  const [viewportH, setViewportH] = useState(0);
+  const [contentH, setContentH] = useState(0);
+  const [scrollY, setScrollY] = useState(0);
+  const [kbHeight, setKbHeight] = useState(0);
+
+  useEffect(() => {
+    const sh = Keyboard.addListener("keyboardDidShow", (e) =>
+      setKbHeight(e?.endCoordinates?.height || 0)
+    );
+    const hd = Keyboard.addListener("keyboardDidHide", () => setKbHeight(0));
+    return () => {
+      sh.remove();
+      hd.remove();
+    };
+  }, []);
+
+  const requestScrollIntoView = useCallback(
+    (nodeRef) => {
+      if (!nodeRef?.current || !scrollRef.current) return;
+      if (contentH <= viewportH) return;
+
+      const viewportHeight =
+        viewportH || Dimensions.get("window").height;
+      const visibleHeight = viewportHeight - kbHeight;
+      const targetCenter = visibleHeight / 2;
+      const DEAD = 10;
+
+      const tryOnce = () => {
+        if (!nodeRef?.current) return;
+        nodeRef.current.measureInWindow((ix, iy, iw, ih) => {
+          const inputCenter = iy + ih / 2;
+          const delta = inputCenter - targetCenter;
+          if (delta > DEAD || kbHeight === 0) {
+            const maxY = Math.max(0, contentH - viewportH);
+            const targetY = Math.min(scrollY + delta + DEAD, maxY);
+            if (targetY > scrollY) {
+              scrollRef.current.scrollTo({ y: targetY, animated: true });
+            }
+          }
+        });
+      };
+
+      tryOnce();
+      setTimeout(tryOnce, 80);
+    },
+    [viewportH, kbHeight, contentH, scrollY]
+  );
 
   /* ---------- Back button logic ---------- */
   useLayoutEffect(() => {
@@ -434,14 +486,22 @@ export default function AddIngredientScreen() {
 
   /* ---------- Render ---------- */
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1, backgroundColor: theme.colors.background }}
-      behavior={Platform.OS === "ios" ? "padding" : "height"}
-    >
-      <ScrollView
-        contentContainerStyle={styles.container}
-        keyboardShouldPersistTaps="handled"
+    <>
+      <View
+        ref={viewportRef}
+        collapsable={false}
+        style={{ flex: 1, backgroundColor: theme.colors.background }}
+        onLayout={(e) => setViewportH(e.nativeEvent.layout.height)}
       >
+        <ScrollView
+          ref={scrollRef}
+          contentContainerStyle={[styles.container, { paddingBottom: 60 + kbHeight }]}
+          keyboardShouldPersistTaps="handled"
+          onContentSizeChange={(_, h) => setContentH(h)}
+          onScroll={(e) => setScrollY(e.nativeEvent.contentOffset.y)}
+          scrollEventThrottle={16}
+          scrollIndicatorInsets={{ bottom: kbHeight }}
+        >
         <Text style={[styles.label, { color: theme.colors.onBackground }]}>
           Name
         </Text>
@@ -682,10 +742,13 @@ export default function AddIngredientScreen() {
           )}
         </Menu>
 
-        <Text style={[styles.label, { color: theme.colors.onBackground }]}> 
+        <Text style={[styles.label, { color: theme.colors.onBackground }]}>
           Description:
         </Text>
         <TextInput
+          ref={descRef}
+          collapsable={false}
+          onFocus={() => requestScrollIntoView(descRef)}
           placeholder="Optional description"
           placeholderTextColor={theme.colors.onSurfaceVariant}
           value={description}
@@ -713,12 +776,13 @@ export default function AddIngredientScreen() {
           </Text>
         </Pressable>
       </ScrollView>
+    </View>
       <IngredientTagsModal
         visible={tagsModalVisible}
         onClose={closeTagsModal}
         autoAdd={tagsModalAutoAdd}
       />
-    </KeyboardAvoidingView>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- center focused inputs within AddCocktail and EditCocktail screens so focused fields scroll upward to the middle of the viewport

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3b6a85efc8326902c0a97200144ed