### PR TITLE
Reset ingredient form when reopened

### DIFF
--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -306,10 +306,21 @@ export default function AddIngredientScreen() {
 
   /* ---------- Lifecycle ---------- */
   useEffect(() => {
-    if (isFocused) {
-      setName(initialNameParam);
-    }
-  }, [isFocused, initialNameParam]);
+    if (!isFocused) return;
+
+    setName(initialNameParam);
+    setDescription("");
+    setPhotoUri(null);
+    setTags(() => {
+      const other = BUILTIN_INGREDIENT_TAGS.find((t) => t.id === 10);
+      return other
+        ? [other]
+        : [{ id: 10, name: "other", color: TAG_COLORS[15] }];
+    });
+    setBaseIngredientId(null);
+    setBaseIngredientSearch("");
+    navigation.setParams({ initialName: undefined });
+  }, [isFocused, initialNameParam, navigation]);
 
   useEffect(() => {
     if (!isFocused) return;


### PR DESCRIPTION
## Summary
- Reset AddIngredientScreen state when returning from cocktail flow so form opens clean

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa3b51ad688326a8e6b975203c7e14