### PR TITLE
Fix spelling and unify app messaging

### DIFF
--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -346,7 +346,7 @@ export default function GeneralMenu({ visible, onClose }) {
                   style={styles.itemText}
                   onPress={toggleAllowSubstitutes}
                 >
-                  <Text style={styles.itemTitle}>Allways allow substitutes</Text>
+                  <Text style={styles.itemTitle}>Always allow substitutes</Text>
                   <Text style={styles.itemSub}>
                     Use base or branded alternatives regardless of recipe
                   </Text>

--- a/src/screens/SplashScreen.js
+++ b/src/screens/SplashScreen.js
@@ -49,7 +49,7 @@ export default function SplashScreen() {
         <Icon2 width={64} height={64} style={styles.centerIcon} />
         <Icon3 width={64} height={64} />
       </View>
-      <Text style={styles.title}>Your bar</Text>
+      <Text style={styles.title}>YourBar</Text>
       <Text style={styles.slogan}>Your rules</Text>
     </View>
   );

--- a/src/storage/backupStorage.js
+++ b/src/storage/backupStorage.js
@@ -63,7 +63,7 @@ export async function exportAllData() {
     if (await Sharing.isAvailableAsync()) {
       await Sharing.shareAsync(fileUri, {
         mimeType: 'application/json',
-        dialogTitle: 'Share yourbar backup',
+        dialogTitle: 'Share YourBar backup',
       });
     }
   } catch (e) {
@@ -129,7 +129,7 @@ export async function exportAllPhotos() {
     if (await Sharing.isAvailableAsync()) {
       await Sharing.shareAsync(fileUri, {
         mimeType: 'application/zip',
-        dialogTitle: 'Share yourbar photos',
+        dialogTitle: 'Share YourBar photos',
       });
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- fix typo in settings menu
- show app name with consistent styling in share dialogs and splash screen

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8a0a5e04483268eeec8bc73002777