### PR TITLE
Adjust scroll offset on form screens

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1547,6 +1547,7 @@ export default function AddCocktailScreen() {
       const visibleHeight = viewportHeight - kbHeight; // видиме поле над клавіатурою
       const targetCenter = visibleHeight / 2; // бажаний центр інпуту
       const DEAD = 10; // додатковий відступ
+      const EXTRA_SCROLL = 10; // підкручуємо трохи вище
 
       const tryOnce = () => {
         if (!nodeRef?.current) return;
@@ -1558,7 +1559,8 @@ export default function AddCocktailScreen() {
             // Скролимо лише вниз (піднімаємо контент), не опускаємо
             const targetY = Math.min(scrollY + delta + DEAD, maxY);
             if (targetY > scrollY) {
-              scrollRef.current.scrollTo({ y: targetY, animated: true });
+              const adjustedY = Math.min(targetY + EXTRA_SCROLL, maxY);
+              scrollRef.current.scrollTo({ y: adjustedY, animated: true });
             }
           }
         });

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1599,6 +1599,7 @@ export default function EditCocktailScreen() {
       const visibleHeight = viewportHeight - kbHeight; // видиме поле над клавіатурою
       const targetCenter = visibleHeight / 2; // бажаний центр інпуту
       const DEAD = 10; // додатковий відступ
+      const EXTRA_SCROLL = 10; // підкручуємо трохи вище
 
       const tryOnce = () => {
         if (!nodeRef?.current) return;
@@ -1610,7 +1611,8 @@ export default function EditCocktailScreen() {
             // Скролимо лише вниз (піднімаємо контент), не опускаємо
             const targetY = Math.min(scrollY + delta + DEAD, maxY);
             if (targetY > scrollY) {
-              scrollRef.current.scrollTo({ y: targetY, animated: true });
+              const adjustedY = Math.min(targetY + EXTRA_SCROLL, maxY);
+              scrollRef.current.scrollTo({ y: adjustedY, animated: true });
             }
           }
         });

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -225,6 +225,7 @@ export default function AddIngredientScreen() {
       const visibleHeight = viewportHeight - kbHeight;
       const targetCenter = visibleHeight / 2;
       const DEAD = 10;
+      const EXTRA_SCROLL = 10; // scroll a bit higher when moving up
 
       const tryOnce = () => {
         if (!nodeRef?.current) return;
@@ -235,7 +236,8 @@ export default function AddIngredientScreen() {
             const maxY = Math.max(0, contentH - viewportH);
             const targetY = Math.min(scrollY + delta + DEAD, maxY);
             if (targetY > scrollY) {
-              scrollRef.current.scrollTo({ y: targetY, animated: true });
+              const adjustedY = Math.min(targetY + EXTRA_SCROLL, maxY);
+              scrollRef.current.scrollTo({ y: adjustedY, animated: true });
             }
           }
         });

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -213,6 +213,7 @@ export default function EditIngredientScreen() {
       const visibleHeight = viewportHeight - kbHeight;
       const targetCenter = visibleHeight / 2;
       const DEAD = 10;
+      const EXTRA_SCROLL = 10; // scroll a bit higher when moving up
 
       const tryOnce = () => {
         if (!nodeRef?.current) return;
@@ -223,7 +224,8 @@ export default function EditIngredientScreen() {
             const maxY = Math.max(0, contentH - viewportH);
             const targetY = Math.min(scrollY + delta + DEAD, maxY);
             if (targetY > scrollY) {
-              scrollRef.current.scrollTo({ y: targetY, animated: true });
+              const adjustedY = Math.min(targetY + EXTRA_SCROLL, maxY);
+              scrollRef.current.scrollTo({ y: adjustedY, animated: true });
             }
           }
         });


### PR DESCRIPTION
## Summary
- overscroll by 10px when moving inputs into view on add/edit ingredient and cocktail screens
- avoid scrolling down when inputs are above target

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8b789bebc83269a35cdedf4aedd4c