### PR TITLE
Fix garnish optionality and rating persistence

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -181,7 +181,11 @@ export default function CocktailDetailsScreen() {
   const navigation = useNavigation();
   const { id, backToIngredientId } = useRoute().params;
   const theme = useTheme();
-  const { ingredients: globalIngredients = [] } = useIngredientUsage();
+  const {
+    ingredients: globalIngredients = [],
+    cocktails: globalCocktails = [],
+    setCocktails: setGlobalCocktails,
+  } = useIngredientUsage();
 
   const [cocktail, setCocktail] = useState(null);
   const [ingMap, setIngMap] = useState(new Map());
@@ -214,9 +218,14 @@ export default function CocktailDetailsScreen() {
       const newRating = cocktail.rating === value ? 0 : value;
       const updated = { ...cocktail, rating: newRating };
       setCocktail(updated);
-      await saveCocktail(updated);
+      const saved = await saveCocktail(updated);
+      setGlobalCocktails((prev) =>
+        Array.isArray(prev)
+          ? prev.map((c) => (c.id === saved.id ? saved : c))
+          : prev
+      );
     },
-    [cocktail]
+    [cocktail, setGlobalCocktails]
   );
 
   useLayoutEffect(() => {

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -19,6 +19,8 @@ import { normalizeSearch } from "../utils/normalizeSearch";
 import {
   getAllowSubstitutes,
   addAllowSubstitutesListener,
+  getIgnoreGarnish,
+  addIgnoreGarnishListener,
 } from "../storage/settingsStorage";
 
 export default function ShakerScreen({ navigation }) {
@@ -31,6 +33,7 @@ export default function ShakerScreen({ navigation }) {
   const [search, setSearch] = useState("");
   const [inStockOnly, setInStockOnly] = useState(true);
   const [allowSubstitutes, setAllowSubstitutes] = useState(false);
+  const [ignoreGarnish, setIgnoreGarnish] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -96,13 +99,21 @@ export default function ShakerScreen({ navigation }) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const allow = await getAllowSubstitutes();
-      if (!cancelled) setAllowSubstitutes(!!allow);
+      const [allow, ig] = await Promise.all([
+        getAllowSubstitutes(),
+        getIgnoreGarnish(),
+      ]);
+      if (!cancelled) {
+        setAllowSubstitutes(!!allow);
+        setIgnoreGarnish(!!ig);
+      }
     })();
-    const sub = addAllowSubstitutesListener(setAllowSubstitutes);
+    const subAllow = addAllowSubstitutesListener(setAllowSubstitutes);
+    const subIg = addIgnoreGarnishListener(setIgnoreGarnish);
     return () => {
       cancelled = true;
-      sub.remove();
+      subAllow.remove();
+      subIg.remove();
     };
   }, []);
 
@@ -173,7 +184,9 @@ export default function ShakerScreen({ navigation }) {
     const ids = [];
     (cocktails || []).forEach((c) => {
       if (!recipeIds.includes(c.id)) return;
-      const required = (c.ingredients || []).filter((r) => !r.optional);
+      const required = (c.ingredients || []).filter(
+        (r) => !r.optional && !(ignoreGarnish && r.garnish)
+      );
       if (required.length === 0) return;
       for (const r of required) {
         if (!isSatisfied(r)) return;
@@ -182,7 +195,7 @@ export default function ShakerScreen({ navigation }) {
     });
 
     return { availableCount: ids.length, availableCocktailIds: ids };
-  }, [recipeIds, cocktails, ingredients, allowSubstitutes]);
+  }, [recipeIds, cocktails, ingredients, allowSubstitutes, ignoreGarnish]);
 
   const handleClear = () => setSelectedIds([]);
 


### PR DESCRIPTION
## Summary
- Respect global "Ignore garnishes" setting in Shaker and ShakerResults screens
- Persist updated cocktail ratings to list and favorites views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a9106635008326a5f610ce46924409