### PR TITLE
Add bottom padding to FlashList screens

### DIFF
--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -262,7 +262,7 @@ export default function AllCocktailsScreen() {
           </View>
         }
         contentContainerStyle={{
-          paddingBottom: 96 + (tabsOnTop ? 0 : 64) + insets.bottom,
+          paddingBottom: 56 + (tabsOnTop ? 0 : 64) + insets.bottom,
         }}
       />
     </View>

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -286,7 +286,7 @@ export default function FavoriteCocktailsScreen() {
           </View>
         }
         contentContainerStyle={{
-          paddingBottom: 96 + (tabsOnTop ? 0 : 64) + insets.bottom,
+          paddingBottom: 56 + (tabsOnTop ? 0 : 64) + insets.bottom,
         }}
       />
     </View>

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -379,7 +379,7 @@ export default function MyCocktailsScreen() {
           </View>
         }
         contentContainerStyle={{
-          paddingBottom: 96 + (tabsOnTop ? 0 : 64) + insets.bottom,
+          paddingBottom: 56 + (tabsOnTop ? 0 : 64) + insets.bottom,
         }}
       />
     </View>

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -184,7 +184,7 @@ export default function AllIngredientsScreen() {
           </View>
         }
         contentContainerStyle={{
-          paddingBottom: 96 + (tabsOnTop ? 0 : 64) + insets.bottom,
+          paddingBottom: 56 + (tabsOnTop ? 0 : 64) + insets.bottom,
         }}
       />
     </View>

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -281,7 +281,7 @@ export default function MyIngredientsScreen() {
           </View>
         }
         contentContainerStyle={{
-          paddingBottom: 96 + (tabsOnTop ? 0 : 64) + insets.bottom,
+          paddingBottom: 56 + (tabsOnTop ? 0 : 64) + insets.bottom,
         }}
       />
     </View>

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -184,7 +184,7 @@ export default function ShoppingIngredientsScreen() {
           </View>
         }
         contentContainerStyle={{
-          paddingBottom: 96 + (tabsOnTop ? 0 : 64) + insets.bottom,
+          paddingBottom: 56 + (tabsOnTop ? 0 : 64) + insets.bottom,
         }}
       />
     </View>


### PR DESCRIPTION
## Summary
- add dynamic bottom padding to ingredient lists to keep items above FAB
- add dynamic bottom padding to cocktail lists accounting for tabs and safe area

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8440625b483269019f7c78d39623b