### PR TITLE
Use Map for ingredient storage

### DIFF
--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -406,14 +406,14 @@ export default function AddIngredientScreen() {
     InteractionManager.runAfterInteractions(() => {
       addIngredient(saved).catch(() => {});
 
-      setGlobalIngredients((list) => {
-        const idx = list.findIndex(
+      setGlobalIngredients((map) => {
+        const arr = Array.from(map.values()).filter((i) => i.id !== saved.id);
+        const idx = arr.findIndex(
           (i) => collator.compare(i.name, saved.name) > 0
         );
-        const next = [...list];
-        if (idx === -1) next.push(saved);
-        else next.splice(idx, 0, saved);
-        return next;
+        if (idx === -1) arr.push(saved);
+        else arr.splice(idx, 0, saved);
+        return new Map(arr.map((i) => [i.id, i]));
       });
       setUsageMap((prev) => ({ ...prev, [saved.id]: [] }));
     });

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -101,7 +101,7 @@ export default function AllIngredientsScreen() {
     (id) => {
       let updated;
       setIngredients((prev) => {
-        const item = prev.find((i) => i.id === id);
+        const item = prev.get(id);
         if (!item) return prev;
         updated = { ...item, inBar: !item.inBar };
         return updateIngredientById(prev, updated);

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -41,11 +41,7 @@ import { useHeaderHeight } from "@react-navigation/elements";
 
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
-import {
-  deleteIngredient,
-  saveIngredient,
-  removeIngredient,
-} from "../../storage/ingredientsStorage";
+import { deleteIngredient, saveIngredient } from "../../storage/ingredientsStorage";
 import { MaterialIcons } from "@expo/vector-icons";
 import IngredientTagsModal from "../../components/IngredientTagsModal";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
@@ -467,15 +463,14 @@ export default function EditIngredientScreen() {
       }
 
       InteractionManager.runAfterInteractions(() => {
-        setGlobalIngredients((list) => {
-          const rest = list.filter((i) => i.id !== newItem.id);
-          const idx = rest.findIndex(
+        setGlobalIngredients((map) => {
+          const arr = Array.from(map.values()).filter((i) => i.id !== newItem.id);
+          const idx = arr.findIndex(
             (i) => collator.compare(i.name, newItem.name) > 0
           );
-          const next = [...rest];
-          if (idx === -1) next.push(newItem);
-          else next.splice(idx, 0, newItem);
-          return next;
+          if (idx === -1) arr.push(newItem);
+          else arr.splice(idx, 0, newItem);
+          return new Map(arr.map((i) => [i.id, i]));
         });
         saveIngredient(updated).catch(() => {});
       });
@@ -835,7 +830,11 @@ export default function EditIngredientScreen() {
           navigation.popToTop();
           setConfirmDelete(false);
           InteractionManager.runAfterInteractions(() => {
-            setGlobalIngredients((list) => removeIngredient(list, ingredient.id));
+            setGlobalIngredients((map) => {
+              const next = new Map(map);
+              next.delete(ingredient.id);
+              return next;
+            });
             setUsageMap((prev) => {
               const next = { ...prev };
               delete next[ingredient.id];

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -353,7 +353,7 @@ export default function EditIngredientScreen() {
       try {
         await loadAvailableTags();
         if (cancelled || !isMountedRef.current) return;
-        const data = ingredientsById[currentId];
+        const data = ingredientsById.get(currentId);
         if (data) {
           setIngredient(data);
           setName(data.name || "");

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -236,7 +236,7 @@ export default function IngredientDetailsScreen() {
         getIgnoreGarnish(),
         getAllowSubstitutes(),
       ]);
-      const loaded = ingredientsById[id] || all.find((i) => i.id === id);
+      const loaded = ingredientsById.get(id) || all.find((i) => i.id === id);
     setIngredient((prev) => (loaded ? { ...loaded, ...(prev || {}) } : prev));
 
     if (!loaded) {

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -194,7 +194,7 @@ export default function MyIngredientsScreen() {
     (id) => {
       let updated;
       setIngredients((prev) => {
-        const item = prev.find((i) => i.id === id);
+        const item = prev.get(id);
         if (!item) return prev;
         updated = { ...item, inBar: !item.inBar };
         return updateIngredientById(prev, updated);

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -101,7 +101,7 @@ export default function ShoppingIngredientsScreen() {
     (id) => {
       let updated;
       setIngredients((prev) => {
-        const item = prev.find((i) => i.id === id);
+        const item = prev.get(id);
         if (!item) return prev;
         updated = { ...item, inShoppingList: false };
         return updateIngredientById(prev, updated);

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -88,11 +88,11 @@ export async function saveAllIngredients(ingredients) {
   });
 }
 
-export function updateIngredientById(list, updated) {
-  const index = list.findIndex((i) => i.id === updated.id);
-  if (index === -1) return list;
-  const next = [...list];
-  next[index] = { ...next[index], ...updated };
+export function updateIngredientById(map, updated) {
+  const prev = map.get(updated.id);
+  if (!prev) return map;
+  const next = new Map(map);
+  next.set(updated.id, { ...prev, ...updated });
   return next;
 }
 


### PR DESCRIPTION
## Summary
- Store ingredients in context as a Map for constant-time updates
- Rewrite updateIngredientById to update Map entries
- Adjust ingredient update calls across screens to use the Map structure

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acc5e8a6008326ae067906e3f05eae