### PR TITLE
refactor: centralize withAlpha utility

### DIFF
--- a/src/components/CocktailRow.js
+++ b/src/components/CocktailRow.js
@@ -3,14 +3,7 @@ import { View, Text, Image, Pressable, StyleSheet, Platform } from "react-native
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import { getGlassById } from "../constants/glassware";
-
-const withAlpha = (hex, alpha) => {
-  if (!hex || hex[0] !== "#" || hex.length !== 7) return hex;
-  const a = Math.round(alpha * 255)
-    .toString(16)
-    .padStart(2, "0");
-  return `${hex}${a}`;
-};
+import { withAlpha } from "../utils/color";
 
 export const IMAGE_SIZE = 50;
 const ROW_VERTICAL = 8;

--- a/src/components/IngredientRow.js
+++ b/src/components/IngredientRow.js
@@ -2,14 +2,7 @@ import React, { memo, useMemo } from "react";
 import { View, Text, Image, Pressable, StyleSheet, Platform } from "react-native";
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
-
-const withAlpha = (hex, alpha) => {
-  if (!hex || hex[0] !== "#" || hex.length !== 7) return hex;
-  const a = Math.round(alpha * 255)
-    .toString(16)
-    .padStart(2, "0");
-  return `${hex}${a}`;
-};
+import { withAlpha } from "../utils/color";
 
 export const IMAGE_SIZE = 50;
 const ROW_VERTICAL = 8;

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -32,6 +32,7 @@ import * as ImagePicker from "expo-image-picker";
 import { resizeImage } from "../../utils/images";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { WORD_SPLIT_RE, wordPrefixMatch } from "../../utils/wordPrefixMatch";
+import { withAlpha } from "../../utils/color";
 import {
   useNavigation,
   useRoute,
@@ -68,17 +69,7 @@ import {
 } from "../../utils/ingredientUsage";
 import { getAllowSubstitutes } from "../../storage/settingsStorage";
 
-
 /* ---------- helpers ---------- */
-const withAlpha = (hex, alpha) => {
-  if (!hex || hex[0] !== "#" || (hex.length !== 7 && hex.length !== 9))
-    return hex;
-  const a = Math.round(alpha * 255)
-    .toString(16)
-    .padStart(2, "0");
-  return hex.length === 7 ? `${hex}${a}` : `${hex.slice(0, 7)}${a}`;
-};
-
 const useDebounced = (value, delay = 250) => {
   const [v, setV] = useState(value);
   useEffect(() => {

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -36,6 +36,7 @@ import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import { getUnitById, formatUnit } from "../../constants/measureUnits";
 import { getGlassById } from "../../constants/glassware";
 import { formatAmount, toMetric, toImperial } from "../../utils/units";
+import { withAlpha } from "../../utils/color";
 import {
   getUseMetric,
   getIgnoreGarnish,
@@ -47,16 +48,6 @@ import {
 } from "../../storage/settingsStorage";
 import { activateKeepAwakeAsync, deactivateKeepAwake } from "expo-keep-awake";
 import ExpandableText from "../../components/ExpandableText";
-
-/* ---------- helpers ---------- */
-const withAlpha = (hex, alpha) => {
-  if (!hex || hex[0] !== "#" || (hex.length !== 7 && hex.length !== 9))
-    return hex;
-  const a = Math.round(alpha * 255)
-    .toString(16)
-    .padStart(2, "0");
-  return hex.length === 7 ? `${hex}${a}` : `${hex.slice(0, 7)}${a}`;
-};
 
 /* ---------- Ingredient row (like AllIngredients) ---------- */
 const IMAGE_SIZE = 50;

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -32,6 +32,7 @@ import * as ImagePicker from "expo-image-picker";
 import { resizeImage } from "../../utils/images";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { WORD_SPLIT_RE, wordPrefixMatch } from "../../utils/wordPrefixMatch";
+import { withAlpha } from "../../utils/color";
 import {
   useNavigation,
   useRoute,
@@ -74,17 +75,7 @@ import {
 } from "../../utils/ingredientUsage";
 import { getAllowSubstitutes } from "../../storage/settingsStorage";
 
-
 /* ---------- helpers ---------- */
-const withAlpha = (hex, alpha) => {
-  if (!hex || hex[0] !== "#" || (hex.length !== 7 && hex.length !== 9))
-    return hex;
-  const a = Math.round(alpha * 255)
-    .toString(16)
-    .padStart(2, "0");
-  return hex.length === 7 ? `${hex}${a}` : `${hex.slice(0, 7)}${a}`;
-};
-
 const useDebounced = (value, delay = 250) => {
   const [v, setV] = useState(value);
   useEffect(() => {

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -45,6 +45,7 @@ import useIngredientsData from "../../hooks/useIngredientsData";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { WORD_SPLIT_RE, wordPrefixMatch } from "../../utils/wordPrefixMatch";
 import useInfoDialog from "../../hooks/useInfoDialog";
+import { withAlpha } from "../../utils/color";
 
 
 
@@ -61,14 +62,6 @@ const useDebounced = (value, delay = 300) => {
 const IMAGE_SIZE = 150;
 const MENU_ROW_HEIGHT = 56;
 const MENU_TOP_OFFSET = 150;
-
-const withAlpha = (hex, alpha) => {
-  if (!hex || hex[0] !== "#" || (hex.length !== 7 && hex.length !== 9)) return hex;
-  const a = Math.round(alpha * 255)
-    .toString(16)
-    .padStart(2, "0");
-  return hex.length === 7 ? `${hex}${a}` : `${hex.slice(0, 7)}${a}`;
-};
 
 /* -------------- pills for tags (memo) -------------- */
 const TagPill = memo(function TagPill({ id, name, color, onToggle }) {

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,0 +1,8 @@
+export const withAlpha = (hex, alpha) => {
+  if (!hex || hex[0] !== "#" || (hex.length !== 7 && hex.length !== 9))
+    return hex;
+  const a = Math.round(alpha * 255)
+    .toString(16)
+    .padStart(2, "0");
+  return hex.length === 9 ? `${hex.slice(0, 7)}${a}` : `${hex}${a}`;
+};


### PR DESCRIPTION
## Summary
- add color.withAlpha helper supporting 7 and 9 char hex values
- replace duplicated withAlpha implementations in components and screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ace7645c9483269f00a3c342b8cf0a