### PR TITLE
Improve ingredient navigation responsiveness

### DIFF
--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -437,6 +437,22 @@ export default function EditIngredientScreen() {
       initialHashRef.current = serialize();
       setDirty(false);
 
+      const searchName = normalizeSearch(updated.name);
+      const searchTokens = searchName.split(WORD_SPLIT_RE).filter(Boolean);
+      const newItem = { ...updated, searchName, searchTokens };
+
+      setGlobalIngredients((list) => {
+        const rest = list.filter((i) => i.id !== newItem.id);
+        const idx = rest.findIndex(
+          (i) => collator.compare(i.name, newItem.name) > 0
+        );
+        const next = [...rest];
+        if (idx === -1) next.push(newItem);
+        else next.splice(idx, 0, newItem);
+        return next;
+      });
+      saveIngredient(updated).catch(() => {});
+
       if (!stay) {
         skipPromptRef.current = true;
         const detailParams = {
@@ -461,23 +477,6 @@ export default function EditIngredientScreen() {
       } else {
         setIngredient(updated);
       }
-
-      InteractionManager.runAfterInteractions(() => {
-        setGlobalIngredients((list) => {
-          const searchName = normalizeSearch(updated.name);
-          const searchTokens = searchName.split(WORD_SPLIT_RE).filter(Boolean);
-          const newItem = { ...updated, searchName, searchTokens };
-          const rest = list.filter((i) => i.id !== newItem.id);
-          const idx = rest.findIndex(
-            (i) => collator.compare(i.name, newItem.name) > 0
-          );
-          const next = [...rest];
-          if (idx === -1) next.push(newItem);
-          else next.splice(idx, 0, newItem);
-          return next;
-        });
-        saveIngredient(updated).catch(() => {});
-      });
 
       return updated;
     },
@@ -839,9 +838,7 @@ export default function EditIngredientScreen() {
           });
           navigation.popToTop();
           setConfirmDelete(false);
-          InteractionManager.runAfterInteractions(() => {
-            deleteIngredient(ingredient.id).catch(() => {});
-          });
+          deleteIngredient(ingredient.id).catch(() => {});
         }}
       />
       <ConfirmationDialog

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -17,7 +17,6 @@ import {
   Platform,
   Alert,
   BackHandler,
-  InteractionManager,
 } from "react-native";
 import {
   useNavigation,
@@ -345,19 +344,15 @@ export default function IngredientDetailsScreen() {
   useFocusEffect(
     useCallback(() => {
       let cancelled = false;
-      const task = InteractionManager.runAfterInteractions(async () => {
+      (async () => {
         try {
-          if (route.params?.initialIngredient) {
-            await new Promise((res) => setTimeout(res, 500));
-          }
           if (!cancelled) await load();
         } catch {}
-      });
+      })();
       return () => {
         cancelled = true;
-        task.cancel();
       };
-    }, [load, route.params?.initialIngredient])
+    }, [load])
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Save new ingredients before navigating to their detail screen
- Update ingredient edits and deletions immediately instead of after interactions
- Load ingredient details without artificial delays

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab9549679483268c38d2a028250db6