### PR TITLE
Ensure transparent PNG regions are white in JPEGs

### DIFF
--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -7,9 +7,13 @@ export async function resizeImage(uri, maxSize = 150) {
       info.width > info.height
         ? { resize: { width: maxSize } }
         : { resize: { height: maxSize } };
+    const actions = [
+      { extent: { width: info.width, height: info.height, backgroundColor: '#fff' } },
+      resizeAction,
+    ];
     const result = await ImageManipulator.manipulateAsync(
       uri,
-      [resizeAction],
+      actions,
       { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG }
     );
     return result.uri;


### PR DESCRIPTION
## Summary
- Fill transparent image areas with a white background before converting to JPEG to avoid black artifacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b224c85d1483269d5bf826131190e3