### PR TITLE
Add animated underline for bottom tabs

### DIFF
--- a/src/components/BottomTabBar.js
+++ b/src/components/BottomTabBar.js
@@ -1,0 +1,109 @@
+import React, { useContext } from "react";
+import { View, Pressable, Text, StyleSheet, Dimensions } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "react-native-paper";
+import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import { TabSwipeContext } from "./TabSwipe";
+
+export default function BottomTabBar({ state, descriptors, navigation }) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const swipe = useContext(TabSwipeContext) || { value: 0 };
+  const width = Dimensions.get("window").width;
+  const tabWidth = width / state.routes.length;
+  const index = state.index;
+
+  const underlineStyle = useAnimatedStyle(
+    () => {
+      const offset = Math.max(-tabWidth, Math.min(tabWidth, -swipe.value));
+      return {
+        transform: [{ translateX: tabWidth * index + offset }],
+      };
+    },
+    [index, tabWidth, swipe]
+  );
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: theme.colors.background,
+          borderTopColor: theme.colors.outline,
+          paddingBottom: insets.bottom || 0,
+        },
+      ]}
+    >
+      {state.routes.map((route, idx) => {
+        const { options } = descriptors[route.key];
+        const label =
+          options.tabBarLabel !== undefined
+            ? options.tabBarLabel
+            : options.title !== undefined
+            ? options.title
+            : route.name;
+        const isFocused = index === idx;
+        const color = isFocused
+          ? theme.colors.primary
+          : theme.colors.onSurfaceVariant;
+        const icon = options.tabBarIcon
+          ? options.tabBarIcon({ color, size: 24 })
+          : null;
+
+        const onPress = () => {
+          const event = navigation.emit({
+            type: "tabPress",
+            target: route.key,
+            canPreventDefault: true,
+          });
+          if (!isFocused && !event.defaultPrevented) {
+            navigation.navigate(route.name);
+          }
+        };
+
+        return (
+          <Pressable
+            key={route.key}
+            onPress={onPress}
+            android_ripple={{ color: theme.colors.surfaceVariant }}
+            style={styles.tab}
+          >
+            {icon}
+            <Text style={[styles.label, { color }]}>{label}</Text>
+          </Pressable>
+        );
+      })}
+      <Animated.View
+        style={[
+          styles.underline,
+          { width: tabWidth, backgroundColor: theme.colors.primary },
+          underlineStyle,
+        ]}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    borderTopWidth: 1,
+  },
+  tab: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 6,
+  },
+  label: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  underline: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    height: 3,
+  },
+});
+

--- a/src/components/TabSwipe.js
+++ b/src/components/TabSwipe.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Dimensions } from "react-native";
 import { GestureDetector, Gesture } from "react-native-gesture-handler";
 import Animated, { runOnJS, useSharedValue } from "react-native-reanimated";
@@ -9,7 +9,8 @@ const UNDERLINE_MOVE_THRESHOLD = 20;
 const NAVIGATE_THRESHOLD = 80;
 
 export default function TabSwipe({ navigation, children }) {
-  const swipeOffset = useSharedValue(0);
+  const inherited = useContext(TabSwipeContext);
+  const swipeOffset = inherited || useSharedValue(0);
   const screenWidth = Dimensions.get("window").width;
 
   const getTabNav = React.useCallback(() => {
@@ -59,11 +60,19 @@ export default function TabSwipe({ navigation, children }) {
       swipeOffset.value = 0;
     });
 
+  const content = (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={{ flex: 1 }}>{children}</Animated.View>
+    </GestureDetector>
+  );
+
+  if (inherited) {
+    return content;
+  }
+
   return (
     <TabSwipeContext.Provider value={swipeOffset}>
-      <GestureDetector gesture={pan}>
-        <Animated.View style={{ flex: 1 }}>{children}</Animated.View>
-      </GestureDetector>
+      {content}
     </TabSwipeContext.Provider>
   );
 }

--- a/src/screens/Cocktails/CocktailsTabsScreen.js
+++ b/src/screens/Cocktails/CocktailsTabsScreen.js
@@ -5,7 +5,10 @@ import { useNavigation } from "@react-navigation/native";
 import { useTheme, FAB } from "react-native-paper";
 import { StyleSheet } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
+import { useSharedValue } from "react-native-reanimated";
 import PlainHeader from "../../components/PlainHeader";
+import BottomTabBar from "../../components/BottomTabBar";
+import { TabSwipeContext } from "../../components/TabSwipe";
 
 // TopTabBar is rendered within each screen
 
@@ -27,8 +30,10 @@ function CocktailTabs({ route }) {
   const navigation = useNavigation();
   const tabsOnTop = useTabsOnTop();
   const initial = route?.params?.screen || "All";
+  const swipe = useSharedValue(0);
+
   return (
-    <>
+    <TabSwipeContext.Provider value={swipe}>
       <Tab.Navigator
         initialRouteName={initial}
         screenOptions={({ route }) => {
@@ -44,16 +49,11 @@ function CocktailTabs({ route }) {
             tabBarActiveTintColor: theme.colors.primary,
             tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
           };
-          if (!tabsOnTop) {
-            options.tabBarStyle = {
-              backgroundColor: theme.colors.background,
-              borderTopWidth: 0,
-              borderTopColor: theme.colors.background,
-            };
-          }
           return options;
         }}
-        tabBar={tabsOnTop ? () => null : undefined}
+        tabBar={
+          tabsOnTop ? () => null : (props) => <BottomTabBar {...props} />
+        }
       >
         <Tab.Screen name="All" component={AllCocktailsScreen} />
         <Tab.Screen name="My" component={MyCocktailsScreen} />
@@ -71,7 +71,7 @@ function CocktailTabs({ route }) {
         color={theme.colors.primary}
         onPress={() => navigation.navigate("AddCocktail")}
       />
-    </>
+    </TabSwipeContext.Provider>
   );
 }
 

--- a/src/screens/Ingredients/IngredientsTabsScreen.js
+++ b/src/screens/Ingredients/IngredientsTabsScreen.js
@@ -5,7 +5,10 @@ import { useNavigation } from "@react-navigation/native";
 import { useTheme, FAB } from "react-native-paper";
 import { StyleSheet } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
+import { useSharedValue } from "react-native-reanimated";
 import PlainHeader from "../../components/PlainHeader";
+import BottomTabBar from "../../components/BottomTabBar";
+import { TabSwipeContext } from "../../components/TabSwipe";
 
 // TopTabBar is rendered within each screen
 
@@ -27,8 +30,10 @@ function IngredientTabs({ route }) {
   const navigation = useNavigation();
   const tabsOnTop = useTabsOnTop();
   const initial = route?.params?.screen || "All";
+  const swipe = useSharedValue(0);
+
   return (
-    <>
+    <TabSwipeContext.Provider value={swipe}>
       <Tab.Navigator
         initialRouteName={initial}
         screenOptions={({ route }) => {
@@ -44,16 +49,11 @@ function IngredientTabs({ route }) {
             tabBarActiveTintColor: theme.colors.primary,
             tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
           };
-          if (!tabsOnTop) {
-            options.tabBarStyle = {
-              backgroundColor: theme.colors.background,
-              borderTopWidth: 0,
-              borderTopColor: theme.colors.background,
-            };
-          }
           return options;
         }}
-        tabBar={tabsOnTop ? () => null : undefined}
+        tabBar={
+          tabsOnTop ? () => null : (props) => <BottomTabBar {...props} />
+        }
       >
         <Tab.Screen name="All" component={AllIngredientsScreen} />
         <Tab.Screen name="My" component={MyIngredientsScreen} />
@@ -71,7 +71,7 @@ function IngredientTabs({ route }) {
         color={theme.colors.primary}
         onPress={() => navigation.navigate("AddIngredient")}
       />
-    </>
+    </TabSwipeContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Summary
- add custom BottomTabBar with animated underline for bottom tab navigation
- share swipe gesture state across screens and tab bars
- wire bottom tab bars for cocktails and ingredients to new animated underline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0690b68cc8326a49a50b03c19e9cc