### PR TITLE
Wrap splash screen in safe area

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,6 +9,7 @@ import {
   useIngredientUsage,
 } from "./src/context/IngredientUsageContext";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+import { StatusBar } from "react-native";
 import { Provider as PaperProvider, useTheme } from "react-native-paper";
 import { MenuProvider } from "react-native-popup-menu";
 
@@ -174,6 +175,7 @@ export default function App() {
   if (showSplash || !startScreen) {
     return (
       <SafeAreaProvider>
+        <StatusBar barStyle="dark-content" backgroundColor="#fff" />
         <SafeAreaView style={{ flex: 1, backgroundColor: "#fff" }}>
           <SplashScreen />
         </SafeAreaView>
@@ -185,24 +187,27 @@ export default function App() {
     <PaperProvider theme={AppTheme}>
       <MenuProvider>
         <SafeAreaProvider>
-          <IngredientUsageProvider>
-            <InitialDataLoader>
-              <TabMemoryProvider>
-                <NavigationContainer>
-                  <RootStack.Navigator>
-                    <RootStack.Screen name="Tabs" options={{ headerShown: false }}>
-                      {() => <Tabs startScreen={startScreen} />}
-                    </RootStack.Screen>
-                    <RootStack.Screen
-                      name="EditCustomTags"
-                      component={EditCustomTagsScreen}
-                      options={{ title: "Custom tags" }}
-                    />
-                  </RootStack.Navigator>
-                </NavigationContainer>
-              </TabMemoryProvider>
-            </InitialDataLoader>
-          </IngredientUsageProvider>
+          <StatusBar barStyle="dark-content" backgroundColor="#fff" />
+          <SafeAreaView style={{ flex: 1, backgroundColor: "#fff" }}>
+            <IngredientUsageProvider>
+              <InitialDataLoader>
+                <TabMemoryProvider>
+                  <NavigationContainer>
+                    <RootStack.Navigator>
+                      <RootStack.Screen name="Tabs" options={{ headerShown: false }}>
+                        {() => <Tabs startScreen={startScreen} />}
+                      </RootStack.Screen>
+                      <RootStack.Screen
+                        name="EditCustomTags"
+                        component={EditCustomTagsScreen}
+                        options={{ title: "Custom tags" }}
+                      />
+                    </RootStack.Navigator>
+                  </NavigationContainer>
+                </TabMemoryProvider>
+              </InitialDataLoader>
+            </IngredientUsageProvider>
+          </SafeAreaView>
         </SafeAreaProvider>
       </MenuProvider>
     </PaperProvider>

--- a/App.js
+++ b/App.js
@@ -8,7 +8,7 @@ import {
   IngredientUsageProvider,
   useIngredientUsage,
 } from "./src/context/IngredientUsageContext";
-import { SafeAreaProvider } from "react-native-safe-area-context";
+import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import { Provider as PaperProvider, useTheme } from "react-native-paper";
 import { MenuProvider } from "react-native-popup-menu";
 
@@ -172,7 +172,13 @@ export default function App() {
   }, []);
 
   if (showSplash || !startScreen) {
-    return <SplashScreen />;
+    return (
+      <SafeAreaProvider>
+        <SafeAreaView style={{ flex: 1, backgroundColor: "#fff" }}>
+          <SplashScreen />
+        </SafeAreaView>
+      </SafeAreaProvider>
+    );
   }
 
   return (

--- a/src/components/HeaderWithSearch.js
+++ b/src/components/HeaderWithSearch.js
@@ -8,7 +8,6 @@ import {
 } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useTheme } from "react-native-paper";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import GeneralMenu from "./GeneralMenu";
 
 export default function HeaderWithSearch({
@@ -20,8 +19,7 @@ export default function HeaderWithSearch({
   filterComponent,
 }) {
   const theme = useTheme();
-  const insets = useSafeAreaInsets();
-  const styles = useMemo(() => makeStyles(theme, insets), [theme, insets]);
+  const styles = useMemo(() => makeStyles(theme), [theme]);
   const [menuVisible, setMenuVisible] = useState(false);
 
   const handleMenuPress = () => {
@@ -95,13 +93,13 @@ export default function HeaderWithSearch({
   );
 }
 
-const makeStyles = (theme, insets) =>
+const makeStyles = (theme) =>
   StyleSheet.create({
     container: {
       flexDirection: "row",
       alignItems: "center",
       paddingHorizontal: 16,
-      paddingTop: insets.top,
+      paddingTop: 8,
       backgroundColor: theme.colors.background,
       gap: 10,
     },


### PR DESCRIPTION
## Summary
- prevent splash screen from overlapping system status bar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68accfcd322c832682f902bba6344734