### PR TITLE
feat: add start screen setting

### DIFF
--- a/App.js
+++ b/App.js
@@ -26,6 +26,7 @@ import CocktailIcon from "./assets/cocktail.svg";
 import ShakerIcon from "./assets/shaker.svg";
 import IngredientIcon from "./assets/lemon.svg";
 import useIngredientsData from "./src/hooks/useIngredientsData";
+import { getStartScreen } from "./src/storage/settingsStorage";
 
 
 const Tab = createBottomTabNavigator();
@@ -79,11 +80,13 @@ function ShakerStackScreen() {
   );
 }
 
-function Tabs() {
+function Tabs({ startScreen }) {
   const theme = useTheme();
   const { getTab } = useTabMemory();
+  const [startTab, startSub] = (startScreen || "cocktails:All").split(":");
   return (
     <Tab.Navigator
+      initialRouteName={startTab === "ingredients" ? "Ingredients" : "Cocktails"}
       screenOptions={({ route }) => ({
         headerShown: false,
         tabBarIcon: ({ color, size }) => {
@@ -110,6 +113,7 @@ function Tabs() {
         name="Cocktails"
         component={CocktailsTabsScreen}
         options={{ unmountOnBlur: true }}
+        initialParams={{ screen: startTab === "cocktails" ? startSub : "All" }}
         listeners={({ navigation }) => ({
           tabPress: (e) => {
             e.preventDefault();
@@ -136,6 +140,7 @@ function Tabs() {
         name="Ingredients"
         component={IngredientsTabsScreen}
         options={{ unmountOnBlur: true }}
+        initialParams={{ screen: startTab === "ingredients" ? startSub : "All" }}
         listeners={({ navigation }) => ({
           tabPress: (e) => {
             e.preventDefault();
@@ -154,13 +159,15 @@ function Tabs() {
 
 export default function App() {
   const [showSplash, setShowSplash] = useState(true);
+  const [startScreen, setStartScreen] = useState(null);
 
   useEffect(() => {
     const timer = setTimeout(() => setShowSplash(false), 2000);
+    getStartScreen().then((v) => setStartScreen(v));
     return () => clearTimeout(timer);
   }, []);
 
-  if (showSplash) {
+  if (showSplash || !startScreen) {
     return <SplashScreen />;
   }
 
@@ -173,11 +180,9 @@ export default function App() {
               <TabMemoryProvider>
                 <NavigationContainer>
                   <RootStack.Navigator>
-                    <RootStack.Screen
-                      name="Tabs"
-                      component={Tabs}
-                      options={{ headerShown: false }}
-                    />
+                    <RootStack.Screen name="Tabs" options={{ headerShown: false }}>
+                      {() => <Tabs startScreen={startScreen} />}
+                    </RootStack.Screen>
                     <RootStack.Screen
                       name="EditCustomTags"
                       component={EditCustomTagsScreen}

--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -18,6 +18,7 @@ import CocktailIcon from "../../assets/cocktail.svg";
 import IngredientTagsModal from "./IngredientTagsModal";
 import CocktailTagsModal from "./CocktailTagsModal";
 import FavoritesRatingModal from "./FavoritesRatingModal";
+import StartScreenModal from "./StartScreenModal";
 import ConfirmationDialog from "./ConfirmationDialog";
 import useIngredientsData from "../hooks/useIngredientsData";
 import { exportAllData, importAllData, exportAllPhotos } from "../storage/backupStorage";
@@ -37,6 +38,8 @@ import {
   addTabsOnTopListener,
   getAllowSubstitutes,
   setAllowSubstitutes as saveAllowSubstitutes,
+  getStartScreen,
+  setStartScreen as saveStartScreen,
 } from "../storage/settingsStorage";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
@@ -109,9 +112,20 @@ export default function GeneralMenu({ visible, onClose }) {
   const [cocktailTagsVisible, setCocktailTagsVisible] = useState(false);
   const [ratingVisible, setRatingVisible] = useState(false);
   const [favRating, setFavRating] = useState(0);
+  const [startScreen, setStartScreen] = useState("cocktails:All");
+  const [startVisible, setStartVisible] = useState(false);
   const [dialog, setDialog] = useState({ visible: false, title: "", message: "" });
 
   const { refresh } = useIngredientsData();
+
+  const startLabels = {
+    "cocktails:All": "Cocktails - All",
+    "cocktails:My": "Cocktails - My",
+    "cocktails:Favorite": "Cocktails - Favorites",
+    "ingredients:All": "Ingredients - All",
+    "ingredients:My": "Ingredients - My",
+    "ingredients:Shopping": "Ingredients - Shopping",
+  };
 
   useEffect(() => {
     if (visible) {
@@ -142,6 +156,11 @@ export default function GeneralMenu({ visible, onClose }) {
   const openRatingModal = () => {
     onClose?.();
     setTimeout(() => setRatingVisible(true), 0);
+  };
+
+  const openStartScreenModal = () => {
+    onClose?.();
+    setTimeout(() => setStartVisible(true), 0);
   };
 
   const handleExportPhotos = async () => {
@@ -216,6 +235,12 @@ export default function GeneralMenu({ visible, onClose }) {
         setFavRating(stored);
       } catch {}
     })();
+    (async () => {
+      try {
+        const stored = await getStartScreen();
+        setStartScreen(stored || "cocktails:All");
+      } catch {}
+    })();
   }, []);
 
   useEffect(() => {
@@ -274,6 +299,11 @@ export default function GeneralMenu({ visible, onClose }) {
   const handleSelectRating = (value) => {
     setFavRating(value);
     saveFavoritesMinRating(value);
+  };
+
+  const handleSelectStart = (value) => {
+    setStartScreen(value);
+    saveStartScreen(value);
   };
 
   const closeTagsModal = () => setTagsVisible(false);
@@ -378,6 +408,28 @@ export default function GeneralMenu({ visible, onClose }) {
                   ) : (
                     <Text style={styles.itemSub}>Show all favorite cocktails</Text>
                   )}
+                </View>
+                <MaterialIcons
+                  name="chevron-right"
+                  size={24}
+                  color={theme.colors.onSurfaceVariant}
+                  style={styles.chevron}
+                />
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.linkRow}
+                onPress={openStartScreenModal}
+              >
+                <MaterialIcons
+                  name="home"
+                  size={22}
+                  color={theme.colors.primary}
+                  style={styles.linkIcon}
+                />
+                <View style={styles.itemText}>
+                  <Text style={styles.itemTitle}>Start screen</Text>
+                  <Text style={styles.itemSub}>{startLabels[startScreen]}</Text>
                 </View>
                 <MaterialIcons
                   name="chevron-right"
@@ -495,6 +547,12 @@ export default function GeneralMenu({ visible, onClose }) {
         rating={favRating}
         onSelect={handleSelectRating}
         onClose={() => setRatingVisible(false)}
+      />
+      <StartScreenModal
+        visible={startVisible}
+        value={startScreen}
+        onSelect={handleSelectStart}
+        onClose={() => setStartVisible(false)}
       />
       <ConfirmationDialog
         visible={dialog.visible}

--- a/src/components/StartScreenModal.js
+++ b/src/components/StartScreenModal.js
@@ -1,0 +1,84 @@
+import React from "react";
+import {
+  Modal,
+  Pressable,
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+} from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { useTheme } from "react-native-paper";
+
+const OPTIONS = [
+  { key: "cocktails:All", label: "Cocktails - All" },
+  { key: "cocktails:My", label: "Cocktails - My" },
+  { key: "cocktails:Favorite", label: "Cocktails - Favorites" },
+  { key: "ingredients:All", label: "Ingredients - All" },
+  { key: "ingredients:My", label: "Ingredients - My" },
+  { key: "ingredients:Shopping", label: "Ingredients - Shopping" },
+];
+
+export default function StartScreenModal({ visible, value, onSelect, onClose }) {
+  const theme = useTheme();
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        overlay: {
+          flex: 1,
+          backgroundColor: theme.colors.backdrop,
+          justifyContent: "center",
+          alignItems: "center",
+        },
+        box: {
+          padding: 24,
+          borderRadius: 8,
+          backgroundColor: theme.colors.background,
+          width: 280,
+        },
+        title: { fontSize: 18, fontWeight: "600", marginBottom: 16, textAlign: "center" },
+        option: {
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          paddingVertical: 8,
+        },
+        optionText: { fontSize: 16 },
+      }),
+    [theme]
+  );
+
+  const handleSelect = (val) => {
+    onSelect?.(val);
+    onClose?.();
+  };
+
+  return (
+    <Modal transparent visible={visible} animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <View style={styles.box} onStartShouldSetResponder={() => true}>
+          <Text style={styles.title}>Start screen</Text>
+          {OPTIONS.map((opt) => (
+            <TouchableOpacity
+              key={opt.key}
+              style={styles.option}
+              onPress={() => handleSelect(opt.key)}
+            >
+              <Text
+                style={[
+                  styles.optionText,
+                  value === opt.key && { color: theme.colors.primary },
+                ]}
+              >
+                {opt.label}
+              </Text>
+              {value === opt.key && (
+                <MaterialIcons name="check" size={24} color={theme.colors.primary} />
+              )}
+            </TouchableOpacity>
+          ))}
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -21,13 +21,15 @@ import useTabsOnTop from "../../hooks/useTabsOnTop";
 const Tab = createBottomTabNavigator();
 const Stack = createNativeStackNavigator();
 
-function CocktailTabs() {
+function CocktailTabs({ route }) {
   const theme = useTheme();
   const navigation = useNavigation();
   const tabsOnTop = useTabsOnTop();
+  const initial = route?.params?.screen || "All";
   return (
     <>
       <Tab.Navigator
+        initialRouteName={initial}
         screenOptions={({ route }) => {
           const options = {
             headerShown: false,
@@ -72,13 +74,14 @@ function CocktailTabs() {
   );
 }
 
-export default function CocktailsTabsScreen() {
+export default function CocktailsTabsScreen({ route }) {
   return (
     <Stack.Navigator>
       <Stack.Screen
         name="CocktailsMain"
         component={CocktailTabs}
         options={{ headerShown: false }}
+        initialParams={{ screen: route?.params?.screen }}
       />
       <Stack.Screen
         name="CocktailDetails"

--- a/src/screens/Ingredients/IngredientsTabsScreen.js
+++ b/src/screens/Ingredients/IngredientsTabsScreen.js
@@ -21,13 +21,15 @@ import useTabsOnTop from "../../hooks/useTabsOnTop";
 const Tab = createBottomTabNavigator();
 const Stack = createNativeStackNavigator();
 
-function IngredientTabs() {
+function IngredientTabs({ route }) {
   const theme = useTheme();
   const navigation = useNavigation();
   const tabsOnTop = useTabsOnTop();
+  const initial = route?.params?.screen || "All";
   return (
     <>
       <Tab.Navigator
+        initialRouteName={initial}
         screenOptions={({ route }) => {
           const options = {
             headerShown: false,
@@ -72,13 +74,14 @@ function IngredientTabs() {
   );
 }
 
-export default function IngredientsTabsScreen() {
+export default function IngredientsTabsScreen({ route }) {
   return (
     <Stack.Navigator>
       <Stack.Screen
         name="IngredientsMain"
         component={IngredientTabs}
         options={{ headerShown: false }}
+        initialParams={{ screen: route?.params?.screen }}
       />
       <Stack.Screen
         name="IngredientDetails"

--- a/src/storage/settingsStorage.js
+++ b/src/storage/settingsStorage.js
@@ -7,6 +7,7 @@ const KEEP_AWAKE_KEY = "keepAwake";
 const FAVORITES_MIN_RATING_KEY = "favoritesMinRating";
 const TABS_ON_TOP_KEY = "tabsOnTop";
 const ALLOW_SUBSTITUTES_KEY = "allowSubstitutes";
+const START_SCREEN_KEY = "startScreen"; // format: "cocktails:All"
 
 export const IGNORE_GARNISH_EVENT = "ignoreGarnishChanged";
 export const KEEP_AWAKE_EVENT = "keepAwakeChanged";
@@ -140,4 +141,19 @@ export function addFavoritesMinRatingListener(listener) {
     FAVORITES_MIN_RATING_EVENT,
     listener
   );
+}
+
+export async function getStartScreen() {
+  try {
+    const value = await AsyncStorage.getItem(START_SCREEN_KEY);
+    return value || "cocktails:All";
+  } catch {
+    return "cocktails:All";
+  }
+}
+
+export async function setStartScreen(value) {
+  try {
+    await AsyncStorage.setItem(START_SCREEN_KEY, value);
+  } catch {}
 }


### PR DESCRIPTION
## Summary
- allow selecting default start screen in settings
- start screen options for cocktails and ingredients
- load app on the chosen tab on launch

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8980eb3988326ad953b99ee6eacbf