### PR TITLE
Ensure Add Cocktail starts fresh from ingredient details

### DIFF
--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -679,7 +679,7 @@ export default function IngredientDetailsScreen() {
         onPress={() =>
           navigation.navigate("Cocktails", {
             screen: "AddCocktail",
-            params: { initialIngredient: ingredient },
+            params: { initialIngredient: ingredient, resetKey: Date.now() },
           })
         }
       >


### PR DESCRIPTION
## Summary
- Reset Add Cocktail form when opened from an ingredient so previous draft data isn't reused
- Include reset key when navigating from ingredient details to force new cocktail creation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acfaa373c88326a442f56a71e7c654