### PR TITLE
feat: add inverse primary theme color

### DIFF
--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -312,7 +312,7 @@ export default function MyCocktailsScreen() {
             baseIngredientId={ing.baseIngredientId}
             onPress={handleIngredientPress}
             onToggleShoppingList={toggleShoppingList}
-            highlightColor={theme.colors.secondaryContainer}
+            highlightColor={theme.colors.inversePrimary}
           />
         );
       }
@@ -330,7 +330,7 @@ export default function MyCocktailsScreen() {
       handleIngredientPress,
       toggleShoppingList,
       theme.colors.onSurfaceVariant,
-      theme.colors.secondaryContainer,
+      theme.colors.inversePrimary,
     ]
   );
 

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -18,7 +18,6 @@ import {
   addIgnoreGarnishListener,
 } from "../storage/settingsStorage";
 
-const SELECTED_COLOR = "#CCFFCC"; // light green
 
 export default function ShakerScreen({ navigation }) {
   const theme = useTheme();
@@ -168,7 +167,7 @@ export default function ShakerScreen({ navigation }) {
             baseIngredientId={ing.baseIngredientId}
             onPress={toggleIngredient}
             onDetails={(id) => navigation.push("IngredientDetails", { id })}
-            highlightColor={active ? SELECTED_COLOR : undefined}
+            highlightColor={active ? theme.colors.inversePrimary : undefined}
           />
         </View>
       );

--- a/src/theme.js
+++ b/src/theme.js
@@ -14,6 +14,8 @@ export const AppTheme = {
 
     secondaryContainer: "#E9F7DF",
 
+    inversePrimary: "#E9F7DF",
+
     background: "#FFFFFF",
     surface: "#F8F9FA",
     outline: "#E5EAF0",


### PR DESCRIPTION
## Summary
- add green inversePrimary color to app theme
- use inversePrimary for ingredient highlight on My Cocktails and Shaker screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb858932483269fcab9777b823b73