### PR TITLE
refactor: reuse TagPill component in cocktail screens

### DIFF
--- a/src/components/TagPill.js
+++ b/src/components/TagPill.js
@@ -3,19 +3,31 @@ import { Pressable, Text, StyleSheet } from "react-native";
 import { useTheme } from "react-native-paper";
 import { withAlpha } from "../utils/color";
 
-const TagPill = memo(function TagPill({ id, name, color, onToggle }) {
+const TagPill = memo(function TagPill({
+  id,
+  name,
+  color,
+  onToggle,
+  rippleColor,
+  defaultColor,
+  textColor,
+}) {
   const theme = useTheme();
+  const effectiveRipple = rippleColor ?? withAlpha(theme.colors.primary, 0.1);
+  const background = color || defaultColor || theme.colors.surfaceVariant;
+  const foreground = textColor || theme.colors.onPrimary;
+
   return (
     <Pressable
       onPress={() => onToggle(id)}
-      android_ripple={{ color: withAlpha(theme.colors.primary, 0.1) }}
+      android_ripple={{ color: effectiveRipple }}
       style={({ pressed }) => [
         styles.tag,
-        { backgroundColor: color || theme.colors.surfaceVariant },
+        { backgroundColor: background },
         pressed && { opacity: 0.9, transform: [{ scale: 0.98 }] },
       ]}
     >
-      <Text style={[styles.tagText, { color: theme.colors.onPrimary }]}>{name}</Text>
+      <Text style={[styles.tagText, { color: foreground }]}>{name}</Text>
     </Pressable>
   );
 });

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -62,6 +62,7 @@ import { UNIT_ID, getUnitById, formatUnit } from "../../constants/measureUnits";
 import { GLASSWARE, getGlassById } from "../../constants/glassware";
 
 import CocktailTagsModal from "../../components/CocktailTagsModal";
+import TagPill from "../../components/TagPill";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import {
@@ -83,26 +84,6 @@ const Divider = ({ color, style }) => (
     ]}
   />
 );
-
-/* ---------- TagPill ---------- */
-const TagPill = memo(function TagPill({ id, name, color, onToggle }) {
-  const theme = useTheme();
-  return (
-    <Pressable
-      onPress={() => onToggle(id)}
-      android_ripple={{ color: withAlpha(theme.colors.tertiary, 0.25) }}
-      style={({ pressed }) => [
-        styles.tag,
-        { backgroundColor: color || theme.colors.secondary },
-        pressed && { opacity: 0.9, transform: [{ scale: 0.98 }] },
-      ]}
-    >
-      <Text style={[styles.tagText, { color: theme.colors.onPrimary }]}>
-        {name}
-      </Text>
-    </Pressable>
-  );
-});
 
 /* ---------- IngredientRow ---------- */
 const SUGGEST_ROW_H = 56;
@@ -1683,6 +1664,8 @@ export default function AddCocktailScreen() {
                 name={t.name}
                 color={t.color}
                 onToggle={toggleTagById}
+                rippleColor={withAlpha(theme.colors.tertiary, 0.25)}
+                defaultColor={theme.colors.secondary}
               />
             ))}
           </View>
@@ -1700,6 +1683,8 @@ export default function AddCocktailScreen() {
                   name={t.name}
                   color={t.color}
                   onToggle={toggleTagById}
+                  rippleColor={withAlpha(theme.colors.tertiary, 0.25)}
+                  defaultColor={theme.colors.secondary}
                 />
               ))}
             <Pressable
@@ -2038,13 +2023,6 @@ const styles = StyleSheet.create({
   },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },
-  tag: {
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 16,
-    margin: 4,
-  },
-  tagText: { fontWeight: "bold" },
 
   addTagButton: {
     paddingHorizontal: 10,

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -65,6 +65,7 @@ import { GLASSWARE, getGlassById } from "../../constants/glassware";
 
 import CocktailTagsModal from "../../components/CocktailTagsModal";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
+import TagPill from "../../components/TagPill";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import useInfoDialog from "../../hooks/useInfoDialog";
@@ -89,26 +90,6 @@ const Divider = ({ color, style }) => (
     ]}
   />
 );
-
-/* ---------- TagPill ---------- */
-const TagPill = memo(function TagPill({ id, name, color, onToggle }) {
-  const theme = useTheme();
-  return (
-    <Pressable
-      onPress={() => onToggle(id)}
-      android_ripple={{ color: withAlpha(theme.colors.tertiary, 0.25) }}
-      style={({ pressed }) => [
-        styles.tag,
-        { backgroundColor: color || theme.colors.secondary },
-        pressed && { opacity: 0.9, transform: [{ scale: 0.98 }] },
-      ]}
-    >
-      <Text style={[styles.tagText, { color: theme.colors.onPrimary }]}>
-        {name}
-      </Text>
-    </Pressable>
-  );
-});
 
 /* ---------- IngredientRow ---------- */
 const SUGGEST_ROW_H = 56;
@@ -1732,6 +1713,8 @@ export default function EditCocktailScreen() {
                 name={t.name}
                 color={t.color}
                 onToggle={toggleTagById}
+                rippleColor={withAlpha(theme.colors.tertiary, 0.25)}
+                defaultColor={theme.colors.secondary}
               />
             ))}
           </View>
@@ -1749,6 +1732,8 @@ export default function EditCocktailScreen() {
                   name={t.name}
                   color={t.color}
                   onToggle={toggleTagById}
+                  rippleColor={withAlpha(theme.colors.tertiary, 0.25)}
+                  defaultColor={theme.colors.secondary}
                 />
               ))}
             <Pressable
@@ -2165,13 +2150,6 @@ const styles = StyleSheet.create({
   },
 
   tagContainer: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },
-  tag: {
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 16,
-    margin: 4,
-  },
-  tagText: { fontWeight: "bold" },
 
   addTagButton: {
     paddingHorizontal: 10,


### PR DESCRIPTION
## Summary
- extend TagPill with ripple and default colors so callers can customize appearance
- replace inline TagPill copies in AddCocktailScreen and EditCocktailScreen with reusable component
- pass theme-based ripple and default colors from both cocktail screens

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68acf7085c108326b5c0ab5bdfb11887