### PR TITLE
Extract ingredient tag management into reusable hook

### DIFF
--- a/src/hooks/useIngredientTags.js
+++ b/src/hooks/useIngredientTags.js
@@ -1,0 +1,38 @@
+import { useState, useCallback } from "react";
+import { getAllTags } from "../storage/ingredientTagsStorage";
+import { BUILTIN_INGREDIENT_TAGS } from "../constants/ingredientTags";
+
+export default function useIngredientTags() {
+  const [availableTags, setAvailableTags] = useState([]);
+  const [tagsModalVisible, setTagsModalVisible] = useState(false);
+  const [tagsModalAutoAdd, setTagsModalAutoAdd] = useState(false);
+
+  const loadAvailableTags = useCallback(async () => {
+    const custom = await getAllTags();
+    setAvailableTags([...BUILTIN_INGREDIENT_TAGS, ...(custom || [])]);
+  }, []);
+
+  const closeTagsModal = useCallback(() => {
+    setTagsModalVisible(false);
+    setTagsModalAutoAdd(false);
+    loadAvailableTags();
+  }, [loadAvailableTags]);
+
+  const openAddTagModal = useCallback(() => {
+    setTagsModalAutoAdd(true);
+    setTagsModalVisible(true);
+  }, []);
+
+  return {
+    availableTags,
+    setAvailableTags,
+    tagsModalVisible,
+    setTagsModalVisible,
+    tagsModalAutoAdd,
+    setTagsModalAutoAdd,
+    loadAvailableTags,
+    openAddTagModal,
+    closeTagsModal,
+  };
+}
+

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -33,7 +33,6 @@ import {
 import { useTheme, Menu, Divider, Text as PaperText } from "react-native-paper";
 import { HeaderBackButton, useHeaderHeight } from "@react-navigation/elements";
 
-import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import { TAG_COLORS } from "../../theme";
 import { addIngredient } from "../../storage/ingredientsStorage";
@@ -45,6 +44,7 @@ import IngredientBaseRow, {
   INGREDIENT_BASE_ROW_HEIGHT,
 } from "../../components/IngredientBaseRow";
 import useIngredientsData from "../../hooks/useIngredientsData";
+import useIngredientTags from "../../hooks/useIngredientTags";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { WORD_SPLIT_RE, wordPrefixMatch } from "../../utils/wordPrefixMatch";
 import useInfoDialog from "../../hooks/useInfoDialog";
@@ -92,26 +92,17 @@ export default function AddIngredientScreen() {
     return other ? [other] : [{ id: 10, name: "other", color: TAG_COLORS[15] }];
   });
 
-  // reference lists
-  const [availableTags, setAvailableTags] = useState([]);
-  const [tagsModalVisible, setTagsModalVisible] = useState(false);
-  const [tagsModalAutoAdd, setTagsModalAutoAdd] = useState(false);
-
-  const loadAvailableTags = useCallback(async () => {
-    const custom = await getAllTags();
-    setAvailableTags([...BUILTIN_INGREDIENT_TAGS, ...(custom || [])]);
-  }, []);
-
-  const closeTagsModal = () => {
-    setTagsModalVisible(false);
-    setTagsModalAutoAdd(false);
-    loadAvailableTags();
-  };
-
-  const openAddTagModal = () => {
-    setTagsModalAutoAdd(true);
-    setTagsModalVisible(true);
-  };
+  // tag helpers & modal state
+  const {
+    availableTags,
+    tagsModalVisible,
+    tagsModalAutoAdd,
+    setTagsModalVisible,
+    setTagsModalAutoAdd,
+    loadAvailableTags,
+    openAddTagModal,
+    closeTagsModal,
+  } = useIngredientTags();
 
   // base ingredient link
   const [baseIngredientId, setBaseIngredientId] = useState(null);

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -37,7 +37,6 @@ import {
 import { useTheme, Menu, Divider, Text as PaperText } from "react-native-paper";
 import { useHeaderHeight } from "@react-navigation/elements";
 
-import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import { deleteIngredient, saveIngredient } from "../../storage/ingredientsStorage";
 import { MaterialIcons } from "@expo/vector-icons";
@@ -48,6 +47,7 @@ import IngredientBaseRow, {
 } from "../../components/IngredientBaseRow";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
 import useIngredientsData from "../../hooks/useIngredientsData";
+import useIngredientTags from "../../hooks/useIngredientTags";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { WORD_SPLIT_RE, wordPrefixMatch } from "../../utils/wordPrefixMatch";
@@ -84,26 +84,17 @@ export default function EditIngredientScreen() {
   const [tags, setTags] = useState([]);
   const selectedTagIds = useMemo(() => new Set(tags.map((t) => t.id)), [tags]);
 
-  // reference lists
-  const [availableTags, setAvailableTags] = useState([]); // builtin + custom
-  const [tagsModalVisible, setTagsModalVisible] = useState(false);
-  const [tagsModalAutoAdd, setTagsModalAutoAdd] = useState(false);
-
-  const loadAvailableTags = useCallback(async () => {
-    const custom = await getAllTags();
-    setAvailableTags([...BUILTIN_INGREDIENT_TAGS, ...(custom || [])]);
-  }, []);
-
-  const closeTagsModal = () => {
-    setTagsModalVisible(false);
-    setTagsModalAutoAdd(false);
-    loadAvailableTags();
-  };
-
-  const openAddTagModal = () => {
-    setTagsModalAutoAdd(true);
-    setTagsModalVisible(true);
-  };
+  // reference lists / tags modal
+  const {
+    availableTags,
+    tagsModalVisible,
+    tagsModalAutoAdd,
+    setTagsModalVisible,
+    setTagsModalAutoAdd,
+    loadAvailableTags,
+    openAddTagModal,
+    closeTagsModal,
+  } = useIngredientTags();
 
   // base link
   const [baseIngredientId, setBaseIngredientId] = useState(null);


### PR DESCRIPTION
## Summary
- add `useIngredientTags` hook for loading tags and managing the tag modal
- refactor add & edit ingredient screens to use the new hook

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68acf720d5688326ada41eee089eda3b