### PR TITLE
Resize uploaded images to 150px on longest side

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-document-picker": "~13.1.6",
     "expo-font": "~13.3.2",
     "expo-image-picker": "^16.1.4",
+    "expo-image-manipulator": "^12.8.2",
     "expo-sharing": "~13.1.5",
     "expo-status-bar": "~2.2.3",
     "jszip": "^3.10.1",

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -29,6 +29,7 @@ import Animated, {
   LinearTransition,
 } from "react-native-reanimated";
 import * as ImagePicker from "expo-image-picker";
+import { resizeImage } from "../../utils/images";
 import {
   useNavigation,
   useRoute,
@@ -1295,7 +1296,10 @@ export default function AddCocktailScreen() {
       allowsEditing: true,
       quality: 0.7,
     });
-    if (!result.canceled) setPhotoUri(result.assets[0].uri);
+    if (!result.canceled) {
+      const resized = await resizeImage(result.assets[0].uri);
+      setPhotoUri(resized);
+    }
   }, []);
 
   const toggleTagById = useCallback(

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -29,6 +29,7 @@ import Animated, {
   LinearTransition,
 } from "react-native-reanimated";
 import * as ImagePicker from "expo-image-picker";
+import { resizeImage } from "../../utils/images";
 import {
   useNavigation,
   useRoute,
@@ -1444,7 +1445,10 @@ export default function EditCocktailScreen() {
       allowsEditing: true,
       quality: 0.7,
     });
-    if (!result.canceled) setPhotoUri(result.assets[0].uri);
+    if (!result.canceled) {
+      const resized = await resizeImage(result.assets[0].uri);
+      setPhotoUri(resized);
+    }
   }, []);
 
   const toggleTagById = useCallback(

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -25,6 +25,7 @@ import {
   Keyboard,
 } from "react-native";
 import * as ImagePicker from "expo-image-picker";
+import { resizeImage } from "../../utils/images";
 import {
   useNavigation,
   useRoute,
@@ -388,7 +389,10 @@ export default function AddIngredientScreen() {
       allowsEditing: true,
       quality: 0.7,
     });
-    if (!result.canceled) setPhotoUri(result.assets[0].uri);
+    if (!result.canceled) {
+      const resized = await resizeImage(result.assets[0].uri);
+      setPhotoUri(resized);
+    }
   }, []);
 
   const handleSave = useCallback(async () => {

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -27,6 +27,7 @@ import {
   Keyboard,
 } from "react-native";
 import * as ImagePicker from "expo-image-picker";
+import { resizeImage } from "../../utils/images";
 import {
   useNavigation,
   useRoute,
@@ -438,7 +439,10 @@ export default function EditIngredientScreen() {
       allowsEditing: true,
       quality: 0.7,
     });
-    if (!result.canceled) setPhotoUri(result.assets[0].uri);
+    if (!result.canceled) {
+      const resized = await resizeImage(result.assets[0].uri);
+      setPhotoUri(resized);
+    }
   }, []);
 
   const handleSave = useCallback(

--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -1,0 +1,17 @@
+import * as ImageManipulator from 'expo-image-manipulator';
+
+export async function resizeImage(uri, maxSize = 150) {
+  try {
+    const info = await ImageManipulator.manipulateAsync(uri, []);
+    const resizeAction = info.width > info.height ? { resize: { width: maxSize } } : { resize: { height: maxSize } };
+    const result = await ImageManipulator.manipulateAsync(
+      uri,
+      [resizeAction],
+      { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG }
+    );
+    return result.uri;
+  } catch (e) {
+    console.warn('resizeImage failed', e);
+    return uri;
+  }
+}


### PR DESCRIPTION
## Summary
- add utility to resize images so the longest side is 150px
- resize ingredient and cocktail images on selection
- add expo-image-manipulator dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo-image-manipulator)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a98e8d0cb88326af3fd0a36ec6e732