### PR TITLE
Add basic utility tests using Node's test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "node --test"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/src/utils/__tests__/normalizeSearch.test.js
+++ b/src/utils/__tests__/normalizeSearch.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeSearch } from '../normalizeSearch.js';
+
+test('normalizes diacritics and case', () => {
+  assert.equal(normalizeSearch('Éxámple'), 'example');
+});
+
+test('handles null values', () => {
+  assert.equal(normalizeSearch(null), '');
+});

--- a/src/utils/__tests__/sortByName.test.js
+++ b/src/utils/__tests__/sortByName.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sortByName } from '../sortByName.js';
+
+test('orders by name ascending ignoring case', () => {
+  const arr = [{ name: 'b' }, { name: 'A' }];
+  arr.sort((a, b) => sortByName(a, b));
+  assert.deepEqual(arr, [{ name: 'A' }, { name: 'b' }]);
+});
+
+test('handles missing names as empty strings', () => {
+  const arr = [{}, { name: 'a' }];
+  arr.sort((a, b) => sortByName(a, b));
+  assert.deepEqual(arr, [{}, { name: 'a' }]);
+});

--- a/src/utils/__tests__/wordPrefixMatch.test.js
+++ b/src/utils/__tests__/wordPrefixMatch.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { wordPrefixMatch } from '../wordPrefixMatch.js';
+
+test('matches sequential prefixes in order', () => {
+  assert.equal(wordPrefixMatch(['hello', 'world'], ['he', 'wo']), true);
+});
+
+test('returns false when tokens not found', () => {
+  assert.equal(wordPrefixMatch(['hello', 'world'], ['he', 'zz']), false);
+});
+
+test('returns false for invalid inputs', () => {
+  assert.equal(wordPrefixMatch(null, ['he']), false);
+  assert.equal(wordPrefixMatch(['hello'], null), false);
+});


### PR DESCRIPTION
## Summary
- add `node --test` script to package.json
- test string normalization helper
- cover word prefix matching and name sorting utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad02ee723883268b2b390b21382e8c