### PR TITLE
Show branded indicator in shaker ingredient list

### DIFF
--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -178,6 +178,7 @@ export default function ShakerScreen({ navigation }) {
                       showMake
                       inBar={ing.inBar}
                       inShoppingList={ing.inShoppingList}
+                      baseIngredientId={ing.baseIngredientId}
                       onPress={toggleIngredient}
                       onDetails={(id) =>
                         navigation.push("IngredientDetails", { id })


### PR DESCRIPTION
## Summary
- show a blue stripe for branded ingredients in the shaker's ingredient selection list, matching My Ingredients

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8a58fdea88326b0305cc54ff984ed