### PR TITLE
Add branded splash screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,6 +9,7 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider as PaperProvider, useTheme } from "react-native-paper";
 import { MenuProvider } from "react-native-popup-menu";
+import SplashScreen from "./src/screens/SplashScreen";
 
 import CocktailsTabsScreen from "./src/screens/Cocktails/CocktailsTabsScreen";
 import ShakerScreen from "./src/screens/ShakerScreen";
@@ -38,6 +39,9 @@ function InitialDataLoader({ children }) {
       refresh();
     }
   }, [loading, refresh]);
+  if (loading) {
+    return <SplashScreen />;
+  }
   return children;
 }
 

--- a/src/screens/SplashScreen.js
+++ b/src/screens/SplashScreen.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { View, Image, StyleSheet, Text } from "react-native";
+
+export default function SplashScreen() {
+  return (
+    <View style={styles.container}>
+      <Image
+        source={require("../../assets/splash-icon.png")}
+        style={styles.image}
+      />
+      <Text style={styles.title}>Your bar</Text>
+      <Text style={styles.tagline}>your rules</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#ffffff",
+  },
+  image: {
+    width: 200,
+    height: 200,
+    marginBottom: 20,
+    resizeMode: "contain",
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: "bold",
+    marginBottom: 8,
+  },
+  tagline: {
+    fontSize: 18,
+    color: "#666666",
+  },
+});


### PR DESCRIPTION
## Summary
- show branded splash screen while initial data loads
- create standalone splash screen component with image and tagline

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a84471c1f48326877e4e8f68be6784