### PR TITLE
Split default data import message into two lines

### DIFF
--- a/App.js
+++ b/App.js
@@ -41,7 +41,7 @@ function InitialDataLoader({ children }) {
   const { loading } = useIngredientUsage();
   if (loading) {
     return (
-      <SplashScreen message="Importing default data… This may take a moment" />
+      <SplashScreen message={'Importing default data…\nThis may take a moment'} />
     );
   }
   return children;


### PR DESCRIPTION
## Summary
- break the default data import splash message into two lines for clearer display

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9c90d89d48326bc6fb9c81cfc11fb