### PR TITLE
feat: optimistically toggle ingredient availability

### DIFF
--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -387,14 +387,13 @@ export default function IngredientDetailsScreen() {
     if (!ingredient) return;
     const updated = { ...ingredient, inBar: !ingredient.inBar };
     setIngredient(updated);
-    setIngredients((list) => {
-      const nextList = updateIngredientById(list, {
+    setIngredients((list) =>
+      updateIngredientById(list, {
         id: updated.id,
         inBar: updated.inBar,
-      });
-      saveIngredient(updated);
-      return nextList;
-    });
+      })
+    );
+    setTimeout(() => saveIngredient(updated).catch(() => {}), 0);
   }, [ingredient, setIngredients]);
 
   const toggleInShoppingList = useCallback(() => {


### PR DESCRIPTION
## Summary
- update ingredient details screen to immediately toggle in-bar checkbox
- persist availability changes in the background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adcd9487908326a7eeffa0d967a7df