### PR TITLE
Optimize storage and shaker performance

### DIFF
--- a/scripts/importCocktailsAndIngredients.js
+++ b/scripts/importCocktailsAndIngredients.js
@@ -3,6 +3,7 @@ import RAW_DATA from "../assets/data/data.json";
 import { BUILTIN_INGREDIENT_TAGS } from "../src/constants/ingredientTags";
 import { BUILTIN_COCKTAIL_TAGS } from "../src/constants/cocktailTags";
 import { replaceAllCocktails } from "../src/storage/cocktailsStorage";
+import { normalizeSearch } from "../src/utils/normalizeSearch";
 import { Image } from "react-native";
 import { ASSET_MAP } from "./assetMap";
 
@@ -63,6 +64,7 @@ function sanitizeCocktails(raw) {
         photoUri: resolvePhoto(c?.photoUri || c?.image),
         tags: mapTags(c?.tags, COCKTAIL_TAG_BY_ID),
         ingredients: Array.isArray(c?.ingredients) ? c.ingredients : [],
+        searchName: normalizeSearch(String(c?.name ?? "")),
       }))
     : [];
 }

--- a/src/hooks/useIngredientsData.js
+++ b/src/hooks/useIngredientsData.js
@@ -16,7 +16,7 @@ import {
 } from "../storage/settingsStorage";
 
 export default function useIngredientsData() {
-  const { ingredients, setIngredients } = useIngredientsContext();
+  const { ingredients, baseIngredients, setIngredients } = useIngredientsContext();
   const { cocktails, setCocktails } = useCocktailsContext();
   const { usageMap, setUsageMap } = useUsageMapContext();
   const { loading, setLoading } = useLoadingContext();
@@ -70,5 +70,13 @@ export default function useIngredientsData() {
     await load();
   }, [load]);
 
-  return { ingredients, cocktails, usageMap, refresh, loading, setIngredients };
+  return {
+    ingredients,
+    baseIngredients,
+    cocktails,
+    usageMap,
+    refresh,
+    loading,
+    setIngredients,
+  };
 }

--- a/src/hooks/useIngredientsData.js
+++ b/src/hooks/useIngredientsData.js
@@ -2,25 +2,24 @@ import { useCallback, useContext, useEffect } from "react";
 import { getAllIngredients } from "../storage/ingredientsStorage";
 import { getAllCocktails } from "../storage/cocktailsStorage";
 import { importCocktailsAndIngredients } from "../../scripts/importCocktailsAndIngredients";
-import { mapCocktailsByIngredient } from "../utils/ingredientUsage";
+import { mapCocktailsByIngredientAsync } from "../utils/ingredientUsage";
 import { normalizeSearch } from "../utils/normalizeSearch";
-import IngredientUsageContext from "../context/IngredientUsageContext";
+import {
+  useIngredientsContext,
+  useCocktailsContext,
+  useUsageMapContext,
+  useLoadingContext,
+} from "../context/IngredientUsageContext";
 import {
   getAllowSubstitutes,
   addAllowSubstitutesListener,
 } from "../storage/settingsStorage";
 
 export default function useIngredientsData() {
-  const {
-    ingredients,
-    setIngredients,
-    cocktails,
-    setCocktails,
-    usageMap,
-    setUsageMap,
-    loading,
-    setLoading,
-  } = useContext(IngredientUsageContext);
+  const { ingredients, setIngredients } = useIngredientsContext();
+  const { cocktails, setCocktails } = useCocktailsContext();
+  const { usageMap, setUsageMap } = useUsageMapContext();
+  const { loading, setLoading } = useLoadingContext();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -33,7 +32,7 @@ export default function useIngredientsData() {
     const sorted = [...ing].sort((a, b) =>
       a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
     );
-    const map = mapCocktailsByIngredient(sorted, cocks, {
+    const map = await mapCocktailsByIngredientAsync(sorted, cocks, {
       allowSubstitutes: !!allowSubs,
     });
     const cocktailMap = new Map(cocks.map((c) => [c.id, c.name]));

--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -27,7 +27,10 @@ import { getAllCocktailTags } from "../../storage/cocktailTagsStorage";
 import CocktailRow, {
   COCKTAIL_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/CocktailRow";
-import { useIngredientUsage } from "../../context/IngredientUsageContext";
+import {
+  useIngredientsContext,
+  useCocktailsContext,
+} from "../../context/IngredientUsageContext";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 
 export default function AllCocktailsScreen() {
@@ -48,8 +51,8 @@ export default function AllCocktailsScreen() {
   const [availableTags, setAvailableTags] = useState([]);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
   const [allowSubstitutes, setAllowSubstitutes] = useState(false);
-  const { cocktails: globalCocktails = [], ingredients: globalIngredients = [] } =
-    useIngredientUsage();
+  const { ingredients: globalIngredients = [] } = useIngredientsContext();
+  const { cocktails: globalCocktails = [] } = useCocktailsContext();
 
   useEffect(() => {
     if (isFocused) setTab("cocktails", "All");
@@ -116,7 +119,7 @@ export default function AllCocktailsScreen() {
       );
     const q = normalizeSearch(searchDebounced);
     let list = cocktails;
-    if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
+    if (q) list = list.filter((c) => c.searchName.includes(q));
     if (selectedTagIds.length > 0)
       list = list.filter(
         (c) =>

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -181,7 +181,8 @@ export default function CocktailDetailsScreen() {
   const navigation = useNavigation();
   const { id, backToIngredientId } = useRoute().params;
   const theme = useTheme();
-  const { ingredients: globalIngredients = [] } = useIngredientUsage();
+  const { ingredients: globalIngredients = [], setCocktails } =
+    useIngredientUsage();
 
   const [cocktail, setCocktail] = useState(null);
   const [ingMap, setIngMap] = useState(new Map());
@@ -213,10 +214,13 @@ export default function CocktailDetailsScreen() {
       if (!cocktail) return;
       const newRating = cocktail.rating === value ? 0 : value;
       const updated = { ...cocktail, rating: newRating };
-      setCocktail(updated);
-      await saveCocktail(updated);
+      const saved = await saveCocktail(updated);
+      setCocktail(saved);
+      setCocktails((prev) =>
+        prev.map((c) => (c.id === saved.id ? saved : c))
+      );
     },
-    [cocktail]
+    [cocktail, setCocktails]
   );
 
   useLayoutEffect(() => {

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -253,20 +253,22 @@ export default function MyCocktailsScreen() {
 
   const toggleShoppingList = useCallback(
     (id) => {
+      let newValue = false;
       setIngredients((prev) => {
         const item = prev.find((i) => String(i.id) === String(id));
         if (!item) return prev;
-        const updated = { ...item, inShoppingList: !item.inShoppingList };
+        newValue = !item.inShoppingList;
+        const updated = { ...item, inShoppingList: newValue };
         const next = updateIngredientById(prev, updated);
         saveIngredient(next).catch(() => {});
-        setGlobalIngredients((list) =>
-          updateIngredientById(list, {
-            id,
-            inShoppingList: updated.inShoppingList,
-          })
-        );
         return next;
       });
+      setGlobalIngredients((list) =>
+        updateIngredientById(list, {
+          id,
+          inShoppingList: newValue,
+        })
+      );
     },
     [setGlobalIngredients]
   );

--- a/src/utils/ingredientUsage.js
+++ b/src/utils/ingredientUsage.js
@@ -1,3 +1,5 @@
+import { InteractionManager } from "react-native";
+
 export function mapCocktailsByIngredient(ingredients, cocktails, options = {}) {
   const { allowSubstitutes = false } = options;
   const byId = new Map(ingredients.map((i) => [i.id, i]));
@@ -63,9 +65,9 @@ export function mapCocktailsByIngredient(ingredients, cocktails, options = {}) {
 
 export function mapCocktailsByIngredientAsync(ingredients, cocktails, options = {}) {
   return new Promise((resolve) => {
-    setTimeout(() => {
+    InteractionManager.runAfterInteractions(() => {
       resolve(mapCocktailsByIngredient(ingredients, cocktails, options));
-    }, 0);
+    });
   });
 }
 

--- a/src/utils/ingredientUsage.js
+++ b/src/utils/ingredientUsage.js
@@ -61,6 +61,14 @@ export function mapCocktailsByIngredient(ingredients, cocktails, options = {}) {
   return result;
 }
 
+export function mapCocktailsByIngredientAsync(ingredients, cocktails, options = {}) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(mapCocktailsByIngredient(ingredients, cocktails, options));
+    }, 0);
+  });
+}
+
 export function calculateIngredientUsage(ingredients, cocktails, options = {}) {
   const map = mapCocktailsByIngredient(ingredients, cocktails, options);
   const result = {};


### PR DESCRIPTION
## Summary
- cache ingredient and cocktail storage in memory with background flushes
- precompute cocktail `searchName` and use it for faster filtering
- virtualize ShakerScreen via SectionList and compute usage map asynchronously
- split IngredientUsageContext into focused slices

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a905154b2c8326a6bd031771650d8d