### PR TITLE
Add animated underline for bottom tab navigation

### DIFF
--- a/src/components/BottomTabBar.js
+++ b/src/components/BottomTabBar.js
@@ -1,0 +1,102 @@
+import React, { useContext } from "react";
+import { View, Pressable, Text, StyleSheet, Dimensions } from "react-native";
+import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "react-native-paper";
+import { TabSwipeContext } from "./TabSwipe";
+
+export default function BottomTabBar({ state, descriptors, navigation }) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const swipe = useContext(TabSwipeContext) || { value: 0 };
+  const tabCount = state.routes.length;
+  const width = Dimensions.get("window").width;
+  const tabWidth = width / tabCount;
+  const index = state.index;
+
+  const underlineStyle = useAnimatedStyle(
+    () => {
+      const offset = Math.max(-tabWidth, Math.min(tabWidth, -swipe.value));
+      return {
+        transform: [{ translateX: tabWidth * index + offset }],
+      };
+    },
+    [index, tabWidth, swipe]
+  );
+
+  const activeColor =
+    descriptors[state.routes[0].key].options.tabBarActiveTintColor ||
+    theme.colors.primary;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          paddingBottom: insets.bottom,
+          backgroundColor: theme.colors.background,
+        },
+      ]}
+    >
+      {state.routes.map((route, idx) => {
+        const { options } = descriptors[route.key];
+        const label =
+          options.tabBarLabel !== undefined
+            ? options.tabBarLabel
+            : options.title !== undefined
+            ? options.title
+            : route.name;
+        const isFocused = index === idx;
+        const color = isFocused
+          ? options.tabBarActiveTintColor || theme.colors.primary
+          : options.tabBarInactiveTintColor || theme.colors.onSurfaceVariant;
+        const icon = options.tabBarIcon
+          ? options.tabBarIcon({ color, size: 24 })
+          : null;
+        return (
+          <Pressable
+            key={route.key}
+            onPress={() => navigation.navigate(route.name)}
+            android_ripple={{ color: theme.colors.surfaceVariant }}
+            style={styles.tab}
+          >
+            {icon}
+            <Text style={[styles.label, { color }]}>{label}</Text>
+          </Pressable>
+        );
+      })}
+      <Animated.View
+        style={[
+          styles.underline,
+          { width: tabWidth, backgroundColor: activeColor },
+          underlineStyle,
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    borderTopWidth: 0,
+    elevation: 4,
+  },
+  tab: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 6,
+  },
+  label: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  underline: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    height: 3,
+  },
+});
+

--- a/src/screens/Cocktails/AllCocktailsScreen.js
+++ b/src/screens/Cocktails/AllCocktailsScreen.js
@@ -27,7 +27,6 @@ import { getAllCocktailTags } from "../../storage/cocktailTagsStorage";
 import CocktailRow, {
   COCKTAIL_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/CocktailRow";
-import TabSwipe from "../../components/TabSwipe";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import {
@@ -184,8 +183,7 @@ export default function AllCocktailsScreen() {
     );
 
   return (
-    <TabSwipe navigation={navigation}>
-      <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
       <HeaderWithSearch
         searchValue={search}
         setSearchValue={setSearch}
@@ -218,8 +216,7 @@ export default function AllCocktailsScreen() {
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,
         }}
       />
-      </View>
-    </TabSwipe>
+    </View>
   );
 }
 

--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -6,6 +6,8 @@ import { useTheme, FAB } from "react-native-paper";
 import { StyleSheet } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 import PlainHeader from "../../components/PlainHeader";
+import BottomTabBar from "../../components/BottomTabBar";
+import TabSwipe from "../../components/TabSwipe";
 
 // TopTabBar is rendered within each screen
 
@@ -28,50 +30,47 @@ function CocktailTabs({ route }) {
   const tabsOnTop = useTabsOnTop();
   const initial = route?.params?.screen || "All";
   return (
-    <>
-      <Tab.Navigator
-        initialRouteName={initial}
-        screenOptions={({ route }) => {
-          const options = {
-            headerShown: false,
-            tabBarIcon: ({ color, size }) => {
-              let iconName;
-              if (route.name === "All") iconName = "list";
-              else if (route.name === "My") iconName = "check-circle";
-              else if (route.name === "Favorites") iconName = "star";
-              return <MaterialIcons name={iconName} size={size} color={color} />;
-            },
-            tabBarActiveTintColor: theme.colors.primary,
-            tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
-          };
-          if (!tabsOnTop) {
-            options.tabBarStyle = {
-              backgroundColor: theme.colors.background,
-              borderTopWidth: 0,
-              borderTopColor: theme.colors.background,
+    <TabSwipe navigation={navigation}>
+      <>
+        <Tab.Navigator
+          initialRouteName={initial}
+          screenOptions={({ route }) => {
+            const options = {
+              headerShown: false,
+              tabBarIcon: ({ color, size }) => {
+                let iconName;
+                if (route.name === "All") iconName = "list";
+                else if (route.name === "My") iconName = "check-circle";
+                else if (route.name === "Favorites") iconName = "star";
+                return <MaterialIcons name={iconName} size={size} color={color} />;
+              },
+              tabBarActiveTintColor: theme.colors.primary,
+              tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
             };
+            return options;
+          }}
+          tabBar={
+            tabsOnTop ? () => null : (props) => <BottomTabBar {...props} />
           }
-          return options;
-        }}
-        tabBar={tabsOnTop ? () => null : undefined}
-      >
-        <Tab.Screen name="All" component={AllCocktailsScreen} />
-        <Tab.Screen name="My" component={MyCocktailsScreen} />
-        <Tab.Screen name="Favorites" component={FavoriteCocktailsScreen} />
-      </Tab.Navigator>
-      <FAB
-        icon="plus"
-        style={[
-          styles.fab,
-          {
-            backgroundColor: theme.colors.primaryContainer,
-            bottom: tabsOnTop ? 16 : 80,
-          },
-        ]}
-        color={theme.colors.primary}
-        onPress={() => navigation.navigate("AddCocktail")}
-      />
-    </>
+        >
+          <Tab.Screen name="All" component={AllCocktailsScreen} />
+          <Tab.Screen name="My" component={MyCocktailsScreen} />
+          <Tab.Screen name="Favorites" component={FavoriteCocktailsScreen} />
+        </Tab.Navigator>
+        <FAB
+          icon="plus"
+          style={[
+            styles.fab,
+            {
+              backgroundColor: theme.colors.primaryContainer,
+              bottom: tabsOnTop ? 16 : 80,
+            },
+          ]}
+          color={theme.colors.primary}
+          onPress={() => navigation.navigate("AddCocktail")}
+        />
+      </>
+    </TabSwipe>
   );
 }
 

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.js
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.js
@@ -31,7 +31,6 @@ import { getAllCocktailTags } from "../../storage/cocktailTagsStorage";
 import CocktailRow, {
   COCKTAIL_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/CocktailRow";
-import TabSwipe from "../../components/TabSwipe";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { sortByName } from "../../utils/sortByName";
 import {
@@ -204,8 +203,7 @@ export default function FavoriteCocktailsScreen() {
     );
 
   return (
-    <TabSwipe navigation={navigation}>
-      <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
       <HeaderWithSearch
         searchValue={search}
         setSearchValue={setSearch}
@@ -243,8 +241,7 @@ export default function FavoriteCocktailsScreen() {
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,
         }}
       />
-      </View>
-    </TabSwipe>
+    </View>
   );
 }
 

--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -30,7 +30,6 @@ import TagFilterMenu from "../../components/TagFilterMenu";
 import { getAllCocktailTags } from "../../storage/cocktailTagsStorage";
 import CocktailRow, { COCKTAIL_ROW_HEIGHT } from "../../components/CocktailRow";
 import IngredientRow, { INGREDIENT_ROW_HEIGHT } from "../../components/IngredientRow";
-import TabSwipe from "../../components/TabSwipe";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import { normalizeSearch } from "../../utils/normalizeSearch";
@@ -344,8 +343,7 @@ export default function MyCocktailsScreen() {
     );
 
   return (
-    <TabSwipe navigation={navigation}>
-      <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
       <HeaderWithSearch
         searchValue={search}
         setSearchValue={setSearch}
@@ -384,8 +382,7 @@ export default function MyCocktailsScreen() {
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,
         }}
       />
-      </View>
-    </TabSwipe>
+    </View>
   );
 }
 

--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -10,7 +10,6 @@ import TagFilterMenu from "../../components/TagFilterMenu";
 import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
-import TabSwipe from "../../components/TabSwipe";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import {
   flushPendingIngredients,
@@ -165,8 +164,7 @@ export default function AllIngredientsScreen() {
   }
 
   return (
-    <TabSwipe navigation={navigation}>
-      <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
       <HeaderWithSearch
         searchValue={search}
         setSearchValue={setSearch}
@@ -199,8 +197,7 @@ export default function AllIngredientsScreen() {
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,
         }}
       />
-      </View>
-    </TabSwipe>
+    </View>
   );
 }
 

--- a/src/screens/Ingredients/IngredientsTabsScreen.js
+++ b/src/screens/Ingredients/IngredientsTabsScreen.js
@@ -6,6 +6,8 @@ import { useTheme, FAB } from "react-native-paper";
 import { StyleSheet } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 import PlainHeader from "../../components/PlainHeader";
+import BottomTabBar from "../../components/BottomTabBar";
+import TabSwipe from "../../components/TabSwipe";
 
 // TopTabBar is rendered within each screen
 
@@ -28,50 +30,47 @@ function IngredientTabs({ route }) {
   const tabsOnTop = useTabsOnTop();
   const initial = route?.params?.screen || "All";
   return (
-    <>
-      <Tab.Navigator
-        initialRouteName={initial}
-        screenOptions={({ route }) => {
-          const options = {
-            headerShown: false,
-            tabBarIcon: ({ color, size }) => {
-              let iconName;
-              if (route.name === "All") iconName = "list";
-              else if (route.name === "My") iconName = "check-circle";
-              else if (route.name === "Shopping") iconName = "shopping-cart";
-              return <MaterialIcons name={iconName} size={size} color={color} />;
-            },
-            tabBarActiveTintColor: theme.colors.primary,
-            tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
-          };
-          if (!tabsOnTop) {
-            options.tabBarStyle = {
-              backgroundColor: theme.colors.background,
-              borderTopWidth: 0,
-              borderTopColor: theme.colors.background,
+    <TabSwipe navigation={navigation}>
+      <>
+        <Tab.Navigator
+          initialRouteName={initial}
+          screenOptions={({ route }) => {
+            const options = {
+              headerShown: false,
+              tabBarIcon: ({ color, size }) => {
+                let iconName;
+                if (route.name === "All") iconName = "list";
+                else if (route.name === "My") iconName = "check-circle";
+                else if (route.name === "Shopping") iconName = "shopping-cart";
+                return <MaterialIcons name={iconName} size={size} color={color} />;
+              },
+              tabBarActiveTintColor: theme.colors.primary,
+              tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
             };
+            return options;
+          }}
+          tabBar={
+            tabsOnTop ? () => null : (props) => <BottomTabBar {...props} />
           }
-          return options;
-        }}
-        tabBar={tabsOnTop ? () => null : undefined}
-      >
-        <Tab.Screen name="All" component={AllIngredientsScreen} />
-        <Tab.Screen name="My" component={MyIngredientsScreen} />
-        <Tab.Screen name="Shopping" component={ShoppingIngredientsScreen} />
-      </Tab.Navigator>
-      <FAB
-        icon="plus"
-        style={[
-          styles.fab,
-          {
-            backgroundColor: theme.colors.primaryContainer,
-            bottom: tabsOnTop ? 16 : 80,
-          },
-        ]}
-        color={theme.colors.primary}
-        onPress={() => navigation.navigate("AddIngredient")}
-      />
-    </>
+        >
+          <Tab.Screen name="All" component={AllIngredientsScreen} />
+          <Tab.Screen name="My" component={MyIngredientsScreen} />
+          <Tab.Screen name="Shopping" component={ShoppingIngredientsScreen} />
+        </Tab.Navigator>
+        <FAB
+          icon="plus"
+          style={[
+            styles.fab,
+            {
+              backgroundColor: theme.colors.primaryContainer,
+              bottom: tabsOnTop ? 16 : 80,
+            },
+          ]}
+          color={theme.colors.primary}
+          onPress={() => navigation.navigate("AddIngredient")}
+        />
+      </>
+    </TabSwipe>
   );
 }
 

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -10,7 +10,6 @@ import TagFilterMenu from "../../components/TagFilterMenu";
 import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
-import TabSwipe from "../../components/TabSwipe";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import {
   flushPendingIngredients,
@@ -225,8 +224,7 @@ export default function MyIngredientsScreen() {
   }
 
   return (
-    <TabSwipe navigation={navigation}>
-      <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
       <HeaderWithSearch
         searchValue={search}
         setSearchValue={setSearch}
@@ -259,8 +257,7 @@ export default function MyIngredientsScreen() {
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,
         }}
       />
-      </View>
-    </TabSwipe>
+    </View>
   );
 }
 

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -10,7 +10,6 @@ import TagFilterMenu from "../../components/TagFilterMenu";
 import IngredientRow, {
   INGREDIENT_ROW_HEIGHT as ITEM_HEIGHT,
 } from "../../components/IngredientRow";
-import TabSwipe from "../../components/TabSwipe";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import {
   flushPendingIngredients,
@@ -167,8 +166,7 @@ export default function ShoppingIngredientsScreen() {
   }
 
   return (
-    <TabSwipe navigation={navigation}>
-      <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
       <HeaderWithSearch
         searchValue={search}
         setSearchValue={setSearch}
@@ -201,8 +199,7 @@ export default function ShoppingIngredientsScreen() {
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,
         }}
       />
-      </View>
-    </TabSwipe>
+    </View>
   );
 }
 


### PR DESCRIPTION
## Summary
- add reusable BottomTabBar with sliding indicator
- move TabSwipe to tab navigators and integrate bottom tabs
- remove per-screen TabSwipe wrappers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0672346508326affb5ce359025630