### PR TITLE
Reset AddIngredientScreen form when reopened

### DIFF
--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -195,7 +195,8 @@ export default function AddIngredientScreen() {
 
   useFocusEffect(
     useCallback(() => {
-      setName(route.params?.initialName || "");
+      const initName = route.params?.initialName;
+      setName(initName || "");
       setDescription("");
       setPhotoUri(null);
       setTags(() => {
@@ -204,10 +205,10 @@ export default function AddIngredientScreen() {
       });
       setBaseIngredientId(null);
       setBaseIngredientSearch("");
-      if (route.params?.initialName !== undefined) {
+      if (initName !== undefined) {
         navigation.setParams({ initialName: undefined });
       }
-    }, [navigation, route.params?.initialName])
+    }, [navigation])
   );
 
   // anchored menu


### PR DESCRIPTION
## Summary
- reset AddIngredientScreen fields when navigating back with new initialName
- clear navigation params after focus to avoid stale data

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa3c0b30cc8326a49aa568090d51bd