### PR TITLE
feat: add partial ingredient update

### DIFF
--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -29,6 +29,7 @@ import {
   getAllIngredients,
   saveIngredient,
   updateIngredientById,
+  updateIngredientFields,
 } from "../../storage/ingredientsStorage";
 import db from "../../storage/sqlite";
 
@@ -392,7 +393,7 @@ export default function IngredientDetailsScreen() {
         id: updated.id,
         inBar: updated.inBar,
       });
-      saveIngredient(updated);
+      updateIngredientFields(updated.id, { inBar: updated.inBar });
       return nextList;
     });
   }, [ingredient, setIngredients]);
@@ -409,7 +410,9 @@ export default function IngredientDetailsScreen() {
         id: updated.id,
         inShoppingList: updated.inShoppingList,
       });
-      saveIngredient(updated);
+      updateIngredientFields(updated.id, {
+        inShoppingList: updated.inShoppingList,
+      });
       return nextList;
     });
   }, [ingredient, setIngredients]);


### PR DESCRIPTION
## Summary
- add updateIngredientFields for updating selected columns
- use updateIngredientFields when toggling ingredient flags
- skip re-sanitizing unchanged ingredient names in saveIngredient

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68add9064cd08326a90164967cfa95be