### PR TITLE
refactor: add reusable TinyDivider component

### DIFF
--- a/src/components/TinyDivider.js
+++ b/src/components/TinyDivider.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+
+export default function TinyDivider({ color, style }) {
+  return (
+    <View
+      style={[
+        {
+          height: StyleSheet.hairlineWidth,
+          backgroundColor: color,
+          opacity: 0.5,
+        },
+        style,
+      ]}
+    />
+  );
+}
+

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -63,6 +63,7 @@ import { GLASSWARE, getGlassById } from "../../constants/glassware";
 
 import CocktailTagsModal from "../../components/CocktailTagsModal";
 import TagPill from "../../components/TagPill";
+import TinyDivider from "../../components/TinyDivider";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import {
@@ -70,20 +71,6 @@ import {
   applyUsageMapToIngredients,
 } from "../../utils/ingredientUsage";
 import { getAllowSubstitutes } from "../../storage/settingsStorage";
-
-/* ---------- Tiny Divider ---------- */
-const Divider = ({ color, style }) => (
-  <View
-    style={[
-      {
-        height: StyleSheet.hairlineWidth,
-        backgroundColor: color,
-        opacity: 0.5,
-      },
-      style,
-    ]}
-  />
-);
 
 /* ---------- IngredientRow ---------- */
 const SUGGEST_ROW_H = 56;
@@ -542,7 +529,7 @@ const IngredientRow = memo(function IngredientRow({
                   }}
                 >
                   {index > 0 ? (
-                    <Divider color={theme.colors.outlineVariant} />
+                    <TinyDivider color={theme.colors.outlineVariant} />
                   ) : null}
                   <View
                     style={[
@@ -698,7 +685,7 @@ const IngredientRow = memo(function IngredientRow({
                 renderItem={({ item, index }) => (
                   <View>
                     {index > 0 ? (
-                      <Divider color={theme.colors.outlineVariant} />
+                      <TinyDivider color={theme.colors.outlineVariant} />
                     ) : null}
                     <MenuOption
                       closeOnSelect
@@ -980,7 +967,7 @@ const GlassPopover = memo(function GlassPopover({ selectedGlass, onSelect }) {
           renderItem={({ item, index }) => (
             <View>
               {index > 0 ? (
-                <Divider color={theme.colors.outlineVariant} />
+                <TinyDivider color={theme.colors.outlineVariant} />
               ) : null}
               <MenuOption
                 closeOnSelect
@@ -1892,7 +1879,7 @@ export default function AddCocktailScreen() {
                   style={styles.modalItemPressable}
                 >
                   {index > 0 ? (
-                    <Divider color={theme.colors.outlineVariant} />
+                    <TinyDivider color={theme.colors.outlineVariant} />
                   ) : null}
                     <View
                       style={[

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -66,6 +66,7 @@ import { GLASSWARE, getGlassById } from "../../constants/glassware";
 import CocktailTagsModal from "../../components/CocktailTagsModal";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
 import TagPill from "../../components/TagPill";
+import TinyDivider from "../../components/TinyDivider";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import useInfoDialog from "../../hooks/useInfoDialog";
@@ -76,20 +77,6 @@ import {
 } from "../../utils/ingredientUsage";
 import { getAllowSubstitutes } from "../../storage/settingsStorage";
 import useDebounced from "../../hooks/useDebounced";
-
-/* ---------- Tiny Divider ---------- */
-const Divider = ({ color, style }) => (
-  <View
-    style={[
-      {
-        height: StyleSheet.hairlineWidth,
-        backgroundColor: color,
-        opacity: 0.5,
-      },
-      style,
-    ]}
-  />
-);
 
 /* ---------- IngredientRow ---------- */
 const SUGGEST_ROW_H = 56;
@@ -551,7 +538,7 @@ const IngredientRow = memo(function IngredientRow({
                   }}
                 >
                   {index > 0 ? (
-                    <Divider color={theme.colors.outlineVariant} />
+                    <TinyDivider color={theme.colors.outlineVariant} />
                   ) : null}
                   <View
                     style={[
@@ -707,7 +694,7 @@ const IngredientRow = memo(function IngredientRow({
                 renderItem={({ item, index }) => (
                   <View>
                     {index > 0 ? (
-                      <Divider color={theme.colors.outlineVariant} />
+                      <TinyDivider color={theme.colors.outlineVariant} />
                     ) : null}
                     <MenuOption
                       closeOnSelect
@@ -989,7 +976,7 @@ const GlassPopover = memo(function GlassPopover({ selectedGlass, onSelect }) {
           renderItem={({ item, index }) => (
             <View>
               {index > 0 ? (
-                <Divider color={theme.colors.outlineVariant} />
+                <TinyDivider color={theme.colors.outlineVariant} />
               ) : null}
               <MenuOption
                 closeOnSelect
@@ -1941,7 +1928,7 @@ export default function EditCocktailScreen() {
                   style={styles.modalItemPressable}
                 >
                   {index > 0 ? (
-                    <Divider color={theme.colors.outlineVariant} />
+                    <TinyDivider color={theme.colors.outlineVariant} />
                   ) : null}
                     <View
                       style={[


### PR DESCRIPTION
## Summary
- add TinyDivider component for a thin divider with configurable color
- use TinyDivider in add and edit cocktail screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acfb94e4d8832688b3dabe504f8e16