### PR TITLE
Adjust Edit Cocktail header spacing

### DIFF
--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -2124,7 +2124,7 @@ export default function EditCocktailScreen() {
 const IMAGE_SIZE = 150;
 
 const styles = StyleSheet.create({
-  container: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 40 },
+  container: { paddingHorizontal: 24, paddingBottom: 40 },
   label: { fontWeight: "bold", marginTop: 16 },
   labelText: { fontWeight: "bold" },
 


### PR DESCRIPTION
## Summary
- remove unnecessary top padding from EditCocktail screen content so title sits directly under status bar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ace41fa7388326aea15e7d52dca3d8