### PR TITLE
feat: extract reusable TinyDivider component

### DIFF
--- a/src/components/TinyDivider.js
+++ b/src/components/TinyDivider.js
@@ -1,0 +1,25 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+
+/**
+ * A tiny divider with hairline height and customizable color.
+ * Accepts optional `style` to extend or override default styles.
+ */
+const TinyDivider = ({ color, style }) => (
+  <View
+    style={[
+      styles.divider,
+      color != null && { backgroundColor: color },
+      style,
+    ]}
+  />
+);
+
+const styles = StyleSheet.create({
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    opacity: 0.5,
+  },
+});
+
+export default TinyDivider;

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -62,6 +62,7 @@ import { UNIT_ID, getUnitById, formatUnit } from "../../constants/measureUnits";
 import { GLASSWARE, getGlassById } from "../../constants/glassware";
 
 import CocktailTagsModal from "../../components/CocktailTagsModal";
+import TinyDivider from "../../components/TinyDivider";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import {
@@ -69,20 +70,6 @@ import {
   applyUsageMapToIngredients,
 } from "../../utils/ingredientUsage";
 import { getAllowSubstitutes } from "../../storage/settingsStorage";
-
-/* ---------- Tiny Divider ---------- */
-const Divider = ({ color, style }) => (
-  <View
-    style={[
-      {
-        height: StyleSheet.hairlineWidth,
-        backgroundColor: color,
-        opacity: 0.5,
-      },
-      style,
-    ]}
-  />
-);
 
 /* ---------- TagPill ---------- */
 const TagPill = memo(function TagPill({ id, name, color, onToggle }) {
@@ -561,7 +548,7 @@ const IngredientRow = memo(function IngredientRow({
                   }}
                 >
                   {index > 0 ? (
-                    <Divider color={theme.colors.outlineVariant} />
+                    <TinyDivider color={theme.colors.outlineVariant} />
                   ) : null}
                   <View
                     style={[
@@ -717,7 +704,7 @@ const IngredientRow = memo(function IngredientRow({
                 renderItem={({ item, index }) => (
                   <View>
                     {index > 0 ? (
-                      <Divider color={theme.colors.outlineVariant} />
+                      <TinyDivider color={theme.colors.outlineVariant} />
                     ) : null}
                     <MenuOption
                       closeOnSelect
@@ -999,7 +986,7 @@ const GlassPopover = memo(function GlassPopover({ selectedGlass, onSelect }) {
           renderItem={({ item, index }) => (
             <View>
               {index > 0 ? (
-                <Divider color={theme.colors.outlineVariant} />
+                <TinyDivider color={theme.colors.outlineVariant} />
               ) : null}
               <MenuOption
                 closeOnSelect
@@ -1907,7 +1894,7 @@ export default function AddCocktailScreen() {
                   style={styles.modalItemPressable}
                 >
                   {index > 0 ? (
-                    <Divider color={theme.colors.outlineVariant} />
+                    <TinyDivider color={theme.colors.outlineVariant} />
                   ) : null}
                     <View
                       style={[

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -65,6 +65,7 @@ import { GLASSWARE, getGlassById } from "../../constants/glassware";
 
 import CocktailTagsModal from "../../components/CocktailTagsModal";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
+import TinyDivider from "../../components/TinyDivider";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import useInfoDialog from "../../hooks/useInfoDialog";
@@ -75,20 +76,6 @@ import {
 } from "../../utils/ingredientUsage";
 import { getAllowSubstitutes } from "../../storage/settingsStorage";
 import useDebounced from "../../hooks/useDebounced";
-
-/* ---------- Tiny Divider ---------- */
-const Divider = ({ color, style }) => (
-  <View
-    style={[
-      {
-        height: StyleSheet.hairlineWidth,
-        backgroundColor: color,
-        opacity: 0.5,
-      },
-      style,
-    ]}
-  />
-);
 
 /* ---------- TagPill ---------- */
 const TagPill = memo(function TagPill({ id, name, color, onToggle }) {
@@ -570,7 +557,7 @@ const IngredientRow = memo(function IngredientRow({
                   }}
                 >
                   {index > 0 ? (
-                    <Divider color={theme.colors.outlineVariant} />
+                    <TinyDivider color={theme.colors.outlineVariant} />
                   ) : null}
                   <View
                     style={[
@@ -726,7 +713,7 @@ const IngredientRow = memo(function IngredientRow({
                 renderItem={({ item, index }) => (
                   <View>
                     {index > 0 ? (
-                      <Divider color={theme.colors.outlineVariant} />
+                      <TinyDivider color={theme.colors.outlineVariant} />
                     ) : null}
                     <MenuOption
                       closeOnSelect
@@ -1008,7 +995,7 @@ const GlassPopover = memo(function GlassPopover({ selectedGlass, onSelect }) {
           renderItem={({ item, index }) => (
             <View>
               {index > 0 ? (
-                <Divider color={theme.colors.outlineVariant} />
+                <TinyDivider color={theme.colors.outlineVariant} />
               ) : null}
               <MenuOption
                 closeOnSelect
@@ -1956,7 +1943,7 @@ export default function EditCocktailScreen() {
                   style={styles.modalItemPressable}
                 >
                   {index > 0 ? (
-                    <Divider color={theme.colors.outlineVariant} />
+                    <TinyDivider color={theme.colors.outlineVariant} />
                   ) : null}
                     <View
                       style={[


### PR DESCRIPTION
## Summary
- add `TinyDivider` component for a hairline divider with customizable color
- replace inline divider implementations in AddCocktailScreen and EditCocktailScreen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acf733ffac832682f3fd10d25d7be0