### PR TITLE
feat: share keyboard height via hook

### DIFF
--- a/src/components/CocktailIngredientRow.js
+++ b/src/components/CocktailIngredientRow.js
@@ -18,6 +18,7 @@ const { Popover } = renderers;
 
 import TinyDivider from "./TinyDivider";
 import useDebounced from "../hooks/useDebounced";
+import useKeyboardHeight from "../hooks/useKeyboardHeight";
 import { normalizeSearch } from "../utils/normalizeSearch";
 import { WORD_SPLIT_RE, wordPrefixMatch } from "../utils/wordPrefixMatch";
 import { withAlpha } from "../utils/color";
@@ -80,18 +81,8 @@ const CocktailIngredientRow = memo(function CocktailIngredientRow({
     });
   }, []);
 
-  // keyboard height (локальне — для підказок)
-  const [kbHeight, setKbHeight] = useState(0);
-  useEffect(() => {
-    const sh = Keyboard.addListener("keyboardDidShow", (e) =>
-      setKbHeight(e?.endCoordinates?.height || 0)
-    );
-    const hd = Keyboard.addListener("keyboardDidHide", () => setKbHeight(0));
-    return () => {
-      sh.remove();
-      hd.remove();
-    };
-  }, []);
+  // keyboard height from global hook
+  const kbHeight = useKeyboardHeight();
 
   // положення випадаючого списку назв інгредієнтів
   const [suggestState, setSuggestState] = useState({

--- a/src/hooks/useKeyboardHeight.js
+++ b/src/hooks/useKeyboardHeight.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from "react";
+import { Keyboard } from "react-native";
+
+// Module-level state shared across all hook consumers
+let currentHeight = 0;
+const subscribers = new Set();
+
+function notify(height) {
+  currentHeight = height;
+  subscribers.forEach((cb) => cb(height));
+}
+
+// Register keyboard listeners once at module load
+Keyboard.addListener("keyboardDidShow", (e) => {
+  notify(e?.endCoordinates?.height || 0);
+});
+Keyboard.addListener("keyboardDidHide", () => {
+  notify(0);
+});
+
+export default function useKeyboardHeight() {
+  const [height, setHeight] = useState(currentHeight);
+
+  useEffect(() => {
+    subscribers.add(setHeight);
+    // Ensure subscriber gets latest known height immediately
+    setHeight(currentHeight);
+    return () => {
+      subscribers.delete(setHeight);
+    };
+  }, []);
+
+  return height;
+}


### PR DESCRIPTION
## Summary
- add global `useKeyboardHeight` hook storing height for all components
- use shared keyboard height in `CocktailIngredientRow` and remove local listeners

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f64259bc8326b4201cb593fc9d68