### PR TITLE
fix: avoid provider update during ingredient render

### DIFF
--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -384,39 +384,35 @@ export default function IngredientDetailsScreen() {
   }, [load]);
 
   const toggleInBar = useCallback(() => {
-    setIngredient((prev) => {
-      if (!prev) return prev;
-      const updated = { ...prev, inBar: !prev.inBar };
-      setIngredients((list) => {
-        const nextList = updateIngredientById(list, {
-          id: updated.id,
-          inBar: updated.inBar,
-        });
-        saveIngredient(updated);
-        return nextList;
+    if (!ingredient) return;
+    const updated = { ...ingredient, inBar: !ingredient.inBar };
+    setIngredient(updated);
+    setIngredients((list) => {
+      const nextList = updateIngredientById(list, {
+        id: updated.id,
+        inBar: updated.inBar,
       });
-      return updated;
+      saveIngredient(updated);
+      return nextList;
     });
-  }, [setIngredients]);
+  }, [ingredient, setIngredients]);
 
   const toggleInShoppingList = useCallback(() => {
-    setIngredient((prev) => {
-      if (!prev) return prev;
-      const updated = {
-        ...prev,
-        inShoppingList: !prev.inShoppingList,
-      };
-      setIngredients((list) => {
-        const nextList = updateIngredientById(list, {
-          id: updated.id,
-          inShoppingList: updated.inShoppingList,
-        });
-        saveIngredient(updated);
-        return nextList;
+    if (!ingredient) return;
+    const updated = {
+      ...ingredient,
+      inShoppingList: !ingredient.inShoppingList,
+    };
+    setIngredient(updated);
+    setIngredients((list) => {
+      const nextList = updateIngredientById(list, {
+        id: updated.id,
+        inShoppingList: updated.inShoppingList,
       });
-      return updated;
+      saveIngredient(updated);
+      return nextList;
     });
-  }, [setIngredients]);
+  }, [ingredient, setIngredients]);
 
   const unlinkIngredients = useCallback(
     ({ base, brandeds }) => {


### PR DESCRIPTION
## Summary
- prevent IngredientUsageProvider state updates during IngredientDetailsScreen render to avoid React warning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc22cf8ec8326a38e2af24f006887