### PR TITLE
Align stack screen headers with search header

### DIFF
--- a/App.js
+++ b/App.js
@@ -49,8 +49,17 @@ function InitialDataLoader({ children }) {
 }
 
 function ShakerStackScreen() {
+  const theme = useTheme();
   return (
-    <ShakerStack.Navigator>
+    <ShakerStack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.colors.background },
+        headerTintColor: theme.colors.onSurface,
+        headerTitleStyle: { color: theme.colors.onSurface },
+        headerShadowVisible: false,
+        headerStatusBarHeight: 0,
+      }}
+    >
       <ShakerStack.Screen
         name="ShakerMain"
         component={ShakerScreen}

--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -75,8 +75,17 @@ function CocktailTabs({ route }) {
 }
 
 export default function CocktailsTabsScreen({ route }) {
+  const theme = useTheme();
   return (
-    <Stack.Navigator>
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.colors.background },
+        headerTintColor: theme.colors.onSurface,
+        headerTitleStyle: { color: theme.colors.onSurface },
+        headerShadowVisible: false,
+        headerStatusBarHeight: 0,
+      }}
+    >
       <Stack.Screen
         name="CocktailsMain"
         component={CocktailTabs}

--- a/src/screens/Ingredients/IngredientsTabsScreen.js
+++ b/src/screens/Ingredients/IngredientsTabsScreen.js
@@ -75,8 +75,17 @@ function IngredientTabs({ route }) {
 }
 
 export default function IngredientsTabsScreen({ route }) {
+  const theme = useTheme();
   return (
-    <Stack.Navigator>
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.colors.background },
+        headerTintColor: theme.colors.onSurface,
+        headerTitleStyle: { color: theme.colors.onSurface },
+        headerShadowVisible: false,
+        headerStatusBarHeight: 0,
+      }}
+    >
       <Stack.Screen
         name="IngredientsMain"
         component={IngredientTabs}


### PR DESCRIPTION
## Summary
- Align titles of cocktail and ingredient add/edit/detail screens with the search header height

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ace964a22883268aa70f5b1bf74517