### PR TITLE
Preload tab screens for smoother cocktail navigation

### DIFF
--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -31,9 +31,11 @@ function CocktailTabs({ route }) {
     <>
       <Tab.Navigator
         initialRouteName={initial}
+        lazyPreloadDistance={1}
         screenOptions={({ route }) => {
           const options = {
             headerShown: false,
+            lazy: false,
             tabBarIcon: ({ color, size }) => {
               let iconName;
               if (route.name === "All") iconName = "list";


### PR DESCRIPTION
## Summary
- Preload cocktail tab screens and neighboring routes for smoother, ready-to-view transitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06490451c832689c4550ecabdaa27