### PR TITLE
Allow using newly created ingredient when adding a cocktail

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -1215,10 +1215,22 @@ export default function AddCocktailScreen() {
   });
 
   // ingredients for suggestions
-  const [allIngredients, setAllIngredients] = useState(globalIngredients);
+  const [allIngredients, setAllIngredients] = useState(() =>
+    initialIngredient && !globalIngredients.some((i) => i.id === initialIngredient.id)
+      ? [...globalIngredients, initialIngredient]
+      : globalIngredients
+  );
+
   useEffect(() => {
-    setAllIngredients(globalIngredients);
-  }, [globalIngredients]);
+    if (
+      initialIngredient &&
+      !globalIngredients.some((i) => i.id === initialIngredient.id)
+    ) {
+      setAllIngredients([...globalIngredients, initialIngredient]);
+    } else {
+      setAllIngredients(globalIngredients);
+    }
+  }, [globalIngredients, initialIngredient]);
 
   // SUBSTITUTE MODAL STATE
   const [subModal, setSubModal] = useState({


### PR DESCRIPTION
## Summary
- include the ingredient passed from IngredientDetails in AddCocktail suggestions so it can be used immediately after creation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68accf6b81b08326a037f9a417b6b788