### PR TITLE
Fix duplicate import logs by removing redundant refresh

### DIFF
--- a/App.js
+++ b/App.js
@@ -34,12 +34,7 @@ const RootStack = createNativeStackNavigator();
 const ShakerStack = createNativeStackNavigator();
 
 function InitialDataLoader({ children }) {
-  const { loading, refresh } = useIngredientsData();
-  useEffect(() => {
-    if (loading) {
-      refresh();
-    }
-  }, [loading, refresh]);
+  useIngredientsData();
   return children;
 }
 


### PR DESCRIPTION
## Summary
- simplify InitialDataLoader to rely solely on useIngredientsData for initial import

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9bac0ea148326a72b7bd6d812eb45