### PR TITLE
feat: initialize SQLite asynchronously

### DIFF
--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -1,67 +1,68 @@
 import * as SQLite from "expo-sqlite";
 
 // Initialize and export a shared SQLite instance for the app.
-const db = SQLite.openDatabaseSync("yourbar.db");
-
+let db;
 let initPromise;
 
 export function initDatabase() {
   if (!initPromise) {
-    initPromise = db.execAsync(`
-      PRAGMA foreign_keys = ON;
-      CREATE TABLE IF NOT EXISTS cocktails (
-        id INTEGER PRIMARY KEY NOT NULL,
-        name TEXT,
-        photoUri TEXT,
-        glassId TEXT,
-        rating INTEGER,
-        tags TEXT,
-        description TEXT,
-        instructions TEXT,
-        createdAt INTEGER,
-        updatedAt INTEGER
-      );
-      CREATE TABLE IF NOT EXISTS cocktail_ingredients (
-        cocktailId INTEGER NOT NULL,
-        orderNum INTEGER,
-        ingredientId TEXT,
-        name TEXT,
-        amount TEXT,
-        unitId INTEGER,
-        garnish INTEGER,
-        optional INTEGER,
-        allowBaseSubstitution INTEGER,
-        allowBrandedSubstitutes INTEGER,
-        substitutes TEXT,
-        PRIMARY KEY (cocktailId, orderNum),
-        FOREIGN KEY (cocktailId) REFERENCES cocktails(id) ON DELETE CASCADE
-      );
-      CREATE TABLE IF NOT EXISTS ingredients (
-        id TEXT PRIMARY KEY NOT NULL,
-        name TEXT,
-        description TEXT,
-        tags TEXT,
-        baseIngredientId TEXT,
-        usageCount INTEGER,
-        singleCocktailName TEXT,
-        searchName TEXT,
-        searchTokens TEXT,
-        photoUri TEXT,
-        inBar INTEGER,
-        inShoppingList INTEGER
-      );
-      CREATE INDEX IF NOT EXISTS idx_cocktails_name ON cocktails (name);
-      CREATE INDEX IF NOT EXISTS idx_cocktail_ingredients_ingredientId ON cocktail_ingredients (ingredientId);
-      CREATE INDEX IF NOT EXISTS idx_ingredients_searchName ON ingredients (searchName);
-      CREATE INDEX IF NOT EXISTS idx_ingredients_inBar ON ingredients (inBar);
-    `);
+    initPromise = SQLite.openDatabaseAsync("yourbar.db").then(async (database) => {
+      db = database;
+      await db.execAsync(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE IF NOT EXISTS cocktails (
+          id INTEGER PRIMARY KEY NOT NULL,
+          name TEXT,
+          photoUri TEXT,
+          glassId TEXT,
+          rating INTEGER,
+          tags TEXT,
+          description TEXT,
+          instructions TEXT,
+          createdAt INTEGER,
+          updatedAt INTEGER
+        );
+        CREATE TABLE IF NOT EXISTS cocktail_ingredients (
+          cocktailId INTEGER NOT NULL,
+          orderNum INTEGER,
+          ingredientId TEXT,
+          name TEXT,
+          amount TEXT,
+          unitId INTEGER,
+          garnish INTEGER,
+          optional INTEGER,
+          allowBaseSubstitution INTEGER,
+          allowBrandedSubstitutes INTEGER,
+          substitutes TEXT,
+          PRIMARY KEY (cocktailId, orderNum),
+          FOREIGN KEY (cocktailId) REFERENCES cocktails(id) ON DELETE CASCADE
+        );
+        CREATE TABLE IF NOT EXISTS ingredients (
+          id TEXT PRIMARY KEY NOT NULL,
+          name TEXT,
+          description TEXT,
+          tags TEXT,
+          baseIngredientId TEXT,
+          usageCount INTEGER,
+          singleCocktailName TEXT,
+          searchName TEXT,
+          searchTokens TEXT,
+          photoUri TEXT,
+          inBar INTEGER,
+          inShoppingList INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_cocktails_name ON cocktails (name);
+        CREATE INDEX IF NOT EXISTS idx_cocktail_ingredients_ingredientId ON cocktail_ingredients (ingredientId);
+        CREATE INDEX IF NOT EXISTS idx_ingredients_searchName ON ingredients (searchName);
+        CREATE INDEX IF NOT EXISTS idx_ingredients_inBar ON ingredients (inBar);
+      `);
+    });
   }
   return initPromise;
 }
 
 export async function query(sql, params = []) {
-  // assume initDatabase() has been invoked at app startup
-  await initPromise;
+  await initDatabase();
   const trimmed = sql.trim().toLowerCase();
   if (trimmed.startsWith("select")) {
     const rows = await db.getAllAsync(sql, params);
@@ -76,5 +77,5 @@ export async function query(sql, params = []) {
   return db.runAsync(sql, params);
 }
 
-export default db;
+export { db as default };
 


### PR DESCRIPTION
## Summary
- replace synchronous SQLite opening with async `openDatabaseAsync`
- ensure `query` initializes the database before executing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae2e84291c8326a287bc6868ec096e