### PR TITLE
Serialize ingredient writes to avoid DB lock errors

### DIFF
--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -129,32 +129,25 @@ export async function saveAllIngredients(ingredients) {
   await withExclusiveWriteAsync(async (tx) => {
     console.log("[ingredientsStorage] saveAllIngredients start", list.length);
     await tx.runAsync("DELETE FROM ingredients");
-    const stmt = await tx.prepareAsync(
-      `INSERT OR REPLACE INTO ingredients (
-        id, name, description, tags, baseIngredientId, usageCount,
-        singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    );
-    try {
-      for (const item of list) {
-        await stmt.executeAsync(
-          String(item.id),
-          item.name ?? null,
-          item.description ?? null,
-          item.tags ? JSON.stringify(item.tags) : null,
-          item.baseIngredientId ?? null,
-          item.usageCount ?? 0,
-          item.singleCocktailName ?? null,
-          item.searchName ?? null,
-          item.searchTokens ? JSON.stringify(item.searchTokens) : null,
-          item.photoUri ?? null,
-          item.inBar ? 1 : 0,
-          item.inShoppingList ? 1 : 0
-        );
-        await stmt.resetAsync();
-      }
-    } finally {
-      await stmt.finalizeAsync();
+    for (const item of list) {
+      await tx.runAsync(
+        `INSERT OR REPLACE INTO ingredients (
+          id, name, description, tags, baseIngredientId, usageCount,
+          singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        String(item.id),
+        item.name ?? null,
+        item.description ?? null,
+        item.tags ? JSON.stringify(item.tags) : null,
+        item.baseIngredientId ?? null,
+        item.usageCount ?? 0,
+        item.singleCocktailName ?? null,
+        item.searchName ?? null,
+        item.searchTokens ? JSON.stringify(item.searchTokens) : null,
+        item.photoUri ?? null,
+        item.inBar ? 1 : 0,
+        item.inShoppingList ? 1 : 0
+      );
     }
     console.log("[ingredientsStorage] saveAllIngredients done");
   });
@@ -268,33 +261,26 @@ export async function flushPendingIngredients(list) {
   await initDatabase();
   await withExclusiveWriteAsync(async (tx) => {
     console.log("[ingredientsStorage] flushPendingIngredients start", items.length);
-    const stmt = await tx.prepareAsync(
-      `INSERT OR REPLACE INTO ingredients (
-        id, name, description, tags, baseIngredientId, usageCount,
-        singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    );
-    try {
-      for (const u of items) {
-        const item = sanitizeIngredient(u);
-        await stmt.executeAsync(
-          String(item.id),
-          item.name ?? null,
-          item.description ?? null,
-          item.tags ? JSON.stringify(item.tags) : null,
-          item.baseIngredientId ?? null,
-          item.usageCount ?? 0,
-          item.singleCocktailName ?? null,
-          item.searchName ?? null,
-          item.searchTokens ? JSON.stringify(item.searchTokens) : null,
-          item.photoUri ?? null,
-          item.inBar ? 1 : 0,
-          item.inShoppingList ? 1 : 0
-        );
-        await stmt.resetAsync();
-      }
-    } finally {
-      await stmt.finalizeAsync();
+    for (const u of items) {
+      const item = sanitizeIngredient(u);
+      await tx.runAsync(
+        `INSERT OR REPLACE INTO ingredients (
+          id, name, description, tags, baseIngredientId, usageCount,
+          singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        String(item.id),
+        item.name ?? null,
+        item.description ?? null,
+        item.tags ? JSON.stringify(item.tags) : null,
+        item.baseIngredientId ?? null,
+        item.usageCount ?? 0,
+        item.singleCocktailName ?? null,
+        item.searchName ?? null,
+        item.searchTokens ? JSON.stringify(item.searchTokens) : null,
+        item.photoUri ?? null,
+        item.inBar ? 1 : 0,
+        item.inShoppingList ? 1 : 0
+      );
     }
     console.log("[ingredientsStorage] flushPendingIngredients done");
   });

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -129,25 +129,32 @@ export async function saveAllIngredients(ingredients) {
   await withExclusiveWriteAsync(async (tx) => {
     console.log("[ingredientsStorage] saveAllIngredients start", list.length);
     await tx.runAsync("DELETE FROM ingredients");
-    for (const item of list) {
-      await tx.runAsync(
-        `INSERT OR REPLACE INTO ingredients (
-          id, name, description, tags, baseIngredientId, usageCount,
-          singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        String(item.id),
-        item.name ?? null,
-        item.description ?? null,
-        item.tags ? JSON.stringify(item.tags) : null,
-        item.baseIngredientId ?? null,
-        item.usageCount ?? 0,
-        item.singleCocktailName ?? null,
-        item.searchName ?? null,
-        item.searchTokens ? JSON.stringify(item.searchTokens) : null,
-        item.photoUri ?? null,
-        item.inBar ? 1 : 0,
-        item.inShoppingList ? 1 : 0
-      );
+    const stmt = await tx.prepareAsync(
+      `INSERT OR REPLACE INTO ingredients (
+        id, name, description, tags, baseIngredientId, usageCount,
+        singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    try {
+      for (const item of list) {
+        await stmt.executeAsync(
+          String(item.id),
+          item.name ?? null,
+          item.description ?? null,
+          item.tags ? JSON.stringify(item.tags) : null,
+          item.baseIngredientId ?? null,
+          item.usageCount ?? 0,
+          item.singleCocktailName ?? null,
+          item.searchName ?? null,
+          item.searchTokens ? JSON.stringify(item.searchTokens) : null,
+          item.photoUri ?? null,
+          item.inBar ? 1 : 0,
+          item.inShoppingList ? 1 : 0
+        );
+        await stmt.resetAsync();
+      }
+    } finally {
+      await stmt.finalizeAsync();
     }
     console.log("[ingredientsStorage] saveAllIngredients done");
   });
@@ -261,26 +268,33 @@ export async function flushPendingIngredients(list) {
   await initDatabase();
   await withExclusiveWriteAsync(async (tx) => {
     console.log("[ingredientsStorage] flushPendingIngredients start", items.length);
-    for (const u of items) {
-      const item = sanitizeIngredient(u);
-      await tx.runAsync(
-        `INSERT OR REPLACE INTO ingredients (
-          id, name, description, tags, baseIngredientId, usageCount,
-          singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        String(item.id),
-        item.name ?? null,
-        item.description ?? null,
-        item.tags ? JSON.stringify(item.tags) : null,
-        item.baseIngredientId ?? null,
-        item.usageCount ?? 0,
-        item.singleCocktailName ?? null,
-        item.searchName ?? null,
-        item.searchTokens ? JSON.stringify(item.searchTokens) : null,
-        item.photoUri ?? null,
-        item.inBar ? 1 : 0,
-        item.inShoppingList ? 1 : 0
-      );
+    const stmt = await tx.prepareAsync(
+      `INSERT OR REPLACE INTO ingredients (
+        id, name, description, tags, baseIngredientId, usageCount,
+        singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    try {
+      for (const u of items) {
+        const item = sanitizeIngredient(u);
+        await stmt.executeAsync(
+          String(item.id),
+          item.name ?? null,
+          item.description ?? null,
+          item.tags ? JSON.stringify(item.tags) : null,
+          item.baseIngredientId ?? null,
+          item.usageCount ?? 0,
+          item.singleCocktailName ?? null,
+          item.searchName ?? null,
+          item.searchTokens ? JSON.stringify(item.searchTokens) : null,
+          item.photoUri ?? null,
+          item.inBar ? 1 : 0,
+          item.inShoppingList ? 1 : 0
+        );
+        await stmt.resetAsync();
+      }
+    } finally {
+      await stmt.finalizeAsync();
     }
     console.log("[ingredientsStorage] flushPendingIngredients done");
   });

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -140,7 +140,7 @@ export async function saveAllIngredients(ingredients) {
   try {
     await withExclusiveWriteAsync(async (tx) => {
       console.log("[ingredientsStorage] saveAllIngredients start", list.length);
-      await tx.execAsync("DELETE FROM ingredients");
+      await tx.runAsync("DELETE FROM ingredients");
       const stmt = await tx.prepareAsync(
         `INSERT OR REPLACE INTO ingredients (
           id, name, description, tags, baseIngredientId, usageCount,

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -148,11 +148,11 @@ export async function saveAllIngredients(ingredients) {
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       );
       try {
-        let i = 0;
-        for (const item of list) {
+        for (let i = 0; i < list.length; i++) {
+          const item = list[i];
           console.log(
-            "[ingredientsStorage] saveAllIngredients insert",
-            i++,
+            "[ingredientsStorage] saveAllIngredients insert start",
+            i,
             item.id
           );
           await stmt.executeAsync(
@@ -169,10 +169,21 @@ export async function saveAllIngredients(ingredients) {
             item.inBar ? 1 : 0,
             item.inShoppingList ? 1 : 0
           );
+          console.log(
+            "[ingredientsStorage] saveAllIngredients insert done",
+            i,
+            item.id
+          );
         }
         console.log("[ingredientsStorage] saveAllIngredients done");
       } finally {
+        console.log(
+          "[ingredientsStorage] saveAllIngredients finalize start"
+        );
         await stmt.finalizeAsync();
+        console.log(
+          "[ingredientsStorage] saveAllIngredients finalize done"
+        );
       }
     });
   } catch (e) {
@@ -305,12 +316,11 @@ export async function flushPendingIngredients(list) {
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       );
       try {
-        let i = 0;
-        for (const u of items) {
-          const item = sanitizeIngredient(u);
+        for (let i = 0; i < items.length; i++) {
+          const item = sanitizeIngredient(items[i]);
           console.log(
-            "[ingredientsStorage] flushPendingIngredients insert",
-            i++,
+            "[ingredientsStorage] flushPendingIngredients insert start",
+            i,
             item.id
           );
           await stmt.executeAsync(
@@ -327,10 +337,21 @@ export async function flushPendingIngredients(list) {
             item.inBar ? 1 : 0,
             item.inShoppingList ? 1 : 0
           );
+          console.log(
+            "[ingredientsStorage] flushPendingIngredients insert done",
+            i,
+            item.id
+          );
         }
         console.log("[ingredientsStorage] flushPendingIngredients done");
       } finally {
+        console.log(
+          "[ingredientsStorage] flushPendingIngredients finalize start"
+        );
         await stmt.finalizeAsync();
+        console.log(
+          "[ingredientsStorage] flushPendingIngredients finalize done"
+        );
       }
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- Import and use `withExclusiveWriteAsync` in ingredient storage
- Serialize writes for ingredient updates, deletes, saves, and flushes

## Testing
- `npm test`
- `grep -n "database is locked" /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68b8503af23c8326977ce3f906654cde