### PR TITLE
feat: cycle splash icons

### DIFF
--- a/src/screens/SplashScreen.js
+++ b/src/screens/SplashScreen.js
@@ -1,17 +1,53 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
 import CocktailIcon from '../../assets/cocktail.svg';
 import ShakerIcon from '../../assets/shaker.svg';
 import IngredientIcon from '../../assets/lemon.svg';
 
+const icons = [CocktailIcon, ShakerIcon, IngredientIcon];
+
+function getRandomOtherIndex(current) {
+  let next = current;
+  while (next === current) {
+    next = Math.floor(Math.random() * icons.length);
+  }
+  return next;
+}
+
 export default function SplashScreen() {
+  const [index1, setIndex1] = useState(0);
+  const [index2, setIndex2] = useState(1);
+  const [index3, setIndex3] = useState(2);
+
+  useEffect(() => {
+    const int1 = setInterval(() => {
+      setIndex1(i => getRandomOtherIndex(i));
+    }, 300);
+    const int2 = setInterval(() => {
+      setIndex2(i => getRandomOtherIndex(i));
+    }, 400);
+    const int3 = setInterval(() => {
+      setIndex3(i => getRandomOtherIndex(i));
+    }, 500);
+
+    return () => {
+      clearInterval(int1);
+      clearInterval(int2);
+      clearInterval(int3);
+    };
+  }, []);
+
+  const Icon1 = icons[index1];
+  const Icon2 = icons[index2];
+  const Icon3 = icons[index3];
+
   return (
     <View style={styles.container}>
       <View style={styles.iconRow}>
-        <CocktailIcon width={64} height={64} />
-        <ShakerIcon width={64} height={64} style={styles.centerIcon} />
-        <IngredientIcon width={64} height={64} />
+        <Icon1 width={64} height={64} />
+        <Icon2 width={64} height={64} style={styles.centerIcon} />
+        <Icon3 width={64} height={64} />
       </View>
       <Text style={styles.title}>Your bar</Text>
       <Text style={styles.slogan}>Your rules</Text>


### PR DESCRIPTION
## Summary
- Randomize three splash screen icons independently every 0.3s, 0.4s, and 0.5s

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a85ef038b483269ded6c0161a2adc7