### PR TITLE
feat: batch ingredient updates

### DIFF
--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -11,7 +11,10 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { saveIngredient, updateIngredientById } from "../../storage/ingredientsStorage";
+import {
+  flushPendingIngredients,
+  updateIngredientById,
+} from "../../storage/ingredientsStorage";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -89,7 +92,7 @@ export default function MyIngredientsScreen() {
 
   const flushPending = useCallback(() => {
     if (pendingUpdates.length) {
-      pendingUpdates.forEach((u) => saveIngredient(u).catch(() => {}));
+      flushPendingIngredients(pendingUpdates).catch(() => {});
       setPendingUpdates([]);
     }
   }, [pendingUpdates]);

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -11,7 +11,10 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { saveIngredient, updateIngredientById } from "../../storage/ingredientsStorage";
+import {
+  flushPendingIngredients,
+  updateIngredientById,
+} from "../../storage/ingredientsStorage";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -59,7 +62,7 @@ export default function ShoppingIngredientsScreen() {
 
   const flushPending = useCallback(() => {
     if (pendingUpdates.length) {
-      pendingUpdates.forEach((u) => saveIngredient(u).catch(() => {}));
+      flushPendingIngredients(pendingUpdates).catch(() => {});
       setPendingUpdates([]);
     }
   }, [pendingUpdates]);

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -155,6 +155,16 @@ export async function saveIngredient(updated) {
   return item;
 }
 
+export async function flushPendingIngredients(list) {
+  const items = Array.isArray(list) ? list : [];
+  if (!items.length) return;
+  await db.withTransactionAsync(async () => {
+    for (const u of items) {
+      await upsertIngredient(sanitizeIngredient(u));
+    }
+  });
+}
+
 export function getIngredientById(id, index) {
   return index ? index[id] : null;
 }


### PR DESCRIPTION
## Summary
- add `flushPendingIngredients` to batch-save ingredient changes in a transaction
- refactor MyIngredientsScreen and ShoppingIngredientsScreen to use new utility instead of per-item saves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc4babb1c8326a0299359537704bd