### PR TITLE
refactor: use new image manipulator API

### DIFF
--- a/src/utils/images.js
+++ b/src/utils/images.js
@@ -2,20 +2,19 @@ import * as ImageManipulator from 'expo-image-manipulator';
 
 export async function resizeImage(uri, maxSize = 150) {
   try {
-    const info = await ImageManipulator.manipulateAsync(uri, []);
-    const resizeAction =
-      info.width > info.height
-        ? { resize: { width: maxSize } }
-        : { resize: { height: maxSize } };
-    const actions = [
-      { extent: { width: info.width, height: info.height, backgroundColor: '#fff' } },
-      resizeAction,
-    ];
-    const result = await ImageManipulator.manipulateAsync(
-      uri,
-      actions,
-      { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG }
-    );
+    const { width, height } = await ImageManipulator.manipulate(uri).renderAsync();
+    const context = ImageManipulator.manipulate(uri);
+    context.extent({ width, height, backgroundColor: '#fff' });
+    if (width > height) {
+      context.resize({ width: maxSize });
+    } else {
+      context.resize({ height: maxSize });
+    }
+    const rendered = await context.renderAsync();
+    const result = await rendered.saveAsync({
+      compress: 0.7,
+      format: ImageManipulator.SaveFormat.JPEG,
+    });
     return result.uri;
   } catch (e) {
     console.warn('resizeImage failed', e);


### PR DESCRIPTION
## Summary
- migrate image resizing to ImageManipulator.manipulate context
- save resized images via ImageRef.saveAsync with JPEG format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7098553c08326a1523ef664c3167a