### PR TITLE
Convert resized ingredient and cocktail photos to JPEG

### DIFF
--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -3,11 +3,14 @@ import * as ImageManipulator from 'expo-image-manipulator';
 export async function resizeImage(uri, maxSize = 150) {
   try {
     const info = await ImageManipulator.manipulateAsync(uri, []);
-    const resizeAction = info.width > info.height ? { resize: { width: maxSize } } : { resize: { height: maxSize } };
+    const resizeAction =
+      info.width > info.height
+        ? { resize: { width: maxSize } }
+        : { resize: { height: maxSize } };
     const result = await ImageManipulator.manipulateAsync(
       uri,
       [resizeAction],
-      { compress: 0.7, format: ImageManipulator.SaveFormat.PNG }
+      { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG }
     );
     return result.uri;
   } catch (e) {


### PR DESCRIPTION
## Summary
- Save resized images as JPEG instead of PNG to ensure added ingredient and cocktail photos are stored in JPG format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0831546d48326aabbeb612cc74772