### PR TITLE
Default imported ingredients as not in bar

### DIFF
--- a/scripts/importCocktailsAndIngredients.js
+++ b/scripts/importCocktailsAndIngredients.js
@@ -49,7 +49,7 @@ function sanitizeIngredients(raw) {
         baseIngredientId: it?.baseIngredientId ?? null,
         usageCount: Number(it?.usageCount ?? 0),
         singleCocktailName: it?.singleCocktailName ?? null,
-        inBar: !!it?.inBar,
+        inBar: false,
       }))
     : [];
 }


### PR DESCRIPTION
## Summary
- Ensure imported sample ingredients always start with `inBar` set to `false`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a48d85e5248326af7778ebe4b1ad56