### PR TITLE
Optimize ingredient loading for cocktail details

### DIFF
--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -28,6 +28,32 @@ export async function getAllIngredients() {
     .sort(sortByName);
 }
 
+export async function getIngredientsByIds(ids) {
+  const list = Array.isArray(ids) ? ids.filter((id) => id != null) : [];
+  if (list.length === 0) return [];
+  const placeholders = list.map(() => "?").join(", ");
+  const res = await query(
+    `SELECT id, name, description, tags, baseIngredientId, usageCount, singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList FROM ingredients WHERE id IN (${placeholders})`,
+    list.map((id) => String(id))
+  );
+  return res.rows._array
+    .map((r) => ({
+      id: Number(r.id),
+      name: r.name,
+      description: r.description,
+      tags: r.tags ? JSON.parse(r.tags) : [],
+      baseIngredientId: r.baseIngredientId != null ? Number(r.baseIngredientId) : null,
+      usageCount: r.usageCount ?? 0,
+      singleCocktailName: r.singleCocktailName,
+      searchName: r.searchName,
+      searchTokens: r.searchTokens ? JSON.parse(r.searchTokens) : [],
+      photoUri: r.photoUri,
+      inBar: !!r.inBar,
+      inShoppingList: !!r.inShoppingList,
+    }))
+    .sort(sortByName);
+}
+
 export function buildIndex(list) {
   return list.reduce((acc, item) => {
     acc[item.id] = item;


### PR DESCRIPTION
## Summary
- add `getIngredientsByIds` to query multiple ingredient rows by id
- load only necessary ingredients for cocktail details and include base ingredients when substitution is enabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad97372c0083268b5c11e21ed3d612