### PR TITLE
Show cocktail usage for ingredients in shaker

### DIFF
--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -173,7 +173,9 @@ export default function ShakerScreen({ navigation }) {
                       id={ing.id}
                       name={ing.name}
                       photoUri={ing.photoUri}
-                      usageCount={0}
+                      usageCount={ing.usageCount}
+                      singleCocktailName={ing.singleCocktailName}
+                      showMake
                       inBar={ing.inBar}
                       inShoppingList={ing.inShoppingList}
                       onPress={toggleIngredient}


### PR DESCRIPTION
## Summary
- Display ingredient cocktail usage in the shaker's ingredient list

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8a00929388326a8f50e1685e337cb