### PR TITLE
feat: lazy import default data

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,7 +4,10 @@ import { NavigationContainer } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { TabMemoryProvider, useTabMemory } from "./src/context/TabMemoryContext";
-import { IngredientUsageProvider } from "./src/context/IngredientUsageContext";
+import {
+  IngredientUsageProvider,
+  useIngredientUsage,
+} from "./src/context/IngredientUsageContext";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider as PaperProvider, useTheme } from "react-native-paper";
 import { MenuProvider } from "react-native-popup-menu";
@@ -35,6 +38,12 @@ const ShakerStack = createNativeStackNavigator();
 
 function InitialDataLoader({ children }) {
   useIngredientsData();
+  const { loading } = useIngredientUsage();
+  if (loading) {
+    return (
+      <SplashScreen message="Importing default data… This may take a moment" />
+    );
+  }
   return children;
 }
 

--- a/src/hooks/useIngredientsData.js
+++ b/src/hooks/useIngredientsData.js
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useEffect } from "react";
 import { getAllIngredients } from "../storage/ingredientsStorage";
 import { getAllCocktails } from "../storage/cocktailsStorage";
-import { importCocktailsAndIngredients } from "../../scripts/importCocktailsAndIngredients";
 import { mapCocktailsByIngredient } from "../utils/ingredientUsage";
 import { normalizeSearch } from "../utils/normalizeSearch";
 import { WORD_SPLIT_RE } from "../utils/wordPrefixMatch";
@@ -26,6 +25,13 @@ export default function useIngredientsData() {
 
   const load = useCallback(async () => {
     setLoading(true);
+    // Lazy-load heavy default data only when needed
+    console.log(
+      "Importing default data… This one-time operation may take a moment"
+    );
+    const { importCocktailsAndIngredients } = await import(
+      "../../scripts/importCocktailsAndIngredients"
+    );
     await importCocktailsAndIngredients({ force: false });
     const [ing, cocks, allowSubs] = await Promise.all([
       getAllIngredients(),

--- a/src/screens/SplashScreen.js
+++ b/src/screens/SplashScreen.js
@@ -15,7 +15,7 @@ function getRandomOtherIndex(current) {
   return next;
 }
 
-export default function SplashScreen() {
+export default function SplashScreen({ message }) {
   const [index1, setIndex1] = useState(0);
   const [index2, setIndex2] = useState(1);
   const [index3, setIndex3] = useState(2);
@@ -51,6 +51,7 @@ export default function SplashScreen() {
       </View>
       <Text style={styles.title}>YourBar</Text>
       <Text style={styles.slogan}>Your rules</Text>
+      {message ? <Text style={styles.message}>{message}</Text> : null}
     </View>
   );
 }
@@ -78,5 +79,12 @@ const styles = StyleSheet.create({
   slogan: {
     fontSize: 16,
     color: '#555',
+  },
+  message: {
+    marginTop: 16,
+    fontSize: 14,
+    color: '#555',
+    textAlign: 'center',
+    paddingHorizontal: 16,
   },
 });


### PR DESCRIPTION
## Summary
- load heavy default data only when needed and log one-time import message
- show splash message while importing default data

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9bc6e2d488326a4ae48c0430d458d