### PR TITLE
Normalize search queries using diacritic-insensitive utility

### DIFF
--- a/src/components/GlasswarePicker.js
+++ b/src/components/GlasswarePicker.js
@@ -14,6 +14,7 @@ import {
 } from "react-native";
 import { useTheme } from "react-native-paper";
 import { GLASSWARE } from "../constants/glassware";
+import { normalizeSearch } from "../utils/normalizeSearch";
 
 const CELL = 86; // розмір картки
 const GAP = 12;
@@ -59,9 +60,9 @@ export default function GlasswarePicker({
   const [query, setQuery] = useState("");
 
   const data = useMemo(() => {
-    const s = query.trim().toLowerCase();
+    const s = normalizeSearch(query);
     if (!s) return GLASSWARE;
-    return GLASSWARE.filter((g) => g.name.toLowerCase().includes(s));
+    return GLASSWARE.filter((g) => normalizeSearch(g.name).includes(s));
   }, [query]);
 
   return (

--- a/src/constants/cocktailTags.js
+++ b/src/constants/cocktailTags.js
@@ -1,4 +1,5 @@
 import { TAG_COLORS } from "../theme";
+import { normalizeSearch } from "../utils/normalizeSearch";
 
 // Вшиті (builtin) теги коктейлів: стабільні numeric id + читабельні кольори під білий текст
 export const BUILTIN_COCKTAIL_TAGS = [
@@ -17,7 +18,7 @@ export const cocktailTagById = (id) =>
   BUILTIN_COCKTAIL_TAGS.find((t) => t.id === id) || null;
 
 export const searchCocktailTags = (q) => {
-  const s = (q || "").trim().toLowerCase();
+  const s = normalizeSearch(q);
   if (!s) return BUILTIN_COCKTAIL_TAGS;
-  return BUILTIN_COCKTAIL_TAGS.filter((t) => t.name.toLowerCase().includes(s));
+  return BUILTIN_COCKTAIL_TAGS.filter((t) => normalizeSearch(t.name).includes(s));
 };

--- a/src/constants/glassware.js
+++ b/src/constants/glassware.js
@@ -1,4 +1,5 @@
 // src/constants/glassware.js
+import { normalizeSearch } from "../utils/normalizeSearch";
 
 // Map IDs to local JPEG assets (place files under: assets/glassware/<id>.jpg)
 const glassImages = {
@@ -82,7 +83,7 @@ export const GLASSWARE = [
 // Утиліти (зручно мати під рукою)
 export const getGlassById = (id) => GLASSWARE.find((g) => g.id === id) || null;
 export const searchGlass = (q) => {
-  const s = (q || "").trim().toLowerCase();
+  const s = normalizeSearch(q);
   if (!s) return GLASSWARE;
-  return GLASSWARE.filter((g) => g.name.toLowerCase().includes(s));
+  return GLASSWARE.filter((g) => normalizeSearch(g.name).includes(s));
 };

--- a/src/constants/ingredientTags.js
+++ b/src/constants/ingredientTags.js
@@ -1,4 +1,5 @@
 import { TAG_COLORS } from "../theme";
+import { normalizeSearch } from "../utils/normalizeSearch";
 
 export const BUILTIN_INGREDIENT_TAGS = [
   { id: 1, name: "strong alcohol", color: TAG_COLORS[0] },
@@ -18,9 +19,9 @@ export const ingredientTagById = (id) =>
   BUILTIN_INGREDIENT_TAGS.find((t) => t.id === id) || null;
 
 export const searchIngredientTags = (q) => {
-  const s = (q || "").trim().toLowerCase();
+  const s = normalizeSearch(q);
   if (!s) return BUILTIN_INGREDIENT_TAGS;
   return BUILTIN_INGREDIENT_TAGS.filter((t) =>
-    t.name.toLowerCase().includes(s)
+    normalizeSearch(t.name).includes(s)
   );
 };

--- a/src/constants/measureUnits.js
+++ b/src/constants/measureUnits.js
@@ -1,4 +1,5 @@
 // src/constants/measureUnits.js
+import { normalizeSearch } from "../utils/normalizeSearch";
 
 export const MEASURE_UNITS = [
   { id: 1, name: " ", plural: " " }, // пустий пункт
@@ -66,9 +67,9 @@ export const getUnitById = (id) =>
   MEASURE_UNITS.find((u) => u.id === id) || null;
 
 export const searchUnits = (q) => {
-  const s = (q || "").trim().toLowerCase();
+  const s = normalizeSearch(q);
   if (!s) return MEASURE_UNITS;
-  return MEASURE_UNITS.filter((u) => u.name.toLowerCase().includes(s));
+  return MEASURE_UNITS.filter((u) => normalizeSearch(u.name).includes(s));
 };
 
 // Return singular or plural unit name based on quantity

--- a/src/hooks/useIngredientsData.js
+++ b/src/hooks/useIngredientsData.js
@@ -2,6 +2,7 @@ import { useCallback, useContext, useEffect } from "react";
 import { getAllIngredients } from "../storage/ingredientsStorage";
 import { getAllCocktails } from "../storage/cocktailsStorage";
 import { mapCocktailsByIngredient } from "../utils/ingredientUsage";
+import { normalizeSearch } from "../utils/normalizeSearch";
 import IngredientUsageContext from "../context/IngredientUsageContext";
 import {
   getAllowSubstitutes,
@@ -40,7 +41,7 @@ export default function useIngredientsData() {
       const singleCocktailName = usageCount === 1 ? cocktailMap.get(ids[0]) : null;
       return {
         ...item,
-        searchName: item.name.toLowerCase(),
+        searchName: normalizeSearch(item.name),
         usageCount,
         singleCocktailName,
       };

--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -27,6 +27,7 @@ import CocktailRow, {
   COCKTAIL_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/CocktailRow";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
+import { normalizeSearch } from "../../utils/normalizeSearch";
 
 export default function AllCocktailsScreen() {
   const theme = useTheme();
@@ -111,9 +112,9 @@ export default function AllCocktailsScreen() {
       ingredients.find(
         (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
       );
-    const q = searchDebounced.trim().toLowerCase();
+    const q = normalizeSearch(searchDebounced);
     let list = cocktails;
-    if (q) list = list.filter((c) => c.name.toLowerCase().includes(q));
+    if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
     if (selectedTagIds.length > 0)
       list = list.filter(
         (c) =>

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -30,6 +30,7 @@ import { getAllCocktailTags } from "../../storage/cocktailTagsStorage";
 import CocktailRow, {
   COCKTAIL_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/CocktailRow";
+import { normalizeSearch } from "../../utils/normalizeSearch";
 
 export default function FavoriteCocktailsScreen() {
   const theme = useTheme();
@@ -121,9 +122,9 @@ export default function FavoriteCocktailsScreen() {
       ingredients.find(
         (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
       );
-    const q = searchDebounced.trim().toLowerCase();
+    const q = normalizeSearch(searchDebounced);
     let list = cocktails.filter((c) => c.rating > 0 && c.rating >= minRating);
-    if (q) list = list.filter((c) => c.name.toLowerCase().includes(q));
+    if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
     if (selectedTagIds.length > 0)
       list = list.filter(
         (c) =>

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -31,6 +31,7 @@ import CocktailRow, { COCKTAIL_ROW_HEIGHT } from "../../components/CocktailRow";
 import IngredientRow, { INGREDIENT_ROW_HEIGHT } from "../../components/IngredientRow";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
+import { normalizeSearch } from "../../utils/normalizeSearch";
 
 const ITEM_HEIGHT = Math.max(COCKTAIL_ROW_HEIGHT, INGREDIENT_ROW_HEIGHT);
 
@@ -116,9 +117,9 @@ export default function MyCocktailsScreen() {
       ingredients.find(
         (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
       );
-    const q = searchDebounced.trim().toLowerCase();
+    const q = normalizeSearch(searchDebounced);
     let list = cocktails;
-    if (q) list = list.filter((c) => c.name.toLowerCase().includes(q));
+    if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
     if (selectedTagIds.length > 0)
       list = list.filter(
         (c) =>

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -45,6 +45,7 @@ import { useTabMemory } from "../../context/TabMemoryContext";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import IngredientTagsModal from "../../components/IngredientTagsModal";
 import useIngredientsData from "../../hooks/useIngredientsData";
+import { normalizeSearch } from "../../utils/normalizeSearch";
 
 
 
@@ -181,9 +182,9 @@ export default function AddIngredientScreen() {
   const debouncedQuery = useDebounced(baseIngredientSearch, 250);
   const deferredQuery = useDeferredValue(debouncedQuery);
   const filteredBase = useMemo(() => {
-    const q = deferredQuery.trim().toLowerCase();
+    const q = normalizeSearch(deferredQuery);
     if (!q) return baseOnlySorted;
-    return baseOnlySorted.filter((i) => i.nameLower.includes(q));
+    return baseOnlySorted.filter((i) => i.searchName.includes(q));
   }, [baseOnlySorted, deferredQuery]);
 
   // anchored menu
@@ -336,7 +337,7 @@ export default function AddIngredientScreen() {
           id: i.id,
           name: i.name,
           photoUri: i.photoUri || null,
-          nameLower: (i.name || "").toLowerCase(),
+          searchName: normalizeSearch(i.name || ""),
         }));
       if (!isMountedRef.current) return;
       setBaseOnlySorted(baseOnly);
@@ -406,7 +407,7 @@ export default function AddIngredientScreen() {
     };
     const enriched = {
       ...newIng,
-      searchName: newIng.name.toLowerCase(),
+      searchName: normalizeSearch(newIng.name),
       usageCount: 0,
       singleCocktailName: null,
     };

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -15,6 +15,7 @@ import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
+import { normalizeSearch } from "../../utils/normalizeSearch";
 
 export default function AllIngredientsScreen() {
   const theme = useTheme();
@@ -82,7 +83,7 @@ export default function AllIngredientsScreen() {
   }, [flushPending]);
 
   const filtered = useMemo(() => {
-    const q = searchDebounced.trim().toLowerCase();
+    const q = normalizeSearch(searchDebounced);
     let data = ingredients;
     if (q) data = data.filter((i) => i.searchName.includes(q));
     if (selectedTagIds.length > 0)

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -21,6 +21,7 @@ import {
   addAllowSubstitutesListener,
 } from "../../storage/settingsStorage";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
+import { normalizeSearch } from "../../utils/normalizeSearch";
 
 export default function MyIngredientsScreen() {
   const theme = useTheme();
@@ -175,7 +176,7 @@ export default function MyIngredientsScreen() {
   }, [ingredients, cocktails, usageMap, ignoreGarnish, allowSubstitutes]);
 
   const filtered = useMemo(() => {
-    const q = searchDebounced.trim().toLowerCase();
+    const q = normalizeSearch(searchDebounced);
     let data = ingredients.filter((i) => i.inBar);
     if (q) data = data.filter((i) => i.searchName.includes(q));
     if (selectedTagIds.length > 0)

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -15,6 +15,7 @@ import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
+import { normalizeSearch } from "../../utils/normalizeSearch";
 
 export default function ShoppingIngredientsScreen() {
   const theme = useTheme();
@@ -82,7 +83,7 @@ export default function ShoppingIngredientsScreen() {
   }, [flushPending]);
 
   const filtered = useMemo(() => {
-    const q = searchDebounced.trim().toLowerCase();
+    const q = normalizeSearch(searchDebounced);
     let data = ingredients.filter((i) => i.inShoppingList);
     if (q) data = data.filter((i) => i.searchName.includes(q));
     if (selectedTagIds.length > 0)

--- a/src/screens/ShakerResultsScreen.js
+++ b/src/screens/ShakerResultsScreen.js
@@ -12,6 +12,7 @@ import {
   getAllowSubstitutes,
   addAllowSubstitutesListener,
 } from "../storage/settingsStorage";
+import { normalizeSearch } from "../utils/normalizeSearch";
 
 export default function ShakerResultsScreen({ route, navigation }) {
   const { ids = [] } = route.params || {};
@@ -52,9 +53,9 @@ export default function ShakerResultsScreen({ route, navigation }) {
       ingredients.find(
         (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
       );
-    const q = search.trim().toLowerCase();
+    const q = normalizeSearch(search);
     let list = cocktails.filter((c) => ids.includes(c.id));
-    if (q) list = list.filter((c) => c.name.toLowerCase().includes(q));
+    if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
     if (selectedTagIds.length > 0)
       list = list.filter(
         (c) =>

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -16,6 +16,7 @@ import IngredientRow from "../components/IngredientRow";
 import useIngredientsData from "../hooks/useIngredientsData";
 import { BUILTIN_INGREDIENT_TAGS } from "../constants/ingredientTags";
 import { getAllTags } from "../storage/ingredientTagsStorage";
+import { normalizeSearch } from "../utils/normalizeSearch";
 
 export default function ShakerScreen({ navigation }) {
   const theme = useTheme();
@@ -56,7 +57,7 @@ export default function ShakerScreen({ navigation }) {
   }, [allTags, ingredients]);
 
   const filteredGrouped = useMemo(() => {
-    const q = search.trim().toLowerCase();
+    const q = normalizeSearch(search);
     if (!q) return grouped;
     const map = new Map();
     grouped.forEach((items, id) => {

--- a/src/storage/cocktailsStorage.js
+++ b/src/storage/cocktailsStorage.js
@@ -1,5 +1,6 @@
 // src/storage/cocktailsStorage.js
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { normalizeSearch } from "../utils/normalizeSearch";
 
 const STORAGE_KEY = "cocktails_v1";
 
@@ -127,10 +128,8 @@ export async function replaceAllCocktails(cocktails) {
 
 /** Simple search by name substring (case-insensitive) */
 export async function searchCocktails(query) {
-  const q = String(query || "")
-    .trim()
-    .toLowerCase();
+  const q = normalizeSearch(String(query || "").trim());
   if (!q) return getAllCocktails();
   const list = await readAll();
-  return list.filter((c) => c.name.toLowerCase().includes(q));
+  return list.filter((c) => normalizeSearch(c.name).includes(q));
 }

--- a/src/utils/normalizeSearch.js
+++ b/src/utils/normalizeSearch.js
@@ -1,0 +1,2 @@
+export const normalizeSearch = (s) =>
+  String(s || "").normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();


### PR DESCRIPTION
## Summary
- add `normalizeSearch` utility for diacritic-insensitive search
- use `normalizeSearch` in storage, constants, and screens to replace `toLowerCase().includes`
- store normalized `searchName` for ingredients when creating or editing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a59fb23bdc8326b48743d23d60cc3b