### PR TITLE
fix: keep unit toggle stable on cocktail screen

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -4,6 +4,7 @@ import React, {
   useLayoutEffect,
   useState,
   useMemo,
+  useRef,
   memo,
 } from "react";
 import {
@@ -205,6 +206,7 @@ export default function CocktailDetailsScreen() {
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
   const [keepAwake, setKeepAwake] = useState(false);
   const [allowSubstitutes, setAllowSubstitutes] = useState(false);
+  const showImperialLocked = useRef(false);
 
   const { ingMap, byBase } = useMemo(
     () => buildIngredientIndex(ingredients),
@@ -360,7 +362,7 @@ export default function CocktailDetailsScreen() {
         }
       }
       setIngredients(allIngredients);
-      setShowImperial(!useMetric);
+      if (!showImperialLocked.current) setShowImperial(!useMetric);
       setIgnoreGarnish(!!ig);
       setAllowSubstitutes(!!allowSubs);
       if (showSpinner) setLoading(false);
@@ -528,7 +530,10 @@ export default function CocktailDetailsScreen() {
       {ratingStars}
 
       <TouchableOpacity
-        onPress={() => setShowImperial((v) => !v)}
+        onPress={() => {
+          showImperialLocked.current = true;
+          setShowImperial((v) => !v);
+        }}
         style={[styles.toggleBtn, { borderColor: theme.colors.primary }]}
         accessibilityRole="button"
         accessibilityLabel={


### PR DESCRIPTION
## Summary
- ensure unit toggle doesn't get reset by reloads on cocktail details

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0581d3a5c8326b1950bbd8a7a4730