### PR TITLE
feat: async ingredient save with syncing indicator

### DIFF
--- a/src/components/IngredientRow.js
+++ b/src/components/IngredientRow.js
@@ -1,5 +1,13 @@
 import React, { memo, useMemo } from "react";
-import { View, Text, Image, Pressable, StyleSheet, Platform } from "react-native";
+import {
+  View,
+  Text,
+  Image,
+  Pressable,
+  StyleSheet,
+  Platform,
+  ActivityIndicator,
+} from "react-native";
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import { withAlpha } from "../utils/color";
@@ -28,6 +36,7 @@ function IngredientRow({
   onRemove,
   isNavigating,
   highlightColor,
+  saving,
 }) {
   const theme = useTheme();
   const isBranded = baseIngredientId != null;
@@ -194,6 +203,13 @@ function IngredientRow({
             />
           </Pressable>
         ) : null}
+        {saving && (
+          <ActivityIndicator
+            size="small"
+            color={theme.colors.primary}
+            style={styles.saving}
+          />
+        )}
       </View>
     </View>
   );
@@ -246,4 +262,5 @@ const styles = StyleSheet.create({
   pressedCheck: { opacity: 0.7, transform: [{ scale: 0.92 }] },
   removeButton: { marginLeft: 8, paddingVertical: 6, paddingHorizontal: 4 },
   pressedRemove: { opacity: 0.7, transform: [{ scale: 0.92 }] },
+  saving: { marginLeft: 4 },
 });

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
+import { View, Text, StyleSheet, ActivityIndicator, Alert } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
 import { useTheme } from "react-native-paper";
@@ -41,7 +41,7 @@ export default function MyIngredientsScreen() {
   const [availableTags, setAvailableTags] = useState([]);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
   const [allowSubstitutes, setAllowSubstitutes] = useState(false);
-  const [pendingUpdates, setPendingUpdates] = useState([]);
+  const [savingIds, setSavingIds] = useState(new Set());
 
   useEffect(() => {
     if (isFocused) setTab("ingredients", "My");
@@ -87,32 +87,28 @@ export default function MyIngredientsScreen() {
     return () => clearTimeout(h);
   }, [search]);
 
-  const flushPending = useCallback(() => {
-    if (pendingUpdates.length) {
-      pendingUpdates.forEach((u) => saveIngredient(u).catch(() => {}));
-      setPendingUpdates([]);
-    }
-  }, [pendingUpdates]);
-
-  useEffect(() => {
-    if (!pendingUpdates.length) return;
-    const handle = setTimeout(() => {
-      flushPending();
-    }, 300);
-    return () => clearTimeout(handle);
-  }, [pendingUpdates, flushPending]);
-
-  useEffect(() => {
-    if (!isFocused) {
-      flushPending();
-    }
-  }, [isFocused, flushPending]);
-
-  useEffect(() => {
-    return () => {
-      flushPending();
-    };
-  }, [flushPending]);
+  const saveWithRetry = useCallback((item) => {
+    setSavingIds((s) => new Set(s).add(item.id));
+    saveIngredient(item)
+      .then(() => {
+        setSavingIds((s) => {
+          const next = new Set(s);
+          next.delete(item.id);
+          return next;
+        });
+      })
+      .catch(() => {
+        setSavingIds((s) => {
+          const next = new Set(s);
+          next.delete(item.id);
+          return next;
+        });
+        Alert.alert("Save failed", "Could not save ingredient", [
+          { text: "Retry", onPress: () => saveWithRetry(item) },
+          { text: "Dismiss", style: "cancel" },
+        ]);
+      });
+  }, []);
 
   const availableMap = useMemo(() => {
     const ingMap = new Map(ingredients.map((i) => [String(i.id), i]));
@@ -199,9 +195,9 @@ export default function MyIngredientsScreen() {
         updated = { ...item, inBar: !item.inBar };
         return updateIngredientById(prev, updated);
       });
-      if (updated) setPendingUpdates((p) => [...p, updated]);
+      if (updated) saveWithRetry(updated);
     },
-    [setIngredients]
+    [setIngredients, saveWithRetry]
   );
 
   const onItemPress = useCallback(
@@ -231,10 +227,11 @@ export default function MyIngredientsScreen() {
           onPress={onItemPress}
           onToggleInBar={toggleInBar}
           isNavigating={navigatingId === item.id}
+          saving={savingIds.has(item.id)}
         />
       );
     },
-    [onItemPress, toggleInBar, navigatingId, availableMap]
+    [onItemPress, toggleInBar, navigatingId, availableMap, savingIds]
   );
 
   const keyExtractor = useCallback((item) => String(item.id), []);

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
+import { View, Text, StyleSheet, ActivityIndicator, Alert } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
 import { useTheme } from "react-native-paper";
@@ -32,7 +32,7 @@ export default function ShoppingIngredientsScreen() {
   const [navigatingId, setNavigatingId] = useState(null);
   const [selectedTagIds, setSelectedTagIds] = useState([]);
   const [availableTags, setAvailableTags] = useState([]);
-  const [pendingUpdates, setPendingUpdates] = useState([]);
+  const [savingIds, setSavingIds] = useState(new Set());
 
   useEffect(() => {
     if (isFocused) setTab("ingredients", "Shopping");
@@ -57,32 +57,28 @@ export default function ShoppingIngredientsScreen() {
     return () => clearTimeout(h);
   }, [search]);
 
-  const flushPending = useCallback(() => {
-    if (pendingUpdates.length) {
-      pendingUpdates.forEach((u) => saveIngredient(u).catch(() => {}));
-      setPendingUpdates([]);
-    }
-  }, [pendingUpdates]);
-
-  useEffect(() => {
-    if (!pendingUpdates.length) return;
-    const handle = setTimeout(() => {
-      flushPending();
-    }, 300);
-    return () => clearTimeout(handle);
-  }, [pendingUpdates, flushPending]);
-
-  useEffect(() => {
-    if (!isFocused) {
-      flushPending();
-    }
-  }, [isFocused, flushPending]);
-
-  useEffect(() => {
-    return () => {
-      flushPending();
-    };
-  }, [flushPending]);
+  const saveWithRetry = useCallback((item) => {
+    setSavingIds((s) => new Set(s).add(item.id));
+    saveIngredient(item)
+      .then(() => {
+        setSavingIds((s) => {
+          const next = new Set(s);
+          next.delete(item.id);
+          return next;
+        });
+      })
+      .catch(() => {
+        setSavingIds((s) => {
+          const next = new Set(s);
+          next.delete(item.id);
+          return next;
+        });
+        Alert.alert("Save failed", "Could not save ingredient", [
+          { text: "Retry", onPress: () => saveWithRetry(item) },
+          { text: "Dismiss", style: "cancel" },
+        ]);
+      });
+  }, []);
 
   const filtered = useMemo(() => {
     const q = normalizeSearch(searchDebounced);
@@ -106,9 +102,9 @@ export default function ShoppingIngredientsScreen() {
         updated = { ...item, inShoppingList: false };
         return updateIngredientById(prev, updated);
       });
-      if (updated) setPendingUpdates((p) => [...p, updated]);
+      if (updated) saveWithRetry(updated);
     },
-    [setIngredients]
+    [setIngredients, saveWithRetry]
   );
 
   const onItemPress = useCallback(
@@ -135,9 +131,10 @@ export default function ShoppingIngredientsScreen() {
         onPress={onItemPress}
         onRemove={removeFromList}
         isNavigating={navigatingId === item.id}
+        saving={savingIds.has(item.id)}
       />
     ),
-    [onItemPress, removeFromList, navigatingId]
+    [onItemPress, removeFromList, navigatingId, savingIds]
   );
 
   const keyExtractor = useCallback((item) => String(item.id), []);


### PR DESCRIPTION
## Summary
- save ingredient state immediately in background and handle failures with retry dialogs
- show spinner on ingredient rows while save is in progress
- remove delayed save queue for ingredient lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc612ab2c8326a1f8f94ca8fcce66