### PR TITLE
Use white background behind cocktail icons

### DIFF
--- a/src/components/CocktailRow.js
+++ b/src/components/CocktailRow.js
@@ -68,13 +68,13 @@ function CocktailRow({
         {photoUri ? (
           <Image
             source={{ uri: photoUri }}
-            style={[styles.image, { backgroundColor: theme.colors.surface }]}
+            style={[styles.image, { backgroundColor: theme.colors.background }]}
             resizeMode="contain"
           />
         ) : glassImage ? (
           <Image
             source={glassImage}
-            style={[styles.image, { backgroundColor: theme.colors.surface }]}
+            style={[styles.image, { backgroundColor: theme.colors.background }]}
             resizeMode="contain"
           />
         ) : (
@@ -82,7 +82,7 @@ function CocktailRow({
             style={[
               styles.image,
               styles.placeholder,
-              { backgroundColor: theme.colors.surface },
+              { backgroundColor: theme.colors.background },
             ]}
           >
             <Text


### PR DESCRIPTION
## Summary
- make cocktail list thumbnails use the app background instead of surface grey

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a89797fe9c8326a36bc72a412d9af4