### PR TITLE
feat: centralize name sorting logic

### DIFF
--- a/src/context/IngredientUsageContext.js
+++ b/src/context/IngredientUsageContext.js
@@ -8,6 +8,7 @@ import React, {
   useMemo,
 } from "react";
 import { updateUsageMap as updateUsageMapUtil } from "../utils/ingredientUsage";
+import { sortByName } from "../utils/sortByName";
 
 const IngredientUsageContext = createContext({
   usageMap: {},
@@ -73,11 +74,7 @@ export function IngredientUsageProvider({ children }) {
     }
     if (!changed) return;
     baseRef.current = nextBaseList.map(({ id, name }) => ({ id, name }));
-    const sorted = [...nextBaseList].sort((a, b) =>
-      (a.name || "").localeCompare(b.name || "", "uk", {
-        sensitivity: "base",
-      })
-    );
+    const sorted = [...nextBaseList].sort(sortByName);
     setBaseIngredients(sorted);
   }, [ingredients]);
 

--- a/src/hooks/useIngredientsData.js
+++ b/src/hooks/useIngredientsData.js
@@ -9,6 +9,7 @@ import {
   getAllowSubstitutes,
   addAllowSubstitutesListener,
 } from "../storage/settingsStorage";
+import { sortByName } from "../utils/sortByName";
 
 export default function useIngredientsData() {
   const {
@@ -38,9 +39,7 @@ export default function useIngredientsData() {
       getAllCocktails(),
       getAllowSubstitutes(),
     ]);
-    const sorted = [...ing].sort((a, b) =>
-      a.name.localeCompare(b.name, "uk", { sensitivity: "base" })
-    );
+    const sorted = [...ing].sort(sortByName);
     const map = mapCocktailsByIngredient(sorted, cocks, {
       allowSubstitutes: !!allowSubs,
     });

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -32,6 +32,7 @@ import CocktailRow, {
   COCKTAIL_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/CocktailRow";
 import { normalizeSearch } from "../../utils/normalizeSearch";
+import { sortByName } from "../../utils/sortByName";
 
 export default function FavoriteCocktailsScreen() {
   const theme = useTheme();
@@ -198,7 +199,7 @@ export default function FavoriteCocktailsScreen() {
     mapped.sort((a, b) => {
       const aRating = a.rating ?? 0;
       const bRating = b.rating ?? 0;
-      if (aRating === bRating) return a.name.localeCompare(b.name);
+      if (aRating === bRating) return sortByName(a, b);
       return sortOrder === "asc" ? aRating - bRating : bRating - aRating;
     });
     return mapped;

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -3,7 +3,6 @@ import React, {
   useState,
   useLayoutEffect,
   useCallback,
-  useMemo,
   memo,
 } from "react";
 import {
@@ -35,6 +34,7 @@ import db from "../../storage/sqlite";
 
 import { getAllCocktails } from "../../storage/cocktailsStorage";
 import { mapCocktailsByIngredient } from "../../utils/ingredientUsage";
+import { sortByName } from "../../utils/sortByName";
 import { MaterialIcons } from "@expo/vector-icons";
 import CocktailRow from "../../components/CocktailRow";
 import { useTheme } from "react-native-paper";
@@ -141,11 +141,6 @@ export default function IngredientDetailsScreen() {
       );
     }
   }, [route.params?.initialIngredient, ingredientsById]);
-
-  const collator = useMemo(
-    () => new Intl.Collator("uk", { sensitivity: "base" }),
-    []
-  );
 
   const handleGoBack = useCallback(() => {
     goBack(navigation);
@@ -258,7 +253,7 @@ export default function IngredientDetailsScreen() {
 
     const children = all
       .filter((i) => i.baseIngredientId === loaded.id)
-      .sort((a, b) => collator.compare(a.name, b.name));
+      .sort(sortByName);
     setBrandedChildren(children);
 
     const baseId =
@@ -276,7 +271,7 @@ export default function IngredientDetailsScreen() {
     const list = (map[loaded.id] || [])
       .map((cid) => byId.get(cid))
       .filter(Boolean)
-      .sort((a, b) => collator.compare(a.name, b.name))
+      .sort(sortByName)
       .map((c) => {
         const required = (c.ingredients || []).filter(
           (r) => !r.optional && !(ig && r.garnish)
@@ -342,13 +337,7 @@ export default function IngredientDetailsScreen() {
         };
       });
     setUsedCocktails(list);
-  }, [
-    id,
-    collator,
-    ingredientsById,
-    ingredients,
-    cocktailsCtx,
-  ]);
+  }, [id, ingredientsById, ingredients, cocktailsCtx]);
 
   useFocusEffect(
     useCallback(() => {

--- a/src/screens/ShakerResultsScreen.js
+++ b/src/screens/ShakerResultsScreen.js
@@ -15,6 +15,7 @@ import {
   addIgnoreGarnishListener,
 } from "../storage/settingsStorage";
 import { normalizeSearch } from "../utils/normalizeSearch";
+import { sortByName } from "../utils/sortByName";
 
 export default function ShakerResultsScreen({ route, navigation }) {
   const { availableIds = [], recipeIds = [] } = route.params || {};
@@ -138,7 +139,7 @@ export default function ShakerResultsScreen({ route, navigation }) {
     return mapped.sort((a, b) => {
       if (a.isAllAvailable && !b.isAllAvailable) return -1;
       if (!a.isAllAvailable && b.isAllAvailable) return 1;
-      return a.name.localeCompare(b.name);
+      return sortByName(a, b);
     });
   }, [
     cocktails,

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -16,6 +16,7 @@ import useIngredientsData from "../hooks/useIngredientsData";
 import { BUILTIN_INGREDIENT_TAGS } from "../constants/ingredientTags";
 import { getAllTags } from "../storage/ingredientTagsStorage";
 import { normalizeSearch } from "../utils/normalizeSearch";
+import { sortByName } from "../utils/sortByName";
 import {
   getAllowSubstitutes,
   addAllowSubstitutesListener,
@@ -58,7 +59,7 @@ export default function ShakerScreen({ navigation }) {
       }
     });
     for (const arr of map.values()) {
-      arr.sort((a, b) => a.name.localeCompare(b.name));
+      arr.sort(sortByName);
     }
     return map;
   }, [allTags, ingredients]);

--- a/src/storage/cocktailsStorage.js
+++ b/src/storage/cocktailsStorage.js
@@ -1,13 +1,12 @@
 // src/storage/cocktailsStorage.js
 import { normalizeSearch } from "../utils/normalizeSearch";
+import { sortByName } from "../utils/sortByName";
 import db, { query } from "./sqlite";
 
 // --- utils ---
 
 const now = () => Date.now();
 const genId = () => now(); // сумісно з твоїми екранами (Date.now())
-
-const sortByName = (a, b) => a.name.localeCompare(b.name);
 
 const sanitizeIngredient = (r, idx) => ({
   order: Number(r?.order ?? idx + 1),

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -1,11 +1,10 @@
 import db, { query } from "./sqlite";
 import { normalizeSearch } from "../utils/normalizeSearch";
 import { WORD_SPLIT_RE } from "../utils/wordPrefixMatch";
+import { sortByName } from "../utils/sortByName";
 
 const now = () => Date.now();
 const genId = () => now();
-
-const sortByName = (a, b) => a.name.localeCompare(b.name);
 
 export async function getAllIngredients() {
   const res = await query(

--- a/src/utils/sortByName.js
+++ b/src/utils/sortByName.js
@@ -1,0 +1,2 @@
+export const sortByName = (a, b, locale = 'uk') =>
+  (a?.name || '').localeCompare(b?.name || '', locale, { sensitivity: 'base' });


### PR DESCRIPTION
## Summary
- add shared `sortByName` helper with locale-aware comparison
- use `sortByName` across hooks, screens, context and storage

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aceec200b883269d5d08c6215af557