### PR TITLE
Disable save buttons and show spinner during saves

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -21,6 +21,7 @@ import {
   Dimensions,
   Keyboard,
   BackHandler,
+  ActivityIndicator,
 } from "react-native";
 import Animated, {
   FadeInDown,
@@ -325,6 +326,8 @@ export default function AddCocktailScreen() {
     initialCocktail?.glassId || "cocktail_glass"
   );
 
+  const [saving, setSaving] = useState(false);
+
   const createBaseRow = (ing) => ({
     localId: Date.now(),
     name: ing?.name || "",
@@ -575,6 +578,7 @@ export default function AddCocktailScreen() {
   );
 
   const handleSave = useCallback(async () => {
+    if (saving) return;
     console.log("[AddCocktailScreen] handleSave start");
     const title = name.trim();
     if (!title) {
@@ -586,6 +590,8 @@ export default function AddCocktailScreen() {
       showInfo("Validation", "Please add at least one ingredient.");
       return;
     }
+
+    setSaving(true);
 
     try {
     // Resolve missing selectedId by exact name match (unique)
@@ -700,6 +706,7 @@ export default function AddCocktailScreen() {
     } catch (e) {
       console.error("[AddCocktailScreen] handleSave error", e);
       showInfo("Error", "Failed to save cocktail.");
+      setSaving(false);
     }
   }, [
     name,
@@ -717,6 +724,7 @@ export default function AddCocktailScreen() {
     navigation,
     fromIngredientFlow,
     initialIngredient?.id,
+    saving,
   ]);
 
   const selectedGlass = getGlassById(glassId) || { name: "Cocktail glass" };
@@ -1134,11 +1142,25 @@ export default function AddCocktailScreen() {
           <Pressable
             onPress={handleSave}
             android_ripple={{ color: withAlpha(theme.colors.onPrimary, 0.15) }}
-            style={[styles.saveBtn, { backgroundColor: theme.colors.primary }]}
+            style={[
+              styles.saveBtn,
+              {
+                backgroundColor: theme.colors.primary,
+                opacity: saving ? 0.7 : 1,
+              },
+            ]}
+            disabled={saving}
           >
             <Text style={{ color: theme.colors.onPrimary, fontWeight: "700" }}>
               Save cocktail
             </Text>
+            {saving && (
+              <ActivityIndicator
+                size="small"
+                color={theme.colors.onPrimary}
+                style={{ marginLeft: 8 }}
+              />
+            )}
           </Pressable>
         </ScrollView>
       </View>
@@ -1437,6 +1459,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     borderRadius: 10,
     alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 8,
   },
 
   addInlineBtn: {

--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -22,6 +22,7 @@ import {
   Keyboard,
   BackHandler,
   InteractionManager,
+  ActivityIndicator,
 } from "react-native";
 import Animated, {
   FadeInDown,
@@ -257,6 +258,7 @@ export default function EditCocktailScreen() {
   const [allIngredients, setAllIngredients] = useState(globalIngredients);
   const [dirty, setDirty] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [pendingNav, setPendingNav] = useState(null);
   const initialHashRef = useRef("{}");
   const skipPromptRef = useRef(false);
@@ -279,6 +281,7 @@ export default function EditCocktailScreen() {
 
   const handleSave = useCallback(
     async (stay = false) => {
+      if (saving) return;
       console.log("[EditCocktailScreen] handleSave start", {
         stay,
         cocktailId,
@@ -293,6 +296,8 @@ export default function EditCocktailScreen() {
         showInfo("Validation", "Please add at least one ingredient.");
         return;
       }
+
+      setSaving(true);
 
       // Resolve missing selectedId by exact name match (unique)
       let allKnown = [];
@@ -408,6 +413,7 @@ export default function EditCocktailScreen() {
             nextCocktails
           )
         );
+        if (stay) setSaving(false);
       });
 
       return cocktail;
@@ -429,6 +435,8 @@ export default function EditCocktailScreen() {
       setCocktails,
       setUsageMap,
       setIngredients,
+      saving,
+      showInfo,
     ]
   );
 
@@ -1154,11 +1162,25 @@ export default function EditCocktailScreen() {
           <Pressable
             onPress={() => handleSave()}
             android_ripple={{ color: withAlpha(theme.colors.onPrimary, 0.15) }}
-            style={[styles.saveBtn, { backgroundColor: theme.colors.primary }]}
+            style={[
+              styles.saveBtn,
+              {
+                backgroundColor: theme.colors.primary,
+                opacity: saving ? 0.7 : 1,
+              },
+            ]}
+            disabled={saving}
           >
             <Text style={{ color: theme.colors.onPrimary, fontWeight: "700" }}>
               Save changes
             </Text>
+            {saving && (
+              <ActivityIndicator
+                size="small"
+                color={theme.colors.onPrimary}
+                style={{ marginLeft: 8 }}
+              />
+            )}
           </Pressable>
         </ScrollView>
       </View>
@@ -1535,6 +1557,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     borderRadius: 10,
     alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 8,
   },
 
   addInlineBtn: {

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -16,6 +16,7 @@ import {
   ScrollView,
   FlatList,
   InteractionManager,
+  ActivityIndicator,
   Pressable,
   BackHandler,
   Dimensions,
@@ -90,6 +91,7 @@ export default function AddIngredientScreen() {
     const other = BUILTIN_INGREDIENT_TAGS.find((t) => t.id === 10);
     return other ? [other] : [{ id: 10, name: "other", color: TAG_COLORS[15] }];
   });
+  const [saving, setSaving] = useState(false);
 
   // tag helpers & modal state
   const {
@@ -298,11 +300,13 @@ export default function AddIngredientScreen() {
   }, []);
 
   const handleSave = useCallback(() => {
+    if (saving) return;
     const trimmed = (name || "").trim();
     if (!trimmed) {
       showInfo("Validation", "Please enter a name for the ingredient.");
       return;
     }
+    setSaving(true);
 
     const searchName = normalizeSearch(trimmed);
     const saved = {
@@ -362,6 +366,7 @@ export default function AddIngredientScreen() {
     setGlobalIngredients,
     setUsageMap,
     collator,
+    saving,
   ]);
 
   const openMenu = useCallback(() => {
@@ -656,13 +661,27 @@ export default function AddIngredientScreen() {
         />
 
         <Pressable
-          style={[styles.saveButton, { backgroundColor: theme.colors.primary }]}
+          style={[
+            styles.saveButton,
+            {
+              backgroundColor: theme.colors.primary,
+              opacity: saving ? 0.7 : 1,
+            },
+          ]}
           onPress={handleSave}
+          disabled={saving}
           android_ripple={{ color: withAlpha(theme.colors.onPrimary, 0.15) }}
         >
           <Text style={{ color: theme.colors.onPrimary, fontWeight: "bold" }}>
             Save Ingredient
           </Text>
+          {saving && (
+            <ActivityIndicator
+              size="small"
+              color={theme.colors.onPrimary}
+              style={{ marginLeft: 8 }}
+            />
+          )}
         </Pressable>
       </ScrollView>
     </View>
@@ -737,6 +756,9 @@ const styles = StyleSheet.create({
     marginTop: 24,
     paddingVertical: 12,
     alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 8,
     borderRadius: 8,
   },
 });

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -82,6 +82,7 @@ export default function EditIngredientScreen() {
   const [photoUri, setPhotoUri] = useState(null);
   const [tags, setTags] = useState([]);
   const selectedTagIds = useMemo(() => new Set(tags.map((t) => t.id)), [tags]);
+  const [saving, setSaving] = useState(false);
 
   // reference lists / tags modal
   const {
@@ -355,12 +356,15 @@ export default function EditIngredientScreen() {
 
   const handleSave = useCallback(
     (stay = false) => {
+      if (saving) return;
       const trimmed = name.trim();
       if (!trimmed) {
         showInfo("Validation", "Please enter a name for the ingredient.");
         return;
       }
       if (!ingredient) return;
+
+      setSaving(true);
 
       const updated = {
         ...ingredient,
@@ -414,6 +418,7 @@ export default function EditIngredientScreen() {
           return new Map(arr.map((i) => [i.id, i]));
         });
         saveIngredient(updated).catch(() => {});
+        if (stay) setSaving(false);
       });
 
       return updated;
@@ -432,6 +437,8 @@ export default function EditIngredientScreen() {
       setGlobalIngredients,
       saveIngredient,
       collator,
+      saving,
+      showInfo,
     ]
   );
 
@@ -757,13 +764,27 @@ export default function EditIngredientScreen() {
         />
 
         <Pressable
-          style={[styles.saveButton, { backgroundColor: theme.colors.primary }]}
+          style={[
+            styles.saveButton,
+            {
+              backgroundColor: theme.colors.primary,
+              opacity: saving ? 0.7 : 1,
+            },
+          ]}
           onPress={() => handleSave(false)}
+          disabled={saving}
           android_ripple={{ color: theme.colors.onPrimary }}
         >
           <Text style={{ color: theme.colors.onPrimary, fontWeight: "bold" }}>
             Save Changes
           </Text>
+          {saving && (
+            <ActivityIndicator
+              size="small"
+              color={theme.colors.onPrimary}
+              style={{ marginLeft: 8 }}
+            />
+          )}
         </Pressable>
 
       </ScrollView>
@@ -904,6 +925,9 @@ const styles = StyleSheet.create({
     marginTop: 24,
     paddingVertical: 12,
     alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 8,
     borderRadius: 8,
   },
 });


### PR DESCRIPTION
## Summary
- disable save button on ingredient creation with spinner
- prevent duplicate save taps on ingredient editing
- add saving indicator to cocktail add/edit forms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3658e96448326beb0514c0b151403