### PR TITLE
feat: allow exporting ingredient and cocktail photos

### DIFF
--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -19,7 +19,7 @@ import CocktailTagsModal from "./CocktailTagsModal";
 import FavoritesRatingModal from "./FavoritesRatingModal";
 import ConfirmationDialog from "./ConfirmationDialog";
 import useIngredientsData from "../hooks/useIngredientsData";
-import { exportAllData, importAllData } from "../storage/backupStorage";
+import { exportAllData, importAllData, exportAllPhotos } from "../storage/backupStorage";
 import { useTheme } from "react-native-paper";
 
 import {
@@ -141,6 +141,24 @@ export default function GeneralMenu({ visible, onClose }) {
   const openRatingModal = () => {
     onClose?.();
     setTimeout(() => setRatingVisible(true), 0);
+  };
+
+  const handleExportPhotos = async () => {
+    onClose?.();
+    try {
+      await exportAllPhotos();
+      setDialog({
+        visible: true,
+        title: "Export photos",
+        message: "Photos exported successfully",
+      });
+    } catch (e) {
+      setDialog({
+        visible: true,
+        title: "Export photos",
+        message: "Failed to export photos",
+      });
+    }
   };
 
   const handleExport = async () => {
@@ -397,6 +415,25 @@ export default function GeneralMenu({ visible, onClose }) {
                 <View style={styles.itemText}>
                   <Text style={styles.itemTitle}>Cocktail tags</Text>
                   <Text style={styles.itemSub}>Create, edit or remove cocktail tags</Text>
+                </View>
+                <MaterialIcons
+                  name="chevron-right"
+                  size={24}
+                  color={theme.colors.onSurfaceVariant}
+                  style={styles.chevron}
+                />
+              </TouchableOpacity>
+
+              <TouchableOpacity style={styles.linkRow} onPress={handleExportPhotos}>
+                <MaterialIcons
+                  name="photo-library"
+                  size={22}
+                  color={theme.colors.primary}
+                  style={styles.linkIcon}
+                />
+                <View style={styles.itemText}>
+                  <Text style={styles.itemTitle}>Export photos</Text>
+                  <Text style={styles.itemSub}>Export all ingredient and cocktail photos</Text>
                 </View>
                 <MaterialIcons
                   name="chevron-right"

--- a/src/storage/backupStorage.js
+++ b/src/storage/backupStorage.js
@@ -1,6 +1,7 @@
 import * as FileSystem from 'expo-file-system';
 import * as DocumentPicker from 'expo-document-picker';
 import * as Sharing from 'expo-sharing';
+import JSZip from 'jszip';
 
 import { getAllIngredients, saveAllIngredients } from './ingredientsStorage';
 import { getAllCocktails, replaceAllCocktails } from './cocktailsStorage';
@@ -26,6 +27,63 @@ export async function exportAllData() {
       await Sharing.shareAsync(fileUri, {
         mimeType: 'application/json',
         dialogTitle: 'Share yourbar backup',
+      });
+    }
+  } catch (e) {
+    console.warn('Sharing failed', e);
+  }
+  return fileUri;
+}
+
+/**
+ * Export all ingredient and cocktail photos as a ZIP archive and open share dialog.
+ * Returns the URI of the created file.
+ */
+export async function exportAllPhotos() {
+  const [ingredients, cocktails] = await Promise.all([
+    getAllIngredients(),
+    getAllCocktails(),
+  ]);
+
+  const zip = new JSZip();
+  const added = new Set();
+
+  const getExt = (uri) => {
+    const match = /\.([a-zA-Z0-9]+)(?:[?#].*)?$/.exec(uri);
+    return match ? `.${match[1]}` : '.jpg';
+  };
+
+  const addFile = async (uri, name) => {
+    if (!uri || added.has(uri)) return;
+    try {
+      const base64 = await FileSystem.readAsStringAsync(uri, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+      zip.file(name, base64, { base64: true });
+      added.add(uri);
+    } catch (e) {
+      console.warn('Failed to add photo', uri, e);
+    }
+  };
+
+  for (const ing of ingredients) {
+    await addFile(ing.photoUri, `ingredient-${ing.id}${getExt(ing.photoUri || '')}`);
+  }
+  for (const c of cocktails) {
+    await addFile(c.photoUri, `cocktail-${c.id}${getExt(c.photoUri || '')}`);
+  }
+
+  const base64Zip = await zip.generateAsync({ type: 'base64' });
+  const fileName = `yourbar-photos-${Date.now()}.zip`;
+  const fileUri = FileSystem.cacheDirectory + fileName;
+  await FileSystem.writeAsStringAsync(fileUri, base64Zip, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+  try {
+    if (await Sharing.isAvailableAsync()) {
+      await Sharing.shareAsync(fileUri, {
+        mimeType: 'application/zip',
+        dialogTitle: 'Share yourbar photos',
       });
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- add backupStorage.exportAllPhotos using JSZip and Expo FileSystem/Sharing
- expose "Export photos" entry in general menu

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a4599d997483268d2a39a6db7b6d0a