### PR TITLE
feat: allow vertical scrolling alongside horizontal swipes

### DIFF
--- a/src/components/TabSwipe.js
+++ b/src/components/TabSwipe.js
@@ -40,6 +40,9 @@ export default function TabSwipe({ navigation, children }) {
   }, [getTabNav]);
 
   const pan = Gesture.Pan()
+    // Only react to horizontal swipes so vertical lists can scroll
+    .activeOffsetX([-UNDERLINE_MOVE_THRESHOLD, UNDERLINE_MOVE_THRESHOLD])
+    .failOffsetY([-UNDERLINE_MOVE_THRESHOLD, UNDERLINE_MOVE_THRESHOLD])
     .onUpdate((e) => {
       const t = e.translationX;
       if (Math.abs(t) > UNDERLINE_MOVE_THRESHOLD) {


### PR DESCRIPTION
## Summary
- restrict TabSwipe pan gesture to horizontal motion only
- prevent TabSwipe from activating when user scrolls vertically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b06b71f908832696429a6ac85ad97f