### PR TITLE
Default settings menu checkboxes to checked on first run

### DIFF
--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -99,11 +99,11 @@ export default function GeneralMenu({ visible, onClose }) {
     [theme]
   );
 
-  const [ignoreGarnish, setIgnoreGarnish] = useState(false);
+  const [ignoreGarnish, setIgnoreGarnish] = useState(true);
   const [useMetric, setUseMetric] = useState(true);
-  const [keepAwake, setKeepAwake] = useState(false);
+  const [keepAwake, setKeepAwake] = useState(true);
   const [tabsOnTop, setTabsOnTop] = useState(true);
-  const [allowSubstitutes, setAllowSubstitutes] = useState(false);
+  const [allowSubstitutes, setAllowSubstitutes] = useState(true);
   const [tagsVisible, setTagsVisible] = useState(false);
   const [cocktailTagsVisible, setCocktailTagsVisible] = useState(false);
   const [ratingVisible, setRatingVisible] = useState(false);

--- a/src/storage/settingsStorage.js
+++ b/src/storage/settingsStorage.js
@@ -33,10 +33,10 @@ export async function setUseMetric(value) {
 export async function getIgnoreGarnish() {
   try {
     const value = await AsyncStorage.getItem(IGNORE_GARNISH_KEY);
-    if (value === null) return false;
+    if (value === null) return true;
     return value === "true";
   } catch {
-    return false;
+    return true;
   }
 }
 
@@ -54,10 +54,10 @@ export function addIgnoreGarnishListener(listener) {
 export async function getAllowSubstitutes() {
   try {
     const value = await AsyncStorage.getItem(ALLOW_SUBSTITUTES_KEY);
-    if (value === null) return false;
+    if (value === null) return true;
     return value === "true";
   } catch {
-    return false;
+    return true;
   }
 }
 
@@ -75,10 +75,10 @@ export function addAllowSubstitutesListener(listener) {
 export async function getKeepAwake() {
   try {
     const value = await AsyncStorage.getItem(KEEP_AWAKE_KEY);
-    if (value === null) return false;
+    if (value === null) return true;
     return value === "true";
   } catch {
-    return false;
+    return true;
   }
 }
 


### PR DESCRIPTION
## Summary
- Ensure all menu checkboxes start checked on first launch
- Default settings storage functions to `true` when unset

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a49391e4388326ac9bb00ab28ea892