### PR TITLE
Display branded ingredient substitutes on cocktail detail

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -447,6 +447,7 @@ export default function CocktailDetailsScreen() {
       let baseSubstitutes = [];
       let brandedSubstitutes = [];
       const baseId = ing?.baseIngredientId ?? ing?.id;
+      const isBaseIngredient = ing?.baseIngredientId == null;
       if (ing) {
         if (Array.isArray(r.substitutes)) {
           declaredSubstitutes = r.substitutes.map((s) => {
@@ -458,7 +459,7 @@ export default function CocktailDetailsScreen() {
           const base = byId.get(baseId);
           if (base && base.id !== ing.id) baseSubstitutes.push(base.name);
         }
-        if (r.allowBrandedSubstitutes) {
+        if (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient) {
           const others = (byBase.get(baseId) || []).filter(
             (i) => i.id !== ing.id && i.baseIngredientId === baseId
           );
@@ -471,7 +472,10 @@ export default function CocktailDetailsScreen() {
           if (base?.inBar && base.id !== ing.id) substitute = base;
         }
 
-        if (!substitute && r.allowBrandedSubstitutes) {
+        if (
+          !substitute &&
+          (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient)
+        ) {
           const brand = (byBase.get(baseId) || []).find(
             (i) =>
               i.inBar &&


### PR DESCRIPTION
## Summary
- Prefer branded substitutes when base ingredient is missing on cocktail detail screen
- Include branded substitutes in the list even without explicit allowance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afa491e76c8326ac0ceebbd051c16c