### PR TITLE
Ensure cocktail details load explicit substitutes

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -315,7 +315,12 @@ export default function CocktailDetailsScreen() {
       const ingredientIds = Array.from(
         new Set(
           (loadedCocktail?.ingredients || [])
-            .map((r) => r.ingredientId)
+            .flatMap((r) => [
+              r.ingredientId,
+              ...(Array.isArray(r.substitutes)
+                ? r.substitutes.map((s) => s.id)
+                : []),
+            ])
             .filter(Boolean)
         )
       );
@@ -428,7 +433,10 @@ export default function CocktailDetailsScreen() {
     if (!updated) return;
 
     const missingIngredient = (updated.ingredients || []).some(
-      (r) => r.ingredientId && !ingMap.has(r.ingredientId)
+      (r) =>
+        (r.ingredientId && !ingMap.has(r.ingredientId)) ||
+        (Array.isArray(r.substitutes) &&
+          r.substitutes.some((s) => s.id && !ingMap.has(s.id)))
     );
 
     setCocktail((prev) => {


### PR DESCRIPTION
## Summary
- load ingredient IDs for declared substitutes in cocktail details
- reload detail screen when substitute ingredient data is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b07b41b9848326a170c0b6a02b05bc