### PR TITLE
feat: keep substitute picker open

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1496,7 +1496,7 @@ export default function AddCocktailScreen() {
 
   const selectedGlass = getGlassById(glassId) || { name: "Cocktail glass" };
 
-  // Додавання сабституту з модалки + закриття модалки
+  // Додавання сабституту з модалки без її закриття
   const addSubstituteToTarget = useCallback(
     (ingredient) => {
       setIngs((prev) =>
@@ -1513,9 +1513,8 @@ export default function AddCocktailScreen() {
           };
         })
       );
-      closeSubstituteModal();
     },
-    [subModal.forLocalId, closeSubstituteModal]
+    [subModal.forLocalId]
   );
 
   /* ---------- Центрування інпута при focus ---------- */
@@ -1911,19 +1910,21 @@ export default function AddCocktailScreen() {
                     <Divider color={theme.colors.outlineVariant} />
                   ) : null}
                   <View style={styles.modalItemRow}>
-                    {item.photoUri ? (
-                      <Image
-                        source={{ uri: item.photoUri }}
-                        style={styles.modalItemAvatar}
-                      />
-                    ) : (
-                      <View
-                        style={[
-                          styles.modalItemAvatar,
-                          { backgroundColor: theme.colors.outlineVariant },
-                        ]}
-                      />
-                    )}
+                    <View style={styles.modalItemAvatar}>
+                      {item.photoUri ? (
+                        <Image
+                          source={{ uri: item.photoUri }}
+                          style={styles.modalItemImg}
+                          resizeMode="contain"
+                        />
+                      ) : (
+                        <MaterialIcons
+                          name="local-drink"
+                          size={20}
+                          color={withAlpha(theme.colors.onSurface, 0.5)}
+                        />
+                      )}
+                    </View>
                     <Text
                       style={{ color: theme.colors.onSurface, flex: 1 }}
                       numberOfLines={1}
@@ -2187,7 +2188,13 @@ const styles = StyleSheet.create({
   modalItemAvatar: {
     width: 32,
     height: 32,
-    aspectRatio: 1,
     borderRadius: 6,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modalItemImg: {
+    width: "100%",
+    height: "100%",
   },
 });

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -898,24 +898,28 @@ const IngredientRow = memo(function IngredientRow({
             Substitutes
           </Text>
           <View style={styles.subList}>
-            {row.substitutes.map((s) => (
-              <View
-                key={s.id}
-                style={[
-                  styles.subItem,
-                  {
-                    borderColor: theme.colors.outline,
-                    backgroundColor:
-                      theme.colors.surfaceVariant ??
-                      withAlpha(theme.colors.onSurface, 0.04),
-                  },
-                ]}
-              >
-                <Text
-                  style={{ color: theme.colors.onSurface, flex: 1 }}
-                  numberOfLines={1}
+              {row.substitutes.map((s) => (
+                <View
+                  key={s.id}
+                  style={[
+                    styles.subItem,
+                    s.baseIngredientId != null && {
+                      ...styles.brandedStripe,
+                      borderLeftColor: theme.colors.primary,
+                    },
+                    {
+                      borderColor: theme.colors.outline,
+                      backgroundColor:
+                        theme.colors.surfaceVariant ??
+                        withAlpha(theme.colors.onSurface, 0.04),
+                    },
+                  ]}
                 >
-                  {s.name}
+                  <Text
+                    style={{ color: theme.colors.onSurface, flex: 1 }}
+                    numberOfLines={1}
+                  >
+                    {s.name}
                 </Text>
                 <Pressable
                   onPress={() =>
@@ -1909,14 +1913,22 @@ export default function AddCocktailScreen() {
                   {index > 0 ? (
                     <Divider color={theme.colors.outlineVariant} />
                   ) : null}
-                  <View style={styles.modalItemRow}>
-                    <View style={styles.modalItemAvatar}>
-                      {item.photoUri ? (
-                        <Image
-                          source={{ uri: item.photoUri }}
-                          style={styles.modalItemImg}
-                          resizeMode="contain"
-                        />
+                    <View
+                      style={[
+                        styles.modalItemRow,
+                        item.baseIngredientId != null && {
+                          ...styles.brandedStripe,
+                          borderLeftColor: theme.colors.primary,
+                        },
+                      ]}
+                    >
+                      <View style={styles.modalItemAvatar}>
+                        {item.photoUri ? (
+                          <Image
+                            source={{ uri: item.photoUri }}
+                            style={styles.modalItemImg}
+                            resizeMode="contain"
+                          />
                       ) : (
                         <MaterialIcons
                           name="local-drink"
@@ -2197,4 +2209,5 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
+  brandedStripe: { borderLeftWidth: 4, paddingLeft: 8 },
 });

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -40,6 +40,7 @@ import { TAG_COLORS } from "../../theme";
 import { MaterialIcons } from "@expo/vector-icons";
 import { HeaderBackButton } from "@react-navigation/elements";
 import { useTabMemory } from "../../context/TabMemoryContext";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import {
   Menu,
@@ -1095,6 +1096,8 @@ export default function AddCocktailScreen() {
   const fromIngredientFlow = initialIngredient != null;
   const lastCocktailsTab =
     (typeof getTab === "function" && getTab("cocktails")) || "All";
+  const insets = useSafeAreaInsets();
+  const subSearchRef = useRef(null);
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -1247,6 +1250,12 @@ export default function AddCocktailScreen() {
     query: "",
   });
   const debouncedSubQuery = useDebounced(subModal.query, 150);
+
+  useEffect(() => {
+    if (subModal.visible) {
+      setTimeout(() => subSearchRef.current?.focus(), 0);
+    }
+  }, [subModal.visible]);
 
   const openSubstituteModal = useCallback((localId) => {
     setSubModal({ visible: true, forLocalId: localId, query: "" });
@@ -1862,6 +1871,7 @@ export default function AddCocktailScreen() {
           contentContainerStyle={[
             styles.modalContainer,
             {
+              marginTop: insets.top + 50,
               backgroundColor: theme.colors.surface,
               borderColor: theme.colors.outline,
             },
@@ -1872,6 +1882,8 @@ export default function AddCocktailScreen() {
           </Text>
 
           <TextInput
+            ref={subSearchRef}
+            autoFocus
             placeholder="Search ingredient..."
             placeholderTextColor={theme.colors.onSurfaceVariant}
             value={subModal.query}

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -38,9 +38,8 @@ import {
 import { useTheme, Portal, Modal } from "react-native-paper";
 import { TAG_COLORS } from "../../theme";
 import { MaterialIcons } from "@expo/vector-icons";
-import { HeaderBackButton } from "@react-navigation/elements";
+import { HeaderBackButton, useHeaderHeight } from "@react-navigation/elements";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import {
   Menu,
@@ -1096,7 +1095,7 @@ export default function AddCocktailScreen() {
   const fromIngredientFlow = initialIngredient != null;
   const lastCocktailsTab =
     (typeof getTab === "function" && getTab("cocktails")) || "All";
-  const insets = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight();
   const subSearchRef = useRef(null);
 
   useLayoutEffect(() => {
@@ -1871,7 +1870,7 @@ export default function AddCocktailScreen() {
           contentContainerStyle={[
             styles.modalContainer,
             {
-              marginTop: insets.top + 50,
+              marginTop: headerHeight,
               backgroundColor: theme.colors.surface,
               borderColor: theme.colors.outline,
             },

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -905,24 +905,28 @@ const IngredientRow = memo(function IngredientRow({
             Substitutes
           </Text>
           <View style={styles.subList}>
-            {row.substitutes.map((s) => (
-              <View
-                key={s.id}
-                style={[
-                  styles.subItem,
-                  {
-                    borderColor: theme.colors.outline,
-                    backgroundColor:
-                      theme.colors.surfaceVariant ??
-                      withAlpha(theme.colors.onSurface, 0.04),
-                  },
-                ]}
-              >
-                <Text
-                  style={{ color: theme.colors.onSurface, flex: 1 }}
-                  numberOfLines={1}
+              {row.substitutes.map((s) => (
+                <View
+                  key={s.id}
+                  style={[
+                    styles.subItem,
+                    s.baseIngredientId != null && {
+                      ...styles.brandedStripe,
+                      borderLeftColor: theme.colors.primary,
+                    },
+                    {
+                      borderColor: theme.colors.outline,
+                      backgroundColor:
+                        theme.colors.surfaceVariant ??
+                        withAlpha(theme.colors.onSurface, 0.04),
+                    },
+                  ]}
                 >
-                  {s.name}
+                  <Text
+                    style={{ color: theme.colors.onSurface, flex: 1 }}
+                    numberOfLines={1}
+                  >
+                    {s.name}
                 </Text>
                 <Pressable
                   onPress={() =>
@@ -1957,14 +1961,22 @@ export default function EditCocktailScreen() {
                   {index > 0 ? (
                     <Divider color={theme.colors.outlineVariant} />
                   ) : null}
-                  <View style={styles.modalItemRow}>
-                    <View style={styles.modalItemAvatar}>
-                      {item.photoUri ? (
-                        <Image
-                          source={{ uri: item.photoUri }}
-                          style={styles.modalItemImg}
-                          resizeMode="contain"
-                        />
+                    <View
+                      style={[
+                        styles.modalItemRow,
+                        item.baseIngredientId != null && {
+                          ...styles.brandedStripe,
+                          borderLeftColor: theme.colors.primary,
+                        },
+                      ]}
+                    >
+                      <View style={styles.modalItemAvatar}>
+                        {item.photoUri ? (
+                          <Image
+                            source={{ uri: item.photoUri }}
+                            style={styles.modalItemImg}
+                            resizeMode="contain"
+                          />
                       ) : (
                         <MaterialIcons
                           name="local-drink"
@@ -2324,4 +2336,5 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
+  brandedStripe: { borderLeftWidth: 4, paddingLeft: 8 },
 });

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -1548,7 +1548,7 @@ export default function EditCocktailScreen() {
 
   const selectedGlass = getGlassById(glassId) || { name: "Cocktail glass" };
 
-  // Додавання сабституту з модалки + закриття модалки
+  // Додавання сабституту з модалки без її закриття
   const addSubstituteToTarget = useCallback(
     (ingredient) => {
       setIngs((prev) =>
@@ -1565,9 +1565,8 @@ export default function EditCocktailScreen() {
           };
         })
       );
-      closeSubstituteModal();
     },
-    [subModal.forLocalId, closeSubstituteModal]
+    [subModal.forLocalId]
   );
 
   /* ---------- Центрування інпута при focus ---------- */
@@ -1959,19 +1958,21 @@ export default function EditCocktailScreen() {
                     <Divider color={theme.colors.outlineVariant} />
                   ) : null}
                   <View style={styles.modalItemRow}>
-                    {item.photoUri ? (
-                      <Image
-                        source={{ uri: item.photoUri }}
-                        style={styles.modalItemAvatar}
-                      />
-                    ) : (
-                      <View
-                        style={[
-                          styles.modalItemAvatar,
-                          { backgroundColor: theme.colors.outlineVariant },
-                        ]}
-                      />
-                    )}
+                    <View style={styles.modalItemAvatar}>
+                      {item.photoUri ? (
+                        <Image
+                          source={{ uri: item.photoUri }}
+                          style={styles.modalItemImg}
+                          resizeMode="contain"
+                        />
+                      ) : (
+                        <MaterialIcons
+                          name="local-drink"
+                          size={20}
+                          color={withAlpha(theme.colors.onSurface, 0.5)}
+                        />
+                      )}
+                    </View>
                     <Text
                       style={{ color: theme.colors.onSurface, flex: 1 }}
                       numberOfLines={1}
@@ -2314,7 +2315,13 @@ const styles = StyleSheet.create({
   modalItemAvatar: {
     width: 32,
     height: 32,
-    aspectRatio: 1,
     borderRadius: 6,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modalItemImg: {
+    width: "100%",
+    height: "100%",
   },
 });

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -37,8 +37,7 @@ import {
 } from "@react-navigation/native";
 import { useTheme, Portal, Modal } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
-import { HeaderBackButton } from "@react-navigation/elements";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { HeaderBackButton, useHeaderHeight } from "@react-navigation/elements";
 
 import {
   Menu,
@@ -1091,7 +1090,7 @@ export default function EditCocktailScreen() {
   const route = useRoute();
   const params = route.params || {};
   const cocktailId = params?.id;
-  const { 
+  const {
     ingredients,
     cocktails,
     setCocktails,
@@ -1100,7 +1099,7 @@ export default function EditCocktailScreen() {
     setIngredients,
   } = useIngredientUsage();
 
-  const insets = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight();
   const subSearchRef = useRef(null);
 
   const [loading, setLoading] = useState(true);
@@ -1920,7 +1919,7 @@ export default function EditCocktailScreen() {
           contentContainerStyle={[
             styles.modalContainer,
             {
-              marginTop: insets.top + 50,
+              marginTop: headerHeight,
               backgroundColor: theme.colors.surface,
               borderColor: theme.colors.outline,
             },

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -38,6 +38,7 @@ import {
 import { useTheme, Portal, Modal } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import { HeaderBackButton } from "@react-navigation/elements";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import {
   Menu,
@@ -1090,7 +1091,7 @@ export default function EditCocktailScreen() {
   const route = useRoute();
   const params = route.params || {};
   const cocktailId = params?.id;
-  const {
+  const { 
     ingredients,
     cocktails,
     setCocktails,
@@ -1098,6 +1099,9 @@ export default function EditCocktailScreen() {
     setUsageMap,
     setIngredients,
   } = useIngredientUsage();
+
+  const insets = useSafeAreaInsets();
+  const subSearchRef = useRef(null);
 
   const [loading, setLoading] = useState(true);
   const [name, setName] = useState("");
@@ -1395,6 +1399,12 @@ export default function EditCocktailScreen() {
     query: "",
   });
   const debouncedSubQuery = useDebounced(subModal.query, 150);
+
+  useEffect(() => {
+    if (subModal.visible) {
+      setTimeout(() => subSearchRef.current?.focus(), 0);
+    }
+  }, [subModal.visible]);
 
   const openSubstituteModal = useCallback((localId) => {
     setSubModal({ visible: true, forLocalId: localId, query: "" });
@@ -1910,6 +1920,7 @@ export default function EditCocktailScreen() {
           contentContainerStyle={[
             styles.modalContainer,
             {
+              marginTop: insets.top + 50,
               backgroundColor: theme.colors.surface,
               borderColor: theme.colors.outline,
             },
@@ -1920,6 +1931,8 @@ export default function EditCocktailScreen() {
           </Text>
 
           <TextInput
+            ref={subSearchRef}
+            autoFocus
             placeholder="Search ingredient..."
             placeholderTextColor={theme.colors.onSurfaceVariant}
             value={subModal.query}


### PR DESCRIPTION
## Summary
- keep substitute picker open after adding ingredient
- show ingredient thumbnails uncropped on white placeholders

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f82197108326b0078b5a2d2cc1e8