### PR TITLE
Add clone-and-edit option for cocktails

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -209,6 +209,7 @@ export default function AddCocktailScreen() {
     useIngredientUsage();
   const { ingredients: globalIngredients = [], setIngredients } =
     useIngredientsData();
+  const initialCocktail = route.params?.initialCocktail;
   const initialIngredient = route.params?.initialIngredient;
   const fromIngredientFlow = initialIngredient != null;
   const lastCocktailsTab =
@@ -284,9 +285,11 @@ export default function AddCocktailScreen() {
     return custom ? [custom] : [{ id: 11, name: "custom", color: TAG_COLORS[15] }];
   }, []);
 
-  const [name, setName] = useState("");
-  const [photoUri, setPhotoUri] = useState(null);
-  const [tags, setTags] = useState(defaultTags);
+  const [name, setName] = useState(initialCocktail?.name || "");
+  const [photoUri, setPhotoUri] = useState(initialCocktail?.photoUri || null);
+  const [tags, setTags] = useState(
+    initialCocktail?.tags?.length ? initialCocktail.tags : defaultTags
+  );
   const [availableTags, setAvailableTags] = useState(BUILTIN_COCKTAIL_TAGS);
   const [tagsModalVisible, setTagsModalVisible] = useState(false);
   const [tagsModalAutoAdd, setTagsModalAutoAdd] = useState(false);
@@ -311,10 +314,16 @@ export default function AddCocktailScreen() {
     loadAvailableTags();
   }, [loadAvailableTags]);
 
-  const [description, setDescription] = useState("");
-  const [instructions, setInstructions] = useState("");
+  const [description, setDescription] = useState(
+    initialCocktail?.description || ""
+  );
+  const [instructions, setInstructions] = useState(
+    initialCocktail?.instructions || ""
+  );
 
-  const [glassId, setGlassId] = useState("cocktail_glass");
+  const [glassId, setGlassId] = useState(
+    initialCocktail?.glassId || "cocktail_glass"
+  );
 
   const createBaseRow = (ing) => ({
     localId: Date.now(),
@@ -333,7 +342,26 @@ export default function AddCocktailScreen() {
 
   // ingredients list
   const [ings, setIngs] = useState(() =>
-    initialIngredient ? [createBaseRow(initialIngredient)] : [createBaseRow()]
+    initialCocktail?.ingredients?.length
+      ? initialCocktail.ingredients.map((r, idx) => ({
+          localId: Date.now() + idx,
+          name: r.name || "",
+          selectedId: r.ingredientId ?? null,
+          selectedItem: null,
+          quantity: r.amount || r.quantity || "",
+          unitId: r.unitId || UNIT_ID.ML,
+          garnish: !!r.garnish,
+          optional: !!r.optional,
+          allowBaseSubstitute: !!(
+            r.allowBaseSubstitution || r.allowBaseSubstitute
+          ),
+          allowBrandedSubstitutes: !!r.allowBrandedSubstitutes,
+          substitutes: Array.isArray(r.substitutes) ? r.substitutes : [],
+          pendingExactMatch: null,
+        }))
+      : initialIngredient
+      ? [createBaseRow(initialIngredient)]
+      : [createBaseRow()]
   );
 
   const resetKey = route.params?.resetKey;

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -607,6 +607,11 @@ export default function CocktailDetailsScreen() {
                 color={theme.colors.primary}
                 style={styles.cloneIcon}
               />
+              <MaterialIcons
+                name="edit"
+                size={16}
+                color={theme.colors.primary}
+              />
             </View>
           </TouchableOpacity>
         </View>

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -597,9 +597,17 @@ export default function CocktailDetailsScreen() {
             <View style={styles.glassInfo} />
           )}
           <TouchableOpacity onPress={handleClone}>
-            <Text style={[styles.cloneText, { color: theme.colors.primary }]}>
-              Clone and edit
-            </Text>
+            <View style={styles.cloneRow}>
+              <Text style={[styles.cloneText, { color: theme.colors.primary }]}>
+                Clone and edit
+              </Text>
+              <MaterialIcons
+                name="content-copy"
+                size={16}
+                color={theme.colors.primary}
+                style={styles.cloneIcon}
+              />
+            </View>
           </TouchableOpacity>
         </View>
 
@@ -694,6 +702,8 @@ const styles = StyleSheet.create({
   glassImage: { width: 40, height: 40, borderRadius: 8 },
   glassText: { marginLeft: 8, flexShrink: 1 },
   cloneText: { fontSize: 14 },
+  cloneRow: { flexDirection: "row", alignItems: "center" },
+  cloneIcon: { marginLeft: 4 },
   ratingRow: {
     flexDirection: "row",
     justifyContent: "center",

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -281,18 +281,37 @@ export default function CocktailDetailsScreen() {
         </TouchableOpacity>
       ),
       headerRight: () => (
-        <TouchableOpacity
-          onPress={handleEdit}
-          style={styles.headerEditBtn}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-          accessibilityRole="button"
-          accessibilityLabel="Edit"
-        >
-          <MaterialIcons name="edit" size={24} color={theme.colors.onSurface} />
-        </TouchableOpacity>
+        <View style={styles.headerActions}>
+          <TouchableOpacity
+            onPress={handleClone}
+            style={[styles.headerIconBtn, styles.headerCloneBtn]}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityRole="button"
+            accessibilityLabel="Clone and edit"
+          >
+            <MaterialIcons
+              name="content-copy"
+              size={24}
+              color={theme.colors.onSurface}
+            />
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={handleEdit}
+            style={styles.headerIconBtn}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityRole="button"
+            accessibilityLabel="Edit"
+          >
+            <MaterialIcons
+              name="edit"
+              size={24}
+              color={theme.colors.onSurface}
+            />
+          </TouchableOpacity>
+        </View>
       ),
     });
-  }, [navigation, handleGoBack, handleEdit, theme.colors.onSurface]);
+  }, [navigation, handleGoBack, handleClone, handleEdit, theme.colors.onSurface]);
 
   useFocusEffect(
     useCallback(() => {
@@ -596,24 +615,6 @@ export default function CocktailDetailsScreen() {
           ) : (
             <View style={styles.glassInfo} />
           )}
-          <TouchableOpacity onPress={handleClone}>
-            <View style={styles.cloneRow}>
-              <Text style={[styles.cloneText, { color: theme.colors.primary }]}>
-                Clone and edit
-              </Text>
-              <MaterialIcons
-                name="content-copy"
-                size={16}
-                color={theme.colors.primary}
-                style={styles.cloneIcon}
-              />
-              <MaterialIcons
-                name="edit"
-                size={16}
-                color={theme.colors.primary}
-              />
-            </View>
-          </TouchableOpacity>
         </View>
 
         {Array.isArray(cocktail.tags) && cocktail.tags.length > 0 && (
@@ -688,7 +689,9 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   loadingContainer: { flex: 1, justifyContent: "center", alignItems: "center" },
   headerBackBtn: { paddingHorizontal: 8, paddingVertical: 4 },
-  headerEditBtn: { paddingHorizontal: 8, paddingVertical: 4 },
+  headerIconBtn: { paddingHorizontal: 8, paddingVertical: 4 },
+  headerActions: { flexDirection: "row", alignItems: "center" },
+  headerCloneBtn: { marginRight: 8 },
   photo: { width: 150, height: 150, marginTop: 12, alignSelf: "center" },
   title: {
     fontSize: 22,
@@ -706,9 +709,6 @@ const styles = StyleSheet.create({
   glassInfo: { flexDirection: "row", alignItems: "center", flex: 1 },
   glassImage: { width: 40, height: 40, borderRadius: 8 },
   glassText: { marginLeft: 8, flexShrink: 1 },
-  cloneText: { fontSize: 14 },
-  cloneRow: { flexDirection: "row", alignItems: "center" },
-  cloneIcon: { marginLeft: 4 },
   ratingRow: {
     flexDirection: "row",
     justifyContent: "center",

--- a/src/screens/Cocktails/CocktailDetailsScreen.js
+++ b/src/screens/Cocktails/CocktailDetailsScreen.js
@@ -231,6 +231,11 @@ export default function CocktailDetailsScreen() {
     navigation.navigate("EditCocktail", { id });
   }, [navigation, id]);
 
+  const handleClone = useCallback(() => {
+    if (!cocktail) return;
+    navigation.navigate("AddCocktail", { initialCocktail: cocktail });
+  }, [navigation, cocktail]);
+
   const handleRate = useCallback(
     async (value) => {
       if (!cocktail) return;
@@ -569,25 +574,34 @@ export default function CocktailDetailsScreen() {
       </TouchableOpacity>
 
       <View style={styles.body}>
-        {glass && (
-          <View style={styles.glassRow}>
-            <Image
-              source={glass.image}
-              style={[
-                styles.glassImage,
-                { backgroundColor: theme.colors.surface },
-              ]}
-            />
-            <Text
-              style={[
-                styles.glassText,
-                { color: theme.colors.onSurfaceVariant },
-              ]}
-            >
-              {glass.name}
+        <View style={styles.glassRow}>
+          {glass ? (
+            <View style={styles.glassInfo}>
+              <Image
+                source={glass.image}
+                style={[
+                  styles.glassImage,
+                  { backgroundColor: theme.colors.surface },
+                ]}
+              />
+              <Text
+                style={[
+                  styles.glassText,
+                  { color: theme.colors.onSurfaceVariant },
+                ]}
+              >
+                {glass.name}
+              </Text>
+            </View>
+          ) : (
+            <View style={styles.glassInfo} />
+          )}
+          <TouchableOpacity onPress={handleClone}>
+            <Text style={[styles.cloneText, { color: theme.colors.primary }]}>
+              Clone and edit
             </Text>
-          </View>
-        )}
+          </TouchableOpacity>
+        </View>
 
         {Array.isArray(cocktail.tags) && cocktail.tags.length > 0 && (
           <View style={styles.section}>
@@ -670,9 +684,16 @@ const styles = StyleSheet.create({
     marginHorizontal: 24,
   },
   body: { paddingHorizontal: 24, marginTop: 0 },
-  glassRow: { flexDirection: "row", alignItems: "center", marginTop: 4 },
+  glassRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginTop: 4,
+  },
+  glassInfo: { flexDirection: "row", alignItems: "center", flex: 1 },
   glassImage: { width: 40, height: 40, borderRadius: 8 },
-  glassText: { marginLeft: 8 },
+  glassText: { marginLeft: 8, flexShrink: 1 },
+  cloneText: { fontSize: 14 },
   ratingRow: {
     flexDirection: "row",
     justifyContent: "center",


### PR DESCRIPTION
## Summary
- add "Clone and edit" button on cocktail details
- prefill add-cocktail form with existing cocktail data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b22ed0043c8326871d3edf08b1e9c6