### PR TITLE
Load sample data before showing ingredient and cocktail lists

### DIFF
--- a/App.js
+++ b/App.js
@@ -24,12 +24,22 @@ import ShakerResultsScreen from "./src/screens/ShakerResultsScreen";
 
 import ShakerIcon from "./assets/shaker.svg";
 import IngredientIcon from "./assets/lemon.svg";
+import useIngredientsData from "./src/hooks/useIngredientsData";
 
-import { importCocktailsAndIngredients } from "./scripts/importCocktailsAndIngredients";
 
 const Tab = createBottomTabNavigator();
 const RootStack = createNativeStackNavigator();
 const ShakerStack = createNativeStackNavigator();
+
+function InitialDataLoader({ children }) {
+  const { loading, refresh } = useIngredientsData();
+  useEffect(() => {
+    if (loading) {
+      refresh();
+    }
+  }, [loading, refresh]);
+  return children;
+}
 
 function ShakerStackScreen() {
   return (
@@ -142,31 +152,29 @@ function Tabs() {
 }
 
 export default function App() {
-  useEffect(() => {
-    importCocktailsAndIngredients();
-  }, []);
-
   return (
     <PaperProvider theme={AppTheme}>
       <MenuProvider>
         <SafeAreaProvider>
           <IngredientUsageProvider>
-            <TabMemoryProvider>
-              <NavigationContainer>
-                <RootStack.Navigator>
-                  <RootStack.Screen
-                    name="Tabs"
-                    component={Tabs}
-                    options={{ headerShown: false }}
-                  />
-                  <RootStack.Screen
-                    name="EditCustomTags"
-                    component={EditCustomTagsScreen}
-                    options={{ title: "Custom tags" }}
-                  />
-                </RootStack.Navigator>
-              </NavigationContainer>
-            </TabMemoryProvider>
+            <InitialDataLoader>
+              <TabMemoryProvider>
+                <NavigationContainer>
+                  <RootStack.Navigator>
+                    <RootStack.Screen
+                      name="Tabs"
+                      component={Tabs}
+                      options={{ headerShown: false }}
+                    />
+                    <RootStack.Screen
+                      name="EditCustomTags"
+                      component={EditCustomTagsScreen}
+                      options={{ title: "Custom tags" }}
+                    />
+                  </RootStack.Navigator>
+                </NavigationContainer>
+              </TabMemoryProvider>
+            </InitialDataLoader>
           </IngredientUsageProvider>
         </SafeAreaProvider>
       </MenuProvider>

--- a/src/hooks/useIngredientsData.js
+++ b/src/hooks/useIngredientsData.js
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect } from "react";
 import { getAllIngredients } from "../storage/ingredientsStorage";
 import { getAllCocktails } from "../storage/cocktailsStorage";
+import { importCocktailsAndIngredients } from "../../scripts/importCocktailsAndIngredients";
 import { mapCocktailsByIngredient } from "../utils/ingredientUsage";
 import { normalizeSearch } from "../utils/normalizeSearch";
 import IngredientUsageContext from "../context/IngredientUsageContext";
@@ -23,6 +24,7 @@ export default function useIngredientsData() {
 
   const load = useCallback(async () => {
     setLoading(true);
+    await importCocktailsAndIngredients({ force: false });
     const [ing, cocks, allowSubs] = await Promise.all([
       getAllIngredients(),
       getAllCocktails(),


### PR DESCRIPTION
## Summary
- Trigger default data import inside `useIngredientsData` before fetching from storage
- Refresh ingredients and cocktails on startup via `InitialDataLoader`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7164b4c948326bdfea569251159c8