### PR TITLE
feat: add branded splash screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 // App.js
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
@@ -20,6 +20,7 @@ import IngredientsTabsScreen from "./src/screens/Ingredients/IngredientsTabsScre
 import EditCustomTagsScreen from "./src/screens/IngredientsTags/EditCustomTagsScreen";
 import { AppTheme } from "./src/theme";
 import ShakerResultsScreen from "./src/screens/ShakerResultsScreen";
+import SplashScreen from "./src/screens/SplashScreen";
 
 import CocktailIcon from "./assets/cocktail.svg";
 import ShakerIcon from "./assets/shaker.svg";
@@ -152,6 +153,17 @@ function Tabs() {
 }
 
 export default function App() {
+  const [showSplash, setShowSplash] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShowSplash(false), 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (showSplash) {
+    return <SplashScreen />;
+  }
+
   return (
     <PaperProvider theme={AppTheme}>
       <MenuProvider>

--- a/src/screens/SplashScreen.js
+++ b/src/screens/SplashScreen.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+import CocktailIcon from '../../assets/cocktail.svg';
+import ShakerIcon from '../../assets/shaker.svg';
+import IngredientIcon from '../../assets/lemon.svg';
+
+export default function SplashScreen() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.iconRow}>
+        <CocktailIcon width={64} height={64} />
+        <ShakerIcon width={64} height={64} style={styles.centerIcon} />
+        <IngredientIcon width={64} height={64} />
+      </View>
+      <Text style={styles.title}>Your bar</Text>
+      <Text style={styles.slogan}>Your rules</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  iconRow: {
+    flexDirection: 'row',
+    marginBottom: 24,
+    alignItems: 'center',
+  },
+  centerIcon: {
+    marginHorizontal: 16,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  slogan: {
+    fontSize: 16,
+    color: '#555',
+  },
+});


### PR DESCRIPTION
## Summary
- add a splash screen with icons and branding text
- show splash screen for a moment before main app loads

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a85d8c00d88326b5db156d3d52ff68