### PR TITLE
Initialize database before app start

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,15 @@
 import { registerRootComponent } from 'expo';
-import { initDatabase } from './src/storage/sqlite';
 import App from './App';
+import { initDatabase } from './src/storage/sqlite';
 
-// initialize SQLite tables once at startup
-initDatabase();
-
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App);
+// Ensure SQLite tables exist before launching the app. If initialization
+// fails, log the error but still attempt to start the application so the user
+// can see an error screen instead of a blank launch.
+initDatabase()
+  .catch((e) => console.error('Failed to initialize database', e))
+  .finally(() => {
+    // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+    // It also ensures that whether you load the app in Expo Go or in a native build,
+    // the environment is set up appropriately
+    registerRootComponent(App);
+  });


### PR DESCRIPTION
## Summary
- ensure SQLite tables are set up before launching the app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09b81ff448326adaaf59c391807a2