### PR TITLE
Rename Favorite tab to Favorites

### DIFF
--- a/src/components/GeneralMenu.js
+++ b/src/components/GeneralMenu.js
@@ -122,7 +122,7 @@ export default function GeneralMenu({ visible, onClose }) {
   const startLabels = {
     "cocktails:All": "Cocktails - All",
     "cocktails:My": "Cocktails - My",
-    "cocktails:Favorite": "Cocktails - Favorites",
+    "cocktails:Favorites": "Cocktails - Favorites",
     "ingredients:All": "Ingredients - All",
     "ingredients:My": "Ingredients - My",
     "ingredients:Shopping": "Ingredients - Shopping",

--- a/src/components/StartScreenModal.js
+++ b/src/components/StartScreenModal.js
@@ -13,7 +13,7 @@ import { useTheme } from "react-native-paper";
 const OPTIONS = [
   { key: "cocktails:All", label: "Cocktails - All" },
   { key: "cocktails:My", label: "Cocktails - My" },
-  { key: "cocktails:Favorite", label: "Cocktails - Favorites" },
+  { key: "cocktails:Favorites", label: "Cocktails - Favorites" },
   { key: "ingredients:All", label: "Ingredients - All" },
   { key: "ingredients:My", label: "Ingredients - My" },
   { key: "ingredients:Shopping", label: "Ingredients - Shopping" },

--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -38,7 +38,7 @@ function CocktailTabs({ route }) {
               let iconName;
               if (route.name === "All") iconName = "list";
               else if (route.name === "My") iconName = "check-circle";
-              else if (route.name === "Favorite") iconName = "star";
+              else if (route.name === "Favorites") iconName = "star";
               return <MaterialIcons name={iconName} size={size} color={color} />;
             },
             tabBarActiveTintColor: theme.colors.primary,
@@ -57,7 +57,7 @@ function CocktailTabs({ route }) {
       >
         <Tab.Screen name="All" component={AllCocktailsScreen} />
         <Tab.Screen name="My" component={MyCocktailsScreen} />
-        <Tab.Screen name="Favorite" component={FavoriteCocktailsScreen} />
+        <Tab.Screen name="Favorites" component={FavoriteCocktailsScreen} />
       </Tab.Navigator>
       <FAB
         icon="plus"

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -58,7 +58,7 @@ export default function FavoriteCocktailsScreen() {
   const [sortOrder, setSortOrder] = useState("desc");
 
   useEffect(() => {
-    if (isFocused) setTab("cocktails", "Favorite");
+    if (isFocused) setTab("cocktails", "Favorites");
   }, [isFocused, setTab]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- rename Cocktails tab label from Favorite to Favorites
- adjust start screen and settings keys to match new Favorites tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc1817ad483269186022651f9f14e