### PR TITLE
Remove deferred ingredient updates

### DIFF
--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -268,7 +268,11 @@ export default function MyCocktailsScreen() {
             inShoppingList: updated.inShoppingList,
           })
         );
-        updateIngredientFields(id, { inShoppingList: updated.inShoppingList });
+        setTimeout(
+          () =>
+            updateIngredientFields(id, { inShoppingList: updated.inShoppingList }),
+          0
+        );
       }
     },
     [setGlobalIngredients, setIngredients]

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -13,11 +13,7 @@ import TopTabBar from "../../components/TopTabBar";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { getAllCocktails } from "../../storage/cocktailsStorage";
-import {
-  getAllIngredients,
-  flushPendingIngredients,
-  updateIngredientById,
-} from "../../storage/ingredientsStorage";
+import { getAllIngredients, updateIngredientById, updateIngredientFields } from "../../storage/ingredientsStorage";
 import {
   getIgnoreGarnish,
   addIgnoreGarnishListener,
@@ -54,7 +50,6 @@ export default function MyCocktailsScreen() {
   const [availableTags, setAvailableTags] = useState([]);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
   const [allowSubstitutes, setAllowSubstitutes] = useState(false);
-  const [pendingUpdates, setPendingUpdates] = useState([]);
   const { setIngredients: setGlobalIngredients } = useIngredientsData();
   const { cocktails: globalCocktails = [], ingredients: globalIngredients = [] } =
     useIngredientUsage();
@@ -78,33 +73,6 @@ export default function MyCocktailsScreen() {
     const h = setTimeout(() => setSearchDebounced(search), 300);
     return () => clearTimeout(h);
   }, [search]);
-
-  const flushPending = useCallback(() => {
-    if (pendingUpdates.length) {
-      flushPendingIngredients(pendingUpdates).catch(() => {});
-      setPendingUpdates([]);
-    }
-  }, [pendingUpdates]);
-
-  useEffect(() => {
-    if (!pendingUpdates.length) return;
-    const handle = setTimeout(() => {
-      flushPending();
-    }, 300);
-    return () => clearTimeout(handle);
-  }, [pendingUpdates, flushPending]);
-
-  useEffect(() => {
-    if (!isFocused) {
-      flushPending();
-    }
-  }, [isFocused, flushPending]);
-
-  useEffect(() => {
-    return () => {
-      flushPending();
-    };
-  }, [flushPending]);
 
   const firstLoad = useRef(true);
   useEffect(() => {
@@ -300,7 +268,7 @@ export default function MyCocktailsScreen() {
             inShoppingList: updated.inShoppingList,
           })
         );
-        setPendingUpdates((p) => [...p, updated]);
+        updateIngredientFields(id, { inShoppingList: updated.inShoppingList });
       }
     },
     [setGlobalIngredients, setIngredients]

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -79,7 +79,10 @@ export default function AllIngredientsScreen() {
         return updateIngredientById(prev, updated);
       });
       if (updated) {
-        updateIngredientFields(updated.id, { inBar: updated.inBar });
+        setTimeout(
+          () => updateIngredientFields(updated.id, { inBar: updated.inBar }),
+          0
+        );
       }
     },
     [setIngredients]

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -11,10 +11,7 @@ import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import {
-  flushPendingIngredients,
-  updateIngredientById,
-} from "../../storage/ingredientsStorage";
+import { updateIngredientById, updateIngredientFields } from "../../storage/ingredientsStorage";
 import { getAllTags } from "../../storage/ingredientTagsStorage";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -35,7 +32,6 @@ export default function AllIngredientsScreen() {
   const [navigatingId, setNavigatingId] = useState(null);
   const [selectedTagIds, setSelectedTagIds] = useState([]);
   const [availableTags, setAvailableTags] = useState([]);
-  const [pendingUpdates, setPendingUpdates] = useState([]);
 
   useEffect(() => {
     if (isFocused) setTab("ingredients", "All");
@@ -60,33 +56,6 @@ export default function AllIngredientsScreen() {
     return () => clearTimeout(h);
   }, [search]);
 
-  const flushPending = useCallback(() => {
-    if (pendingUpdates.length) {
-      flushPendingIngredients(pendingUpdates).catch(() => {});
-      setPendingUpdates([]);
-    }
-  }, [pendingUpdates]);
-
-  useEffect(() => {
-    if (!pendingUpdates.length) return;
-    const handle = setTimeout(() => {
-      flushPending();
-    }, 300);
-    return () => clearTimeout(handle);
-  }, [pendingUpdates, flushPending]);
-
-  useEffect(() => {
-    if (!isFocused) {
-      flushPending();
-    }
-  }, [isFocused, flushPending]);
-
-  useEffect(() => {
-    return () => {
-      flushPending();
-    };
-  }, [flushPending]);
-
   const filtered = useMemo(() => {
     const q = normalizeSearch(searchDebounced);
     let data = ingredients;
@@ -109,7 +78,9 @@ export default function AllIngredientsScreen() {
         updated = { ...item, inBar: !item.inBar };
         return updateIngredientById(prev, updated);
       });
-      if (updated) setPendingUpdates((p) => [...p, updated]);
+      if (updated) {
+        updateIngredientFields(updated.id, { inBar: updated.inBar });
+      }
     },
     [setIngredients]
   );

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -388,14 +388,10 @@ export default function IngredientDetailsScreen() {
     if (!ingredient) return;
     const updated = { ...ingredient, inBar: !ingredient.inBar };
     setIngredient(updated);
-    setIngredients((list) => {
-      const nextList = updateIngredientById(list, {
-        id: updated.id,
-        inBar: updated.inBar,
-      });
-      updateIngredientFields(updated.id, { inBar: updated.inBar });
-      return nextList;
-    });
+    setIngredients((list) =>
+      updateIngredientById(list, { id: updated.id, inBar: updated.inBar })
+    );
+    updateIngredientFields(updated.id, { inBar: updated.inBar });
   }, [ingredient, setIngredients]);
 
   const toggleInShoppingList = useCallback(() => {

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -391,7 +391,10 @@ export default function IngredientDetailsScreen() {
     setIngredients((list) =>
       updateIngredientById(list, { id: updated.id, inBar: updated.inBar })
     );
-    updateIngredientFields(updated.id, { inBar: updated.inBar });
+    setTimeout(
+      () => updateIngredientFields(updated.id, { inBar: updated.inBar }),
+      0
+    );
   }, [ingredient, setIngredients]);
 
   const toggleInShoppingList = useCallback(() => {
@@ -401,16 +404,17 @@ export default function IngredientDetailsScreen() {
       inShoppingList: !ingredient.inShoppingList,
     };
     setIngredient(updated);
-    setIngredients((list) => {
-      const nextList = updateIngredientById(list, {
+    setIngredients((list) =>
+      updateIngredientById(list, {
         id: updated.id,
         inShoppingList: updated.inShoppingList,
-      });
+      })
+    );
+    setTimeout(() => {
       updateIngredientFields(updated.id, {
         inShoppingList: updated.inShoppingList,
       });
-      return nextList;
-    });
+    }, 0);
   }, [ingredient, setIngredients]);
 
   const unlinkIngredients = useCallback(

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -221,7 +221,6 @@ export default function IngredientDetailsScreen() {
   const [usedCocktails, setUsedCocktails] = useState(initialUsed);
   const [unlinkBaseVisible, setUnlinkBaseVisible] = useState(false);
   const [unlinkChildTarget, setUnlinkChildTarget] = useState(null);
-  const [dummyChecked, setDummyChecked] = useState(false);
 
   useEffect(() => {
     const current =
@@ -385,9 +384,20 @@ export default function IngredientDetailsScreen() {
     return () => sub.remove();
   }, [load]);
 
-  const toggleDummyChecked = useCallback(() => {
-    setDummyChecked((prev) => !prev);
-  }, []);
+  const toggleInBar = useCallback(() => {
+    if (!ingredient) return;
+    const updated = { ...ingredient, inBar: !ingredient.inBar };
+    setIngredient(updated);
+    setIngredients((list) =>
+      updateIngredientById(list, {
+        id: updated.id,
+        inBar: updated.inBar,
+      })
+    );
+    setTimeout(() => {
+      updateIngredientFields(updated.id, { inBar: updated.inBar });
+    }, 0);
+  }, [ingredient, setIngredients]);
 
   const toggleInShoppingList = useCallback(() => {
     if (!ingredient) return;
@@ -538,22 +548,19 @@ export default function IngredientDetailsScreen() {
       )}
 
       <View style={styles.iconRow}>
-        <TouchableOpacity onPress={toggleDummyChecked} style={styles.iconButton}>
+        <TouchableOpacity onPress={toggleInBar} style={styles.iconButton}>
           <MaterialIcons
-            name={dummyChecked ? "check-circle" : "radio-button-unchecked"}
+            name={ingredient.inBar ? "check-circle" : "radio-button-unchecked"}
             size={24}
             color={
-              dummyChecked
+              ingredient.inBar
                 ? theme.colors.primary
                 : theme.colors.onSurfaceVariant
             }
           />
         </TouchableOpacity>
 
-        <TouchableOpacity
-          onPress={toggleInShoppingList}
-          style={styles.iconButton}
-        >
+        <TouchableOpacity onPress={toggleInShoppingList} style={styles.iconButton}>
           <MaterialIcons
             name={
               ingredient.inShoppingList ? "shopping-cart" : "add-shopping-cart"

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -221,6 +221,7 @@ export default function IngredientDetailsScreen() {
   const [usedCocktails, setUsedCocktails] = useState(initialUsed);
   const [unlinkBaseVisible, setUnlinkBaseVisible] = useState(false);
   const [unlinkChildTarget, setUnlinkChildTarget] = useState(null);
+  const [dummyChecked, setDummyChecked] = useState(false);
 
   useEffect(() => {
     const current =
@@ -384,6 +385,10 @@ export default function IngredientDetailsScreen() {
     return () => sub.remove();
   }, [load]);
 
+  const toggleDummyChecked = useCallback(() => {
+    setDummyChecked((prev) => !prev);
+  }, []);
+
   const toggleInBar = useCallback(() => {
     if (!ingredient) return;
     const updated = { ...ingredient, inBar: !ingredient.inBar };
@@ -546,6 +551,18 @@ export default function IngredientDetailsScreen() {
       )}
 
       <View style={styles.iconRow}>
+        <TouchableOpacity onPress={toggleDummyChecked} style={styles.iconButton}>
+          <MaterialIcons
+            name={dummyChecked ? "check-circle" : "radio-button-unchecked"}
+            size={24}
+            color={
+              dummyChecked
+                ? theme.colors.primary
+                : theme.colors.onSurfaceVariant
+            }
+          />
+        </TouchableOpacity>
+
         <TouchableOpacity
           onPress={toggleInShoppingList}
           style={styles.iconButton}

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -389,19 +389,6 @@ export default function IngredientDetailsScreen() {
     setDummyChecked((prev) => !prev);
   }, []);
 
-  const toggleInBar = useCallback(() => {
-    if (!ingredient) return;
-    const updated = { ...ingredient, inBar: !ingredient.inBar };
-    setIngredient(updated);
-    setIngredients((list) =>
-      updateIngredientById(list, { id: updated.id, inBar: updated.inBar })
-    );
-    setTimeout(
-      () => updateIngredientFields(updated.id, { inBar: updated.inBar }),
-      0
-    );
-  }, [ingredient, setIngredients]);
-
   const toggleInShoppingList = useCallback(() => {
     if (!ingredient) return;
     const updated = {
@@ -574,18 +561,6 @@ export default function IngredientDetailsScreen() {
             size={24}
             color={
               ingredient.inShoppingList
-                ? theme.colors.primary
-                : theme.colors.onSurfaceVariant
-            }
-          />
-        </TouchableOpacity>
-
-        <TouchableOpacity onPress={toggleInBar} style={styles.iconButton}>
-          <MaterialIcons
-            name={ingredient.inBar ? "check-circle" : "radio-button-unchecked"}
-            size={24}
-            color={
-              ingredient.inBar
                 ? theme.colors.primary
                 : theme.colors.onSurfaceVariant
             }

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -127,8 +127,8 @@ export default function MyIngredientsScreen() {
         return next;
       });
       if (updated && next) {
-        updateIngredientFields(updated.id, { inBar: updated.inBar });
         setTimeout(() => {
+          updateIngredientFields(updated.id, { inBar: updated.inBar });
           const nextArr = Array.from(next.values());
           const map = updateIngredientAvailability(updated.id, nextArr);
           setAvailableMap(new Map(map));

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -118,18 +118,21 @@ export default function MyIngredientsScreen() {
   const toggleInBar = useCallback(
     (id) => {
       let updated;
+      let next;
       setIngredients((prev) => {
         const item = prev.get(id);
         if (!item) return prev;
         updated = { ...item, inBar: !item.inBar };
-        const next = updateIngredientById(prev, updated);
-        const nextArr = Array.from(next.values());
-        const map = updateIngredientAvailability(id, nextArr);
-        setAvailableMap(new Map(map));
+        next = updateIngredientById(prev, updated);
         return next;
       });
-      if (updated) {
+      if (updated && next) {
         updateIngredientFields(updated.id, { inBar: updated.inBar });
+        setTimeout(() => {
+          const nextArr = Array.from(next.values());
+          const map = updateIngredientAvailability(updated.id, nextArr);
+          setAvailableMap(new Map(map));
+        }, 0);
       }
     },
     [setIngredients]

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -79,7 +79,7 @@ export default function ShoppingIngredientsScreen() {
         return updateIngredientById(prev, updated);
       });
       if (updated) {
-        updateIngredientFields(id, { inShoppingList: false });
+        setTimeout(() => updateIngredientFields(id, { inShoppingList: false }), 0);
       }
     },
     [setIngredients]


### PR DESCRIPTION
## Summary
- save ingredient availability immediately when toggled
- remove pending update queue and flushing logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68addaee533c83268a3187447bb16aaa