### PR TITLE
Style shaker in-stock filter as themed checkbox

### DIFF
--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -6,7 +6,6 @@ import {
   ScrollView,
   TouchableOpacity,
   ActivityIndicator,
-  Switch,
 } from "react-native";
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
@@ -143,7 +142,21 @@ export default function ShakerScreen({ navigation }) {
         searchValue={search}
         setSearchValue={setSearch}
         filterComponent={
-          <Switch value={inStockOnly} onValueChange={setInStockOnly} />
+          <TouchableOpacity
+            onPress={() => setInStockOnly((prev) => !prev)}
+            style={{ paddingVertical: 4, paddingHorizontal: 2 }}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <MaterialIcons
+              name={inStockOnly ? "check-circle" : "radio-button-unchecked"}
+              size={22}
+              color={
+                inStockOnly
+                  ? theme.colors.primary
+                  : theme.colors.onSurfaceVariant
+              }
+            />
+          </TouchableOpacity>
         }
       />
       <ScrollView contentContainerStyle={styles.scroll}>


### PR DESCRIPTION
## Summary
- Replace Shaker screen's in-stock switch with a checkbox-style icon that matches ingredient checkboxes
- Use theme colors for the new checkbox icon

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8cbe576b88326833ace55087cba30