### PR TITLE
Store ingredients individually for faster updates

### DIFF
--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -258,7 +258,7 @@ export default function MyCocktailsScreen() {
         if (!item) return prev;
         const updated = { ...item, inShoppingList: !item.inShoppingList };
         const next = updateIngredientById(prev, updated);
-        saveIngredient(next).catch(() => {});
+        saveIngredient(updated).catch(() => {});
         setGlobalIngredients((list) =>
           updateIngredientById(list, {
             id,

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -1,10 +1,26 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-const INGREDIENTS_KEY = "ingredients";
+const INGREDIENTS_KEY = "ingredients"; // stores list of ids
+const INGREDIENT_PREFIX = "ingredient:";
 
 export async function getAllIngredients() {
   const json = await AsyncStorage.getItem(INGREDIENTS_KEY);
-  return json ? JSON.parse(json) : [];
+  const ids = json ? JSON.parse(json) : [];
+  if (!Array.isArray(ids) || ids.length === 0) return [];
+  if (typeof ids[0] === "object") {
+    // migrate from old array storage
+    await saveAllIngredients(ids);
+    return ids;
+  }
+  const keys = ids.map((id) => `${INGREDIENT_PREFIX}${id}`);
+  const values = await AsyncStorage.multiGet(keys);
+  const map = new Map(values);
+  return ids
+    .map((id) => {
+      const raw = map.get(`${INGREDIENT_PREFIX}${id}`);
+      return raw ? JSON.parse(raw) : null;
+    })
+    .filter(Boolean);
 }
 
 export function buildIndex(list) {
@@ -15,7 +31,21 @@ export function buildIndex(list) {
 }
 
 export async function saveAllIngredients(ingredients) {
-  await AsyncStorage.setItem(INGREDIENTS_KEY, JSON.stringify(ingredients));
+  const ids = ingredients.map((i) => String(i.id));
+  const keyValues = ingredients.map((i) => [
+    `${INGREDIENT_PREFIX}${i.id}`,
+    JSON.stringify(i),
+  ]);
+
+  const existing = await AsyncStorage.getItem(INGREDIENTS_KEY);
+  const existingIds = existing ? JSON.parse(existing) : [];
+  const toRemove = existingIds
+    .filter((id) => !ids.includes(String(id)))
+    .map((id) => `${INGREDIENT_PREFIX}${id}`);
+  if (toRemove.length) await AsyncStorage.multiRemove(toRemove);
+
+  await AsyncStorage.multiSet(keyValues);
+  await AsyncStorage.setItem(INGREDIENTS_KEY, JSON.stringify(ids));
 }
 
 export function updateIngredientById(list, updated) {
@@ -26,8 +56,15 @@ export function updateIngredientById(list, updated) {
   return next;
 }
 
-export async function saveIngredient(updatedList) {
-  await saveAllIngredients(updatedList);
+export async function saveIngredient(ingredient) {
+  const key = `${INGREDIENT_PREFIX}${ingredient.id}`;
+  await AsyncStorage.setItem(key, JSON.stringify(ingredient));
+  const json = await AsyncStorage.getItem(INGREDIENTS_KEY);
+  const ids = json ? JSON.parse(json) : [];
+  if (!ids.includes(String(ingredient.id))) {
+    ids.push(String(ingredient.id));
+    await AsyncStorage.setItem(INGREDIENTS_KEY, JSON.stringify(ids));
+  }
 }
 
 export function addIngredient(list, ingredient) {


### PR DESCRIPTION
## Summary
- Persist ingredients individually in AsyncStorage to avoid rewriting the whole list
- Save only the modified ingredient from MyCocktailsScreen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ab46600ce48326a5f92abd1c019621