### PR TITLE
Use themed dialogs for alerts

### DIFF
--- a/src/hooks/useInfoDialog.js
+++ b/src/hooks/useInfoDialog.js
@@ -1,0 +1,27 @@
+import { useState, useCallback } from "react";
+import ConfirmationDialog from "../components/ConfirmationDialog";
+
+export default function useInfoDialog() {
+  const [data, setData] = useState({ visible: false, title: "", message: "" });
+
+  const hide = useCallback(() => {
+    setData((d) => ({ ...d, visible: false }));
+  }, []);
+
+  const show = useCallback((title, message) => {
+    setData({ visible: true, title, message });
+  }, []);
+
+  const dialog = (
+    <ConfirmationDialog
+      visible={data.visible}
+      title={data.title}
+      message={data.message}
+      onConfirm={hide}
+      onCancel={hide}
+      actions={[{ label: "OK", onPress: hide }]}
+    />
+  );
+
+  return [show, dialog];
+}

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -15,7 +15,6 @@ import {
   Image,
   ScrollView,
   TextInput,
-  Alert,
   Pressable,
   Platform,
   FlatList,
@@ -44,6 +43,7 @@ import { TAG_COLORS } from "../../theme";
 import { MaterialIcons } from "@expo/vector-icons";
 import { HeaderBackButton, useHeaderHeight } from "@react-navigation/elements";
 import { useTabMemory } from "../../context/TabMemoryContext";
+import useInfoDialog from "../../hooks/useInfoDialog";
 
 import {
   Menu,
@@ -803,7 +803,7 @@ const IngredientRow = memo(function IngredientRow({
             )}
             <Pressable
               onPress={() =>
-                Alert.alert(
+                showInfo(
                   "Allow base substitute",
                   `If the specified ingredient isn't available, the cocktail will be shown as available with its base ingredient.\n\nBase ingredient:\n ${
                     baseIngredientName || "—"
@@ -844,7 +844,7 @@ const IngredientRow = memo(function IngredientRow({
                         "\n- "
                       )}`
                     : "";
-                Alert.alert(
+                showInfo(
                   "Allow branded substitutes",
                   `If the specified ingredient isn't available, the cocktail will be shown as available with branded ingredients of the base.${list}`
                 );
@@ -1086,6 +1086,7 @@ export default function AddCocktailScreen() {
     (typeof getTab === "function" && getTab("cocktails")) || "All";
   const headerHeight = useHeaderHeight();
   const subSearchRef = useRef(null);
+  const [showInfo, infoDialog] = useInfoDialog();
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -1276,7 +1277,7 @@ export default function AddCocktailScreen() {
   const pickImage = useCallback(async () => {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) {
-      Alert.alert("Permission required", "Allow access to media library");
+      showInfo("Permission required", "Allow access to media library");
       return;
     }
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -1405,12 +1406,12 @@ export default function AddCocktailScreen() {
   const handleSave = useCallback(() => {
     const title = name.trim();
     if (!title) {
-      Alert.alert("Validation", "Please enter a cocktail name.");
+      showInfo("Validation", "Please enter a cocktail name.");
       return;
     }
     const nonEmptyIngredients = ings.filter((r) => r.name.trim().length > 0);
     if (nonEmptyIngredients.length === 0) {
-      Alert.alert("Validation", "Please add at least one ingredient.");
+      showInfo("Validation", "Please add at least one ingredient.");
       return;
     }
 
@@ -1988,6 +1989,7 @@ export default function AddCocktailScreen() {
           </Text>
         </Modal>
       </Portal>
+      {infoDialog}
     </>
   );
 }

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -15,7 +15,6 @@ import {
   Image,
   ScrollView,
   TextInput,
-  Alert,
   Pressable,
   Platform,
   FlatList,
@@ -67,6 +66,7 @@ import CocktailTagsModal from "../../components/CocktailTagsModal";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
+import useInfoDialog from "../../hooks/useInfoDialog";
 import {
   addCocktailToUsageMap,
   removeCocktailFromUsageMap,
@@ -812,7 +812,7 @@ const IngredientRow = memo(function IngredientRow({
             )}
             <Pressable
               onPress={() =>
-                Alert.alert(
+                showInfo(
                   "Allow base substitute",
                   `If the specified ingredient isn't available, the cocktail will be shown as available with its base ingredient.\n\nBase ingredient:\n ${
                     baseIngredientName || "—"
@@ -853,7 +853,7 @@ const IngredientRow = memo(function IngredientRow({
                         "\n- "
                       )}`
                     : "";
-                Alert.alert(
+                showInfo(
                   "Allow branded substitutes",
                   `If the specified ingredient isn't available, the cocktail will be shown as available with branded ingredients of the base.${list}`
                 );
@@ -1092,6 +1092,7 @@ export default function EditCocktailScreen() {
 
   const headerHeight = useHeaderHeight();
   const subSearchRef = useRef(null);
+  const [showInfo, infoDialog] = useInfoDialog();
 
   const [loading, setLoading] = useState(true);
   const [name, setName] = useState("");
@@ -1153,12 +1154,12 @@ export default function EditCocktailScreen() {
     (stay = false) => {
       const title = name.trim();
       if (!title) {
-        Alert.alert("Validation", "Please enter a cocktail name.");
+        showInfo("Validation", "Please enter a cocktail name.");
         return;
       }
       const nonEmptyIngredients = ings.filter((r) => r.name.trim().length > 0);
       if (nonEmptyIngredients.length === 0) {
-        Alert.alert("Validation", "Please add at least one ingredient.");
+        showInfo("Validation", "Please add at least one ingredient.");
         return;
       }
 
@@ -1440,7 +1441,7 @@ export default function EditCocktailScreen() {
   const pickImage = useCallback(async () => {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) {
-      Alert.alert("Permission required", "Allow access to media library");
+      showInfo("Permission required", "Allow access to media library");
       return;
     }
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -2114,6 +2115,7 @@ export default function EditCocktailScreen() {
         ]}
         onCancel={() => setPendingNav(null)}
       />
+      {infoDialog}
     </>
   );
 }

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -17,7 +17,6 @@ import {
   StyleSheet,
   ScrollView,
   FlatList,
-  Alert,
   InteractionManager,
   Pressable,
   BackHandler,
@@ -45,6 +44,7 @@ import IngredientTagsModal from "../../components/IngredientTagsModal";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { WORD_SPLIT_RE, wordPrefixMatch } from "../../utils/wordPrefixMatch";
+import useInfoDialog from "../../hooks/useInfoDialog";
 
 
 
@@ -131,6 +131,7 @@ export default function AddIngredientScreen() {
     baseIngredients = [],
   } = useIngredientsData();
   const { setUsageMap } = useIngredientUsage();
+  const [showInfo, infoDialog] = useInfoDialog();
 
   const collator = useMemo(
     () => new Intl.Collator("uk", { sensitivity: "base" }),
@@ -351,7 +352,7 @@ export default function AddIngredientScreen() {
   const pickImage = useCallback(async () => {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) {
-      Alert.alert("Permission required", "Allow access to media library");
+      showInfo("Permission required", "Allow access to media library");
       return;
     }
     await InteractionManager.runAfterInteractions();
@@ -369,7 +370,7 @@ export default function AddIngredientScreen() {
   const handleSave = useCallback(() => {
     const trimmed = (name || "").trim();
     if (!trimmed) {
-      Alert.alert("Validation", "Please enter a name for the ingredient.");
+      showInfo("Validation", "Please enter a name for the ingredient.");
       return;
     }
 
@@ -726,6 +727,7 @@ export default function AddIngredientScreen() {
         onClose={closeTagsModal}
         autoAdd={tagsModalAutoAdd}
       />
+      {infoDialog}
     </>
   );
 }

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -714,7 +714,6 @@ export default function AddIngredientScreen() {
           style={[styles.saveButton, { backgroundColor: theme.colors.primary }]}
           onPress={handleSave}
           android_ripple={{ color: withAlpha(theme.colors.onPrimary, 0.15) }}
-          disabled={!name.trim()}
         >
           <Text style={{ color: theme.colors.onPrimary, fontWeight: "bold" }}>
             Save Ingredient

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -17,7 +17,6 @@ import {
   StyleSheet,
   ScrollView,
   FlatList,
-  Alert,
   Platform,
   InteractionManager,
   ActivityIndicator,
@@ -49,6 +48,7 @@ import useIngredientsData from "../../hooks/useIngredientsData";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { WORD_SPLIT_RE, wordPrefixMatch } from "../../utils/wordPrefixMatch";
+import useInfoDialog from "../../hooks/useInfoDialog";
 
 // ----------- helpers -----------
 const useDebounced = (value, delay = 300) => {
@@ -134,6 +134,7 @@ export default function EditIngredientScreen() {
     baseIngredients = [],
   } = useIngredientsData();
   const { setUsageMap, ingredientsById } = useIngredientUsage();
+  const [showInfo, infoDialog] = useInfoDialog();
   const collator = useMemo(
     () => new Intl.Collator("uk", { sensitivity: "base" }),
     []
@@ -397,7 +398,7 @@ export default function EditIngredientScreen() {
   const pickImage = useCallback(async () => {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) {
-      Alert.alert("Permission required", "Allow access to media library");
+      showInfo("Permission required", "Allow access to media library");
       return;
     }
     await InteractionManager.runAfterInteractions();
@@ -416,7 +417,7 @@ export default function EditIngredientScreen() {
     (stay = false) => {
       const trimmed = name.trim();
       if (!trimmed) {
-        Alert.alert("Please enter a name for the ingredient.");
+        showInfo("Validation", "Please enter a name for the ingredient.");
         return;
       }
       if (!ingredient) return;
@@ -888,6 +889,7 @@ export default function EditIngredientScreen() {
         ]}
         onCancel={() => setPendingNav(null)}
       />
+      {infoDialog}
     </>
   );
 }

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -805,7 +805,6 @@ export default function EditIngredientScreen() {
           style={[styles.saveButton, { backgroundColor: theme.colors.primary }]}
           onPress={() => handleSave(false)}
           android_ripple={{ color: theme.colors.onPrimary }}
-          disabled={!name.trim()}
         >
           <Text style={{ color: theme.colors.onPrimary, fontWeight: "bold" }}>
             Save Changes
@@ -870,6 +869,10 @@ export default function EditIngredientScreen() {
             onPress: async () => {
               skipPromptRef.current = true;
               const updated = await handleSave(true);
+              if (!updated) {
+                skipPromptRef.current = false;
+                return;
+              }
               const prevRoute = navigation.getState().routes.slice(-2)[0];
               if (prevRoute) {
                 navigation.dispatch(

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -15,7 +15,6 @@ import {
   ScrollView,
   ActivityIndicator,
   Platform,
-  Alert,
   BackHandler,
   InteractionManager,
 } from "react-native";

--- a/src/screens/IngredientsTags/AddTagScreen.js
+++ b/src/screens/IngredientsTags/AddTagScreen.js
@@ -5,7 +5,6 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
-  Alert,
   KeyboardAvoidingView,
   Platform,
 } from "react-native";
@@ -16,16 +15,18 @@ import { useNavigation } from "@react-navigation/native";
 import WheelColorPicker from "react-native-wheel-color-picker";
 import { useTheme } from "react-native-paper";
 import { TAG_COLORS } from "../theme";
+import useInfoDialog from "../../hooks/useInfoDialog";
 
 export default function AddTagScreen() {
   const navigation = useNavigation();
   const theme = useTheme();
+  const [showInfo, infoDialog] = useInfoDialog();
   const [name, setName] = useState("");
   const [color, setColor] = useState(TAG_COLORS[0]);
 
   const handleSave = async () => {
     if (!name.trim()) {
-      Alert.alert("Please enter a name for the tag.");
+      showInfo("Validation", "Please enter a name for the tag.");
       return;
     }
 
@@ -43,43 +44,46 @@ export default function AddTagScreen() {
   };
 
   return (
-    <KeyboardAvoidingView
-      style={[styles.container, { backgroundColor: theme.colors.background }]}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-    >
-      <Text style={styles.label}>Tag name:</Text>
-      <TextInput
-        placeholder="e.g. bitters"
-        value={name}
-        onChangeText={setName}
-        style={[styles.input, { borderColor: theme.colors.outline }]}
-      />
-
-      <Text style={styles.label}>Choose color:</Text>
-      <View style={styles.colorPreview}>
-        <View
-          style={[
-            styles.colorBox,
-            { backgroundColor: color, borderColor: theme.colors.onSurface },
-          ]}
-        />
-        <Text style={styles.colorCode}>{color}</Text>
-      </View>
-
-      <WheelColorPicker
-        color={color}
-        onColorChange={setColor}
-        thumbStyle={{ borderWidth: 2, borderColor: theme.colors.onSurface }}
-        style={{ height: 240, marginBottom: 16 }}
-      />
-
-      <TouchableOpacity
-        style={[styles.saveButton, { backgroundColor: theme.colors.primary }]}
-        onPress={handleSave}
+    <>
+      <KeyboardAvoidingView
+        style={[styles.container, { backgroundColor: theme.colors.background }]}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
-        <Text style={[styles.saveText, { color: theme.colors.onPrimary }]}>Save Tag</Text>
-      </TouchableOpacity>
-    </KeyboardAvoidingView>
+        <Text style={styles.label}>Tag name:</Text>
+        <TextInput
+          placeholder="e.g. bitters"
+          value={name}
+          onChangeText={setName}
+          style={[styles.input, { borderColor: theme.colors.outline }]}
+        />
+
+        <Text style={styles.label}>Choose color:</Text>
+        <View style={styles.colorPreview}>
+          <View
+            style={[
+              styles.colorBox,
+              { backgroundColor: color, borderColor: theme.colors.onSurface },
+            ]}
+          />
+          <Text style={styles.colorCode}>{color}</Text>
+        </View>
+
+        <WheelColorPicker
+          color={color}
+          onColorChange={setColor}
+          thumbStyle={{ borderWidth: 2, borderColor: theme.colors.onSurface }}
+          style={{ height: 240, marginBottom: 16 }}
+        />
+
+        <TouchableOpacity
+          style={[styles.saveButton, { backgroundColor: theme.colors.primary }]}
+          onPress={handleSave}
+        >
+          <Text style={[styles.saveText, { color: theme.colors.onPrimary }]}>Save Tag</Text>
+        </TouchableOpacity>
+      </KeyboardAvoidingView>
+      {infoDialog}
+    </>
   );
 }
 

--- a/src/screens/IngredientsTags/TagsScreen.js
+++ b/src/screens/IngredientsTags/TagsScreen.js
@@ -5,18 +5,19 @@ import {
   ScrollView,
   StyleSheet,
   TouchableOpacity,
-  Alert,
 } from "react-native";
 
 import { BUILTIN_INGREDIENT_TAGS } from "../constants/ingredientTags";
 import { getUserTags } from "../storage/ingredientTagsStorage";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
 import { useTheme } from "react-native-paper";
+import useInfoDialog from "../../hooks/useInfoDialog";
 
 export default function TagsScreen() {
   const navigation = useNavigation();
   const isFocused = useIsFocused();
   const theme = useTheme();
+  const [showInfo, infoDialog] = useInfoDialog();
   const styles = useMemo(
     () =>
       StyleSheet.create({
@@ -49,7 +50,7 @@ export default function TagsScreen() {
   }, [isFocused]);
 
   const handleBuiltInTap = () => {
-    Alert.alert("Built-in Tag", "Built-in tags cannot be edited or deleted.");
+    showInfo("Built-in Tag", "Built-in tags cannot be edited or deleted.");
   };
 
   const handleUserTagTap = (tag) => {
@@ -92,6 +93,7 @@ export default function TagsScreen() {
       >
         <Text style={styles.addText}>+ Add Tag</Text>
       </TouchableOpacity>
+      {infoDialog}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Add `useInfoDialog` hook to render theme-styled confirmation dialog
- Replace native alerts across screens with `useInfoDialog`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acdb427b748326b49334fd5d785ce1