### PR TITLE
Batch ingredient updates before DB flush

### DIFF
--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -11,7 +11,10 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { saveIngredient, updateIngredientById } from "../../storage/ingredientsStorage";
+import {
+  flushPendingIngredients,
+  updateIngredientById,
+} from "../../storage/ingredientsStorage";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -59,7 +62,7 @@ export default function AllIngredientsScreen() {
 
   const flushPending = useCallback(() => {
     if (pendingUpdates.length) {
-      pendingUpdates.forEach((u) => saveIngredient(u).catch(() => {}));
+      flushPendingIngredients(pendingUpdates).catch(() => {});
       setPendingUpdates([]);
     }
   }, [pendingUpdates]);


### PR DESCRIPTION
## Summary
- batch pending ingredient updates in AllIngredients and MyCocktails screens
- defer DB writes using flushPendingIngredients after memory state updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc893a95483268f41bd45e7e3fa23