### PR TITLE
refactor: extract useDebounced hook

### DIFF
--- a/src/hooks/useDebounced.js
+++ b/src/hooks/useDebounced.js
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export default function useDebounced(value, delay = 300) {
+  const [v, setV] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setV(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return v;
+}

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -45,6 +45,7 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { HeaderBackButton, useHeaderHeight } from "@react-navigation/elements";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import useInfoDialog from "../../hooks/useInfoDialog";
+import useDebounced from "../../hooks/useDebounced";
 
 import {
   Menu,
@@ -68,17 +69,6 @@ import {
   applyUsageMapToIngredients,
 } from "../../utils/ingredientUsage";
 import { getAllowSubstitutes } from "../../storage/settingsStorage";
-
-/* ---------- helpers ---------- */
-const useDebounced = (value, delay = 250) => {
-  const [v, setV] = useState(value);
-  useEffect(() => {
-    const id = setTimeout(() => setV(value), delay);
-    return () => clearTimeout(id);
-  }, [value, delay]);
-  return v;
-};
-
 
 /* ---------- Tiny Divider ---------- */
 const Divider = ({ color, style }) => (

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -74,17 +74,7 @@ import {
   applyUsageMapToIngredients,
 } from "../../utils/ingredientUsage";
 import { getAllowSubstitutes } from "../../storage/settingsStorage";
-
-/* ---------- helpers ---------- */
-const useDebounced = (value, delay = 250) => {
-  const [v, setV] = useState(value);
-  useEffect(() => {
-    const id = setTimeout(() => setV(value), delay);
-    return () => clearTimeout(id);
-  }, [value, delay]);
-  return v;
-};
-
+import useDebounced from "../../hooks/useDebounced";
 
 /* ---------- Tiny Divider ---------- */
 const Divider = ({ color, style }) => (

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -45,19 +45,8 @@ import useIngredientsData from "../../hooks/useIngredientsData";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { WORD_SPLIT_RE, wordPrefixMatch } from "../../utils/wordPrefixMatch";
 import useInfoDialog from "../../hooks/useInfoDialog";
+import useDebounced from "../../hooks/useDebounced";
 import { withAlpha } from "../../utils/color";
-
-
-
-/* ---------------- helpers ---------------- */
-const useDebounced = (value, delay = 300) => {
-  const [v, setV] = useState(value);
-  useEffect(() => {
-    const id = setTimeout(() => setV(value), delay);
-    return () => clearTimeout(id);
-  }, [value, delay]);
-  return v;
-};
 
 const IMAGE_SIZE = 150;
 const MENU_ROW_HEIGHT = 56;

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -49,17 +49,9 @@ import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { WORD_SPLIT_RE, wordPrefixMatch } from "../../utils/wordPrefixMatch";
 import useInfoDialog from "../../hooks/useInfoDialog";
+import useDebounced from "../../hooks/useDebounced";
 
 // ----------- helpers -----------
-const useDebounced = (value, delay = 300) => {
-  const [v, setV] = useState(value);
-  useEffect(() => {
-    const id = setTimeout(() => setV(value), delay);
-    return () => clearTimeout(id);
-  }, [value, delay]);
-  return v;
-};
-
 const IMAGE_SIZE = 150;
 const MENU_ROW_HEIGHT = 56;
 const MENU_TOP_OFFSET = 150;


### PR DESCRIPTION
## Summary
- add reusable useDebounced hook
- replace screen-level implementations with shared hook

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ace9701fd48326894eb4bd8e38b5e0