### PR TITLE
refactor: centralize ingredient tag state via reusable hook

### DIFF
--- a/src/hooks/useIngredientTags.js
+++ b/src/hooks/useIngredientTags.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { getAllTags } from "../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../constants/ingredientTags";
 
@@ -11,6 +11,12 @@ export default function useIngredientTags() {
     const custom = await getAllTags();
     setAvailableTags([...BUILTIN_INGREDIENT_TAGS, ...(custom || [])]);
   }, []);
+
+  // Load tag reference list on first use so screens using the hook
+  // immediately have the up‑to‑date tag collection available.
+  useEffect(() => {
+    loadAvailableTags();
+  }, [loadAvailableTags]);
 
   const closeTagsModal = useCallback(() => {
     setTagsModalVisible(false);

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -257,9 +257,16 @@ export default function AddIngredientScreen() {
     navigation.setParams({ initialName: undefined });
   }, [isFocused, initialNameParam, navigation]);
 
+  const didLoadTagsRef = useRef(false);
   useEffect(() => {
     if (!isFocused) return;
-    loadAvailableTags();
+    if (didLoadTagsRef.current) {
+      // Refresh available tags when returning to this screen.
+      loadAvailableTags();
+    } else {
+      // Skip the first run – the hook loads tags on mount.
+      didLoadTagsRef.current = true;
+    }
   }, [isFocused, loadAvailableTags]);
 
   /* ---------- UI handlers ---------- */

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -268,13 +268,19 @@ export default function EditIngredientScreen() {
   }, [navigation]);
 
   // load tags + entity on focus (паралельно)
+  const didLoadTagsRef = useRef(false);
   useEffect(() => {
     if (!isFocused) return;
     let cancelled = false;
 
     (async () => {
       try {
-        await loadAvailableTags();
+        if (didLoadTagsRef.current) {
+          await loadAvailableTags();
+        } else {
+          // The hook loads tags on initial mount; mark as loaded.
+          didLoadTagsRef.current = true;
+        }
         if (cancelled || !isMountedRef.current) return;
         const data = ingredientsById.get(currentId);
         if (data) {


### PR DESCRIPTION
## Summary
- auto-load ingredient tags in new `useIngredientTags` hook
- refresh tags on Add/Edit Ingredient screens only when returning

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acfb7480c4832688f68bd8a4a7b6d1