### PR TITLE
Fix transparent image backgrounds

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -2046,6 +2046,7 @@ const styles = StyleSheet.create({
   mediaImg: {
     width: "100%",
     height: "100%",
+    backgroundColor: "#fff",
   },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -2181,6 +2181,7 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
     resizeMode: "contain",
+    backgroundColor: "#fff",
   },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -753,7 +753,13 @@ const styles = StyleSheet.create({
     alignItems: "center",
     alignSelf: "flex-start",
   },
-  image: { width: IMAGE_SIZE, height: IMAGE_SIZE, aspectRatio: 1, resizeMode: "contain" },
+  image: {
+    width: IMAGE_SIZE,
+    height: IMAGE_SIZE,
+    aspectRatio: 1,
+    resizeMode: "contain",
+    backgroundColor: "#fff",
+  },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },
   tag: {

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -921,7 +921,13 @@ const styles = StyleSheet.create({
     alignItems: "center",
     alignSelf: "flex-start",
   },
-  image: { width: IMAGE_SIZE, height: IMAGE_SIZE, aspectRatio: 1, resizeMode: "contain" },
+  image: {
+    width: IMAGE_SIZE,
+    height: IMAGE_SIZE,
+    aspectRatio: 1,
+    resizeMode: "contain",
+    backgroundColor: "#fff",
+  },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },
   tag: {

--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -7,7 +7,7 @@ export async function resizeImage(uri, maxSize = 150) {
     const result = await ImageManipulator.manipulateAsync(
       uri,
       [resizeAction],
-      { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG }
+      { compress: 0.7, format: ImageManipulator.SaveFormat.PNG }
     );
     return result.uri;
   } catch (e) {


### PR DESCRIPTION
## Summary
- save resized images as PNG to preserve transparency
- display uploaded images on white background

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa04e49be88326a4c43fc8c405ec0d