### PR TITLE
Remove duplicate substitute names in ingredient list

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -145,11 +145,13 @@ const IngredientRow = memo(function IngredientRow({
               .join(" ");
             if (propLine) lines.push(propLine);
             if (substituteFor) lines.push(`Substitute for: ${substituteFor}`);
-            const allSubs = [
-              ...declaredSubstitutes,
-              ...baseSubstitutes,
-              ...brandedSubstitutes,
-            ];
+            const allSubs = Array.from(
+              new Set([
+                ...declaredSubstitutes,
+                ...baseSubstitutes,
+                ...brandedSubstitutes,
+              ])
+            );
             if (!inBar && !substituteFor && allSubs.length > 0) {
               allSubs.forEach((s, i) =>
                 lines.push(i === 0 ? `or ${s}` : s)


### PR DESCRIPTION
## Summary
- avoid duplicate substitute names by deduplicating combined lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b08a898e848326a7a6af2b0d00fba5