### PR TITLE
Add missing photo URIs for cocktails

### DIFF
--- a/assets/data/data.json
+++ b/assets/data/data.json
@@ -27365,7 +27365,7 @@
       ],
       "createdAt": 1757000000150,
       "updatedAt": 1757000000150,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000150-electric-lemonade.jpg"
     },
     {
       "id": 1757000000151,
@@ -27432,7 +27432,7 @@
       ],
       "createdAt": 1757000000151,
       "updatedAt": 1757000000151,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000151-emerson.jpg"
     },
     {
       "id": 1757000000152,
@@ -27487,7 +27487,7 @@
       ],
       "createdAt": 1757000000152,
       "updatedAt": 1757000000152,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000152-end-of-the-road.jpg"
     },
     {
       "id": 1757000000153,
@@ -27583,7 +27583,7 @@
       ],
       "createdAt": 1757000000153,
       "updatedAt": 1757000000153,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000153-final-ward.jpg"
     },
     {
       "id": 1757000000154,
@@ -27655,7 +27655,7 @@
       ],
       "createdAt": 1757000000154,
       "updatedAt": 1757000000154,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000154-fireball.jpg"
     },
     {
       "id": 1757000000155,
@@ -27734,7 +27734,7 @@
       ],
       "createdAt": 1757000000155,
       "updatedAt": 1757000000155,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000155-first-word.jpg"
     },
     {
       "id": 1757000000156,
@@ -27794,7 +27794,7 @@
       ],
       "createdAt": 1757000000156,
       "updatedAt": 1757000000156,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000156-flaming-dr-pepper.jpg"
     },
     {
       "id": 1757000000157,
@@ -27866,7 +27866,7 @@
       ],
       "createdAt": 1757000000157,
       "updatedAt": 1757000000157,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000157-flaming-lamborghini.jpg"
     },
     {
       "id": 1757000000158,
@@ -27979,7 +27979,7 @@
       ],
       "createdAt": 1757000000158,
       "updatedAt": 1757000000158,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000158-flaming-volcano.jpg"
     },
     {
       "id": 1757000000159,
@@ -28039,7 +28039,7 @@
       ],
       "createdAt": 1757000000159,
       "updatedAt": 1757000000159,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000159-flatliner.jpg"
     },
     {
       "id": 1757000000160,
@@ -28118,7 +28118,7 @@
       ],
       "createdAt": 1757000000160,
       "updatedAt": 1757000000160,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000160-fluffy-duck.jpg"
     },
     {
       "id": 1757000000161,
@@ -28190,7 +28190,7 @@
       ],
       "createdAt": 1757000000161,
       "updatedAt": 1757000000161,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000161-fluffy-duck-2.jpg"
     },
     {
       "id": 1757000000162,
@@ -28274,7 +28274,7 @@
       ],
       "createdAt": 1757000000162,
       "updatedAt": 1757000000162,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000162-frozen-daiquiri.jpg"
     },
     {
       "id": 1757000000163,
@@ -28346,7 +28346,7 @@
       ],
       "createdAt": 1757000000163,
       "updatedAt": 1757000000163,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000163-fuzzy-navel.jpg"
     },
     {
       "id": 1757000000164,
@@ -28406,7 +28406,7 @@
       ],
       "createdAt": 1757000000164,
       "updatedAt": 1757000000164,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000164-galliano-hotshot.jpg"
     },
     {
       "id": 1757000000165,
@@ -28473,7 +28473,7 @@
       ],
       "createdAt": 1757000000165,
       "updatedAt": 1757000000165,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000165-gibson.jpg"
     },
     {
       "id": 1757000000166,
@@ -28552,7 +28552,7 @@
       ],
       "createdAt": 1757000000166,
       "updatedAt": 1757000000166,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000166-gimlet.jpg"
     },
     {
       "id": 1757000000167,
@@ -28631,7 +28631,7 @@
       ],
       "createdAt": 1757000000167,
       "updatedAt": 1757000000167,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000167-gin-and-sin.jpg"
     },
     {
       "id": 1757000000168,
@@ -28715,7 +28715,7 @@
       ],
       "createdAt": 1757000000168,
       "updatedAt": 1757000000168,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000168-gin-rickey.jpg"
     },
     {
       "id": 1757000000169,
@@ -28840,7 +28840,7 @@
       ],
       "createdAt": 1757000000169,
       "updatedAt": 1757000000169,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000169-gin-sour.jpg"
     },
     {
       "id": 1757000000170,
@@ -28917,7 +28917,7 @@
       ],
       "createdAt": 1757000000170,
       "updatedAt": 1757000000170,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000170-gladiator.jpg"
     },
     {
       "id": 1757000000171,
@@ -28977,7 +28977,7 @@
       ],
       "createdAt": 1757000000171,
       "updatedAt": 1757000000171,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000171-godfather.jpg"
     },
     {
       "id": 1757000000172,
@@ -29037,7 +29037,7 @@
       ],
       "createdAt": 1757000000172,
       "updatedAt": 1757000000172,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000172-godmother.jpg"
     },
     {
       "id": 1757000000173,
@@ -29116,7 +29116,7 @@
       ],
       "createdAt": 1757000000173,
       "updatedAt": 1757000000173,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000173-gold-rush.jpg"
     },
     {
       "id": 1757000000174,
@@ -29183,7 +29183,7 @@
       ],
       "createdAt": 1757000000174,
       "updatedAt": 1757000000174,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000174-golden-cadillac.jpg"
     },
     {
       "id": 1757000000175,
@@ -29267,7 +29267,7 @@
       ],
       "createdAt": 1757000000175,
       "updatedAt": 1757000000175,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000175-golden-dream.jpg"
     },
     {
       "id": 1757000000176,
@@ -29351,7 +29351,7 @@
       ],
       "createdAt": 1757000000176,
       "updatedAt": 1757000000176,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000176-green-mexican.jpg"
     },
     {
       "id": 1757000000177,
@@ -29411,7 +29411,7 @@
       ],
       "createdAt": 1757000000177,
       "updatedAt": 1757000000177,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000177-green-mexican-shot.jpg"
     },
     {
       "id": 1757000000178,
@@ -29490,7 +29490,7 @@
       ],
       "createdAt": 1757000000178,
       "updatedAt": 1757000000178,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000178-green-vesper.jpg"
     },
     {
       "id": 1757000000179,
@@ -29562,7 +29562,7 @@
       ],
       "createdAt": 1757000000179,
       "updatedAt": 1757000000179,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000179-greyhound.jpg"
     },
     {
       "id": 1757000000180,
@@ -29646,7 +29646,7 @@
       ],
       "createdAt": 1757000000180,
       "updatedAt": 1757000000180,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000180-hairy-navel.jpg"
     },
     {
       "id": 1757000000181,
@@ -29735,7 +29735,7 @@
       ],
       "createdAt": 1757000000181,
       "updatedAt": 1757000000181,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000181-hanky-panky.jpg"
     },
     {
       "id": 1757000000182,
@@ -29841,7 +29841,7 @@
       ],
       "createdAt": 1757000000182,
       "updatedAt": 1757000000182,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000182-harvey-wallbanger.jpg"
     },
     {
       "id": 1757000000183,
@@ -29908,7 +29908,7 @@
       ],
       "createdAt": 1757000000183,
       "updatedAt": 1757000000183,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000183-hazelnut-martini.jpg"
     },
     {
       "id": 1757000000184,
@@ -29987,7 +29987,7 @@
       ],
       "createdAt": 1757000000184,
       "updatedAt": 1757000000184,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000184-hellboy.jpg"
     },
     {
       "id": 1757000000185,
@@ -30052,7 +30052,7 @@
       ],
       "createdAt": 1757000000185,
       "updatedAt": 1757000000185,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000185-highball.jpg"
     },
     {
       "id": 1757000000186,
@@ -30124,7 +30124,7 @@
       ],
       "createdAt": 1757000000186,
       "updatedAt": 1757000000186,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000186-hiroshima.jpg"
     },
     {
       "id": 1757000000187,
@@ -30189,7 +30189,7 @@
       ],
       "createdAt": 1757000000187,
       "updatedAt": 1757000000187,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000187-horny-bull-long.jpg"
     },
     {
       "id": 1757000000188,
@@ -30261,7 +30261,7 @@
       ],
       "createdAt": 1757000000188,
       "updatedAt": 1757000000188,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000188-horny-bull-shot.jpg"
     },
     {
       "id": 1757000000189,
@@ -30376,7 +30376,7 @@
       ],
       "createdAt": 1757000000189,
       "updatedAt": 1757000000189,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000189-hot-buttered-rum.jpg"
     },
     {
       "id": 1757000000190,
@@ -30448,7 +30448,7 @@
       ],
       "createdAt": 1757000000190,
       "updatedAt": 1757000000190,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000190-hot-toddy.jpg"
     },
     {
       "id": 1757000000191,
@@ -30604,7 +30604,7 @@
       ],
       "createdAt": 1757000000191,
       "updatedAt": 1757000000191,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000191-hurricane.jpg"
     },
     {
       "id": 1757000000192,
@@ -30731,7 +30731,7 @@
       ],
       "createdAt": 1757000000192,
       "updatedAt": 1757000000192,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000192-improved-scotch-sling.jpg"
     },
     {
       "id": 1757000000193,
@@ -30786,7 +30786,7 @@
       ],
       "createdAt": 1757000000193,
       "updatedAt": 1757000000193,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000193-incredible-hulk.jpg"
     },
     {
       "id": 1757000000194,
@@ -30846,7 +30846,7 @@
       ],
       "createdAt": 1757000000194,
       "updatedAt": 1757000000194,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000194-innocent-sex.jpg"
     },
     {
       "id": 1757000000195,
@@ -30906,7 +30906,7 @@
       ],
       "createdAt": 1757000000195,
       "updatedAt": 1757000000195,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000195-irish-car-bomb.jpg"
     },
     {
       "id": 1757000000196,
@@ -30966,7 +30966,7 @@
       ],
       "createdAt": 1757000000196,
       "updatedAt": 1757000000196,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000196-irish-flag.jpg"
     },
     {
       "id": 1757000000197,
@@ -31014,7 +31014,7 @@
       ],
       "createdAt": 1757000000197,
       "updatedAt": 1757000000197,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000197-irish-frog.jpg"
     },
     {
       "id": 1757000000198,
@@ -31074,7 +31074,7 @@
       ],
       "createdAt": 1757000000198,
       "updatedAt": 1757000000198,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000198-jack-and-coke.jpg"
     },
     {
       "id": 1757000000199,
@@ -31177,7 +31177,7 @@
       ],
       "createdAt": 1757000000199,
       "updatedAt": 1757000000199,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000199-jack-rose.jpg"
     },
     {
       "id": 1757000000200,
@@ -31232,7 +31232,7 @@
       ],
       "createdAt": 1757000000200,
       "updatedAt": 1757000000200,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000200-jagertee.jpg"
     },
     {
       "id": 1757000000201,
@@ -31316,7 +31316,7 @@
       ],
       "createdAt": 1757000000201,
       "updatedAt": 1757000000201,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000201-japanese-slipper.jpg"
     },
     {
       "id": 1757000000202,
@@ -31376,7 +31376,7 @@
       ],
       "createdAt": 1757000000202,
       "updatedAt": 1757000000202,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000202-jelly-bean.jpg"
     },
     {
       "id": 1757000000203,
@@ -31448,7 +31448,7 @@
       ],
       "createdAt": 1757000000203,
       "updatedAt": 1757000000203,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000203-jellyfish.jpg"
     },
     {
       "id": 1757000000204,
@@ -31520,7 +31520,7 @@
       ],
       "createdAt": 1757000000204,
       "updatedAt": 1757000000204,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000204-jellyfish-2.jpg"
     },
     {
       "id": 1757000000205,
@@ -31592,7 +31592,7 @@
       ],
       "createdAt": 1757000000205,
       "updatedAt": 1757000000205,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000205-jellyfish-3.jpg"
     },
     {
       "id": 1757000000206,
@@ -31664,7 +31664,7 @@
       ],
       "createdAt": 1757000000206,
       "updatedAt": 1757000000206,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000206-jolly-rancher.jpg"
     },
     {
       "id": 1757000000207,
@@ -31712,7 +31712,7 @@
       ],
       "createdAt": 1757000000207,
       "updatedAt": 1757000000207,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000207-jagerbomb.jpg"
     },
     {
       "id": 1757000000208,
@@ -31801,7 +31801,7 @@
       ],
       "createdAt": 1757000000208,
       "updatedAt": 1757000000208,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000208-kamikaze.jpg"
     },
     {
       "id": 1757000000209,
@@ -31933,7 +31933,7 @@
       ],
       "createdAt": 1757000000209,
       "updatedAt": 1757000000209,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000209-ladykiller.jpg"
     },
     {
       "id": 1757000000210,
@@ -32053,7 +32053,7 @@
       ],
       "createdAt": 1757000000210,
       "updatedAt": 1757000000210,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000210-lava-flow.jpg"
     },
     {
       "id": 1757000000211,
@@ -32125,7 +32125,7 @@
       ],
       "createdAt": 1757000000211,
       "updatedAt": 1757000000211,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000211-light-word.jpg"
     },
     {
       "id": 1757000000212,
@@ -32197,7 +32197,7 @@
       ],
       "createdAt": 1757000000212,
       "updatedAt": 1757000000212,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000212-liquid-cocaine.jpg"
     },
     {
       "id": 1757000000213,
@@ -32305,7 +32305,7 @@
       ],
       "createdAt": 1757000000213,
       "updatedAt": 1757000000213,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000213-liquid-marijuana-long.jpg"
     },
     {
       "id": 1757000000214,
@@ -32425,7 +32425,7 @@
       ],
       "createdAt": 1757000000214,
       "updatedAt": 1757000000214,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000214-liquid-marijuana-shot.jpg"
     },
     {
       "id": 1757000000215,
@@ -32528,7 +32528,7 @@
       ],
       "createdAt": 1757000000215,
       "updatedAt": 1757000000215,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000215-london-calling.jpg"
     },
     {
       "id": 1757000000216,
@@ -32660,7 +32660,7 @@
       ],
       "createdAt": 1757000000216,
       "updatedAt": 1757000000216,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000216-long-beach-iced-tea.jpg"
     },
     {
       "id": 1757000000217,
@@ -32739,7 +32739,7 @@
       ],
       "createdAt": 1757000000217,
       "updatedAt": 1757000000217,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000217-love-and-murder.jpg"
     },
     {
       "id": 1757000000218,
@@ -32830,7 +32830,7 @@
       ],
       "createdAt": 1757000000218,
       "updatedAt": 1757000000218,
-      "photoUri": null
+      "photoUri": "assets/cocktails/1757000000218-lucien-gaudin.jpg"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- generate photo URIs for cocktails that lacked them in data.json
- ensure path naming consistent with existing assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b81e6e369c8326beece80045210cbb