### PR TITLE
feat: use custom cocktail tab icon

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,7 +5,6 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { TabMemoryProvider, useTabMemory } from "./src/context/TabMemoryContext";
 import { IngredientUsageProvider } from "./src/context/IngredientUsageContext";
-import { MaterialIcons } from "@expo/vector-icons";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider as PaperProvider, useTheme } from "react-native-paper";
 import { MenuProvider } from "react-native-popup-menu";
@@ -24,6 +23,7 @@ import ShakerResultsScreen from "./src/screens/ShakerResultsScreen";
 
 import ShakerIcon from "./assets/shaker.svg";
 import IngredientIcon from "./assets/lemon.svg";
+import CocktailIcon from "./assets/cocktail.svg";
 import useIngredientsData from "./src/hooks/useIngredientsData";
 
 
@@ -87,7 +87,7 @@ function Tabs() {
         headerShown: false,
         tabBarIcon: ({ color, size }) => {
           if (route.name === "Cocktails") {
-            return <MaterialIcons name="local-bar" size={size} color={color} />;
+            return <CocktailIcon width={size} height={size} fill={color} />;
           } else if (route.name === "Shaker") {
             return <ShakerIcon width={size} height={size} fill={color} />;
           } else if (route.name === "Ingredients") {

--- a/assets/cocktail.svg
+++ b/assets/cocktail.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg fill="#000000" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M3 3h18L12 13 3 3zm9 12 7-8H5l7 8zm-1 2v4H7v2h10v-2h-4v-4h-2z"/>
+</svg>


### PR DESCRIPTION
## Summary
- use cocktail.svg for Cocktails tab icon
- add cocktail.svg asset

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a85360b8f883268214f97586da8d79