### PR TITLE
Serialize ingredient writes to avoid SQLite lock

### DIFF
--- a/scripts/importCocktailsAndIngredients.js
+++ b/scripts/importCocktailsAndIngredients.js
@@ -116,7 +116,7 @@ function sanitizeCocktails(raw) {
 }
 
 export async function importCocktailsAndIngredients({ force = false } = {}) {
-  startImport();
+  await startImport();
   try {
     await initDatabase();
     const already = force

--- a/scripts/importCocktailsAndIngredients.js
+++ b/scripts/importCocktailsAndIngredients.js
@@ -3,14 +3,14 @@ import RAW_DATA from "../assets/data/data.json";
 import { BUILTIN_INGREDIENT_TAGS } from "../src/constants/ingredientTags";
 import { BUILTIN_COCKTAIL_TAGS } from "../src/constants/cocktailTags";
 import {
-  replaceAllCocktails,
+  replaceAllCocktailsTx,
   getAllCocktails,
 } from "../src/storage/cocktailsStorage";
 import {
   getAllIngredients,
-  saveAllIngredients,
+  saveAllIngredientsTx,
 } from "../src/storage/ingredientsStorage";
-import { initDatabase } from "../src/storage/sqlite";
+import { initDatabase, withExclusiveWriteAsync } from "../src/storage/sqlite";
 import { normalizeSearch } from "../src/utils/normalizeSearch";
 import { WORD_SPLIT_RE } from "../src/utils/wordPrefixMatch";
 import { Image } from "react-native";
@@ -163,8 +163,10 @@ export async function importCocktailsAndIngredients({ force = false } = {}) {
       return c;
     });
 
-    await saveAllIngredients(ingredients);
-    await replaceAllCocktails(cocktails);
+    await withExclusiveWriteAsync(async (tx) => {
+      await saveAllIngredientsTx(tx, ingredients);
+      await replaceAllCocktailsTx(tx, cocktails);
+    });
     await AsyncStorage.setItem(IMPORT_FLAG_KEY, "true");
 
     console.log(

--- a/scripts/importCocktailsAndIngredients.js
+++ b/scripts/importCocktailsAndIngredients.js
@@ -4,10 +4,10 @@ import { BUILTIN_INGREDIENT_TAGS } from "../src/constants/ingredientTags";
 import { BUILTIN_COCKTAIL_TAGS } from "../src/constants/cocktailTags";
 import {
   replaceAllCocktailsTx,
-  getAllCocktails,
+  getAllCocktailsTx,
 } from "../src/storage/cocktailsStorage";
 import {
-  getAllIngredients,
+  getAllIngredientsTx,
   saveAllIngredientsTx,
 } from "../src/storage/ingredientsStorage";
 import { initDatabase, withExclusiveWriteAsync } from "../src/storage/sqlite";
@@ -117,61 +117,64 @@ function sanitizeCocktails(raw) {
 export async function importCocktailsAndIngredients({ force = false } = {}) {
   try {
     await initDatabase();
-    const [already, existingIngredients, existingCocktails] = await Promise.all([
-      force ? null : AsyncStorage.getItem(IMPORT_FLAG_KEY),
-      getAllIngredients(),
-      getAllCocktails(),
-    ]);
-
-    if (
-      !force &&
-      already === "true" &&
-      existingIngredients.length > 0 &&
-      existingCocktails.length > 0
-    ) {
-      console.log("ℹ️ Sample data already imported — skip");
-      return;
-    }
-
-    const existingIngredientsMap = Object.fromEntries(
-      existingIngredients.map((it) => [it.id, it])
-    );
-    const existingCocktailsMap = Object.fromEntries(
-      existingCocktails.map((c) => [c.id, c])
-    );
-
-    const ingredients = sanitizeIngredients(RAW_DATA.ingredients).map((it) => {
-      const existing = existingIngredientsMap[it.id];
-      if (existing) {
-        return {
-          ...it,
-          inBar: existing.inBar,
-          inShoppingList: existing.inShoppingList,
-        };
-      }
-      return it;
-    });
-
-    const cocktails = sanitizeCocktails(RAW_DATA.cocktails).map((c) => {
-      const existing = existingCocktailsMap[c.id];
-      if (existing) {
-        return {
-          ...c,
-          rating: existing.rating,
-        };
-      }
-      return c;
-    });
-
+    const already = force
+      ? null
+      : await AsyncStorage.getItem(IMPORT_FLAG_KEY);
+    let counts = null;
     await withExclusiveWriteAsync(async (tx) => {
+      const existingIngredients = await getAllIngredientsTx(tx);
+      const existingCocktails = await getAllCocktailsTx(tx);
+
+      if (
+        !force &&
+        already === "true" &&
+        existingIngredients.length > 0 &&
+        existingCocktails.length > 0
+      ) {
+        console.log("ℹ️ Sample data already imported — skip");
+        return;
+      }
+
+      const existingIngredientsMap = Object.fromEntries(
+        existingIngredients.map((it) => [it.id, it])
+      );
+      const existingCocktailsMap = Object.fromEntries(
+        existingCocktails.map((c) => [c.id, c])
+      );
+
+      const ingredients = sanitizeIngredients(RAW_DATA.ingredients).map((it) => {
+        const existing = existingIngredientsMap[it.id];
+        if (existing) {
+          return {
+            ...it,
+            inBar: existing.inBar,
+            inShoppingList: existing.inShoppingList,
+          };
+        }
+        return it;
+      });
+
+      const cocktails = sanitizeCocktails(RAW_DATA.cocktails).map((c) => {
+        const existing = existingCocktailsMap[c.id];
+        if (existing) {
+          return {
+            ...c,
+            rating: existing.rating,
+          };
+        }
+        return c;
+      });
+
       await saveAllIngredientsTx(tx, ingredients);
       await replaceAllCocktailsTx(tx, cocktails);
+      counts = { ingredients: ingredients.length, cocktails: cocktails.length };
     });
-    await AsyncStorage.setItem(IMPORT_FLAG_KEY, "true");
-
-    console.log(
-      `✅ Imported ${ingredients.length} ingredients and ${cocktails.length} cocktails`
-    );
+    if (counts) {
+      await AsyncStorage.setItem(IMPORT_FLAG_KEY, "true");
+      console.log(
+        `✅ Imported ${counts.ingredients} ingredients and ${counts.cocktails} cocktails`
+      );
+    }
   } catch (error) {
     console.error("❌ Error importing data:", error);
   }

--- a/scripts/importCocktailsAndIngredients.js
+++ b/scripts/importCocktailsAndIngredients.js
@@ -15,6 +15,7 @@ import { normalizeSearch } from "../src/utils/normalizeSearch";
 import { WORD_SPLIT_RE } from "../src/utils/wordPrefixMatch";
 import { Image } from "react-native";
 import { ASSET_MAP } from "./assetMap";
+import { startImport, finishImport } from "../src/storage/importLock";
 
 const IMPORT_FLAG_KEY = "default_data_imported_flag";
 
@@ -115,6 +116,7 @@ function sanitizeCocktails(raw) {
 }
 
 export async function importCocktailsAndIngredients({ force = false } = {}) {
+  startImport();
   try {
     await initDatabase();
     const already = force
@@ -177,5 +179,7 @@ export async function importCocktailsAndIngredients({ force = false } = {}) {
     }
   } catch (error) {
     console.error("❌ Error importing data:", error);
+  } finally {
+    finishImport();
   }
 }

--- a/src/storage/cocktailsStorage.js
+++ b/src/storage/cocktailsStorage.js
@@ -2,6 +2,7 @@
 import { normalizeSearch } from "../utils/normalizeSearch";
 import { sortByName } from "../utils/sortByName";
 import db, { query, initDatabase, withExclusiveWriteAsync } from "./sqlite";
+import { waitForImport } from "./importLock";
 
 // Serialize write operations to avoid `database is locked` on Android.
 let writeQueue = Promise.resolve();
@@ -58,6 +59,7 @@ const sanitizeCocktail = (c) => {
 };
 
 async function readAll() {
+  await waitForImport();
   await initDatabase();
   const res = await query(
     `SELECT id, name, photoUri, glassId, rating, tags, description, instructions, createdAt, updatedAt FROM cocktails`
@@ -203,6 +205,7 @@ export async function getAllCocktails() {
 
 /** Get single cocktail by id (number) */
 export async function getCocktailById(id) {
+  await waitForImport();
   await initDatabase();
   const res = await query(
     `SELECT id, name, photoUri, glassId, rating, tags, description, instructions, createdAt, updatedAt FROM cocktails WHERE id = ?`,

--- a/src/storage/cocktailsStorage.js
+++ b/src/storage/cocktailsStorage.js
@@ -289,9 +289,14 @@ export async function replaceAllCocktailsTx(tx, cocktails) {
   const normalized = Array.isArray(cocktails)
     ? cocktails.map(sanitizeCocktail)
     : [];
+  console.log("[cocktailsStorage] replaceAllCocktails start", normalized.length);
+  console.log("[cocktailsStorage] deleting cocktail tables");
   await tx.runAsync("DELETE FROM cocktail_ingredients");
   await tx.runAsync("DELETE FROM cocktails");
+  let idx = 0;
   for (const item of normalized) {
+    idx += 1;
+    console.log("[cocktailsStorage] insert cocktail", idx, item.id);
     await tx.runAsync(
       `INSERT OR REPLACE INTO cocktails (
             id, name, photoUri, glassId, rating, tags, description, instructions, createdAt, updatedAt
@@ -327,6 +332,7 @@ export async function replaceAllCocktailsTx(tx, cocktails) {
       );
     }
   }
+  console.log("[cocktailsStorage] replaceAllCocktails done");
   return normalized;
 }
 

--- a/src/storage/importLock.js
+++ b/src/storage/importLock.js
@@ -1,0 +1,22 @@
+let resolveImport;
+let importPromise = Promise.resolve();
+
+export function startImport() {
+  if (!resolveImport) {
+    importPromise = new Promise((res) => {
+      resolveImport = res;
+    });
+  }
+}
+
+export function finishImport() {
+  if (resolveImport) {
+    resolveImport();
+    resolveImport = null;
+    importPromise = Promise.resolve();
+  }
+}
+
+export function waitForImport() {
+  return importPromise;
+}

--- a/src/storage/importLock.js
+++ b/src/storage/importLock.js
@@ -1,11 +1,41 @@
 let resolveImport;
 let importPromise = Promise.resolve();
 
-export function startImport() {
+let activeReads = 0;
+let resolveNoReads;
+let noReadsPromise = Promise.resolve();
+
+function waitForNoReads() {
+  return activeReads === 0
+    ? Promise.resolve()
+    : noReadsPromise;
+}
+
+export async function beforeRead() {
+  activeReads += 1;
+  await importPromise;
+}
+
+export function afterRead() {
+  activeReads -= 1;
+  if (activeReads === 0 && resolveNoReads) {
+    resolveNoReads();
+    resolveNoReads = null;
+    noReadsPromise = Promise.resolve();
+  }
+}
+
+export async function startImport() {
   if (!resolveImport) {
     importPromise = new Promise((res) => {
       resolveImport = res;
     });
+  }
+  if (activeReads > 0) {
+    noReadsPromise = new Promise((res) => {
+      resolveNoReads = res;
+    });
+    await waitForNoReads();
   }
 }
 

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -155,8 +155,13 @@ async function upsertIngredient(item) {
 export async function saveAllIngredientsTx(tx, ingredients) {
   const list = Array.isArray(ingredients) ? ingredients : [];
   console.log("[ingredientsStorage] saveAllIngredients start", list.length);
+  console.log("[ingredientsStorage] deleting ingredients");
   await tx.runAsync("DELETE FROM ingredients");
+  console.log("[ingredientsStorage] inserting ingredients");
+  let idx = 0;
   for (const item of list) {
+    idx += 1;
+    console.log("[ingredientsStorage] insert", idx, item.id);
     await tx.runAsync(
       `INSERT OR REPLACE INTO ingredients (
           id, name, description, tags, baseIngredientId, usageCount,

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -1,4 +1,5 @@
 import { query, initDatabase, withExclusiveWriteAsync } from "./sqlite";
+import { waitForImport } from "./importLock";
 import { normalizeSearch } from "../utils/normalizeSearch";
 import { WORD_SPLIT_RE } from "../utils/wordPrefixMatch";
 import { sortByName } from "../utils/sortByName";
@@ -8,6 +9,7 @@ const genId = () => now();
 
 export async function getAllIngredients() {
   console.log("[ingredientsStorage] getAllIngredients start");
+  await waitForImport();
   await initDatabase();
   const res = await query(
     "SELECT id, name, description, tags, baseIngredientId, usageCount, singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList FROM ingredients"
@@ -65,6 +67,7 @@ export async function getIngredientsByIds(ids) {
   const list = Array.isArray(ids) ? ids.filter((id) => id != null) : [];
   if (list.length === 0) return [];
   const placeholders = list.map(() => "?").join(", ");
+  await waitForImport();
   await initDatabase();
   const res = await query(
     `SELECT id, name, description, tags, baseIngredientId, usageCount, singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList FROM ingredients WHERE id IN (${placeholders})`,
@@ -94,6 +97,7 @@ export async function getIngredientsByBaseIds(baseIds, { inBarOnly = false } = {
   const list = Array.isArray(baseIds) ? baseIds.filter((id) => id != null) : [];
   if (list.length === 0) return [];
   const placeholders = list.map(() => "?").join(", ");
+  await waitForImport();
   await initDatabase();
   const res = await query(
     `SELECT id, name, description, tags, baseIngredientId, usageCount, singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList FROM ingredients WHERE baseIngredientId IN (${placeholders})${inBarOnly ? ' AND inBar = 1' : ''}`,

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -1,4 +1,4 @@
-import db, { query, initDatabase } from "./sqlite";
+import { query, initDatabase, withExclusiveWriteAsync } from "./sqlite";
 import { normalizeSearch } from "../utils/normalizeSearch";
 import { WORD_SPLIT_RE } from "../utils/wordPrefixMatch";
 import { sortByName } from "../utils/sortByName";
@@ -99,7 +99,7 @@ export function buildIndex(list) {
 
 async function upsertIngredient(item) {
   await initDatabase();
-  await db.withExclusiveTransactionAsync(async (tx) => {
+  await withExclusiveWriteAsync(async (tx) => {
     console.log("[ingredientsStorage] upsertIngredient start", item.id, item.name);
     await tx.runAsync(
       `INSERT OR REPLACE INTO ingredients (
@@ -126,7 +126,7 @@ async function upsertIngredient(item) {
 export async function saveAllIngredients(ingredients) {
   const list = Array.isArray(ingredients) ? ingredients : [];
   await initDatabase();
-  await db.withExclusiveTransactionAsync(async (tx) => {
+  await withExclusiveWriteAsync(async (tx) => {
     console.log("[ingredientsStorage] saveAllIngredients start", list.length);
     await tx.runAsync("DELETE FROM ingredients");
     for (const item of list) {
@@ -251,7 +251,9 @@ export async function updateIngredientFields(id, fields) {
   if (!parts.length) return;
   params.push(String(id));
   const sql = `UPDATE ingredients SET ${parts.join(", ")} WHERE id = ?`;
-  await db.runAsync(sql, params);
+  await withExclusiveWriteAsync(async (tx) => {
+    await tx.runAsync(sql, params);
+  });
   console.log("[ingredientsStorage] updateIngredientFields", id, Object.keys(fields));
 }
 
@@ -259,7 +261,7 @@ export async function flushPendingIngredients(list) {
   const items = Array.isArray(list) ? list : [];
   if (!items.length) return;
   await initDatabase();
-  await db.withExclusiveTransactionAsync(async (tx) => {
+  await withExclusiveWriteAsync(async (tx) => {
     console.log("[ingredientsStorage] flushPendingIngredients start", items.length);
     for (const u of items) {
       const item = sanitizeIngredient(u);
@@ -292,7 +294,9 @@ export function getIngredientById(id, index) {
 
 export async function deleteIngredient(id) {
   await initDatabase();
-  await db.runAsync("DELETE FROM ingredients WHERE id = ?", [String(id)]);
+  await withExclusiveWriteAsync(async (tx) => {
+    await tx.runAsync("DELETE FROM ingredients WHERE id = ?", [String(id)]);
+  });
   console.log("[ingredientsStorage] deleteIngredient", String(id));
 }
 

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -32,6 +32,35 @@ export async function getAllIngredients() {
   return list;
 }
 
+export async function getAllIngredientsTx(tx) {
+  console.log("[ingredientsStorage] getAllIngredientsTx start");
+  const rows = await tx.getAllAsync(
+    "SELECT id, name, description, tags, baseIngredientId, usageCount, singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList FROM ingredients"
+  );
+  const list = rows
+    .map((r) => ({
+      id: Number(r.id),
+      name: r.name,
+      description: r.description,
+      tags: r.tags ? JSON.parse(r.tags) : [],
+      baseIngredientId:
+        r.baseIngredientId != null ? Number(r.baseIngredientId) : null,
+      usageCount: r.usageCount ?? 0,
+      singleCocktailName: r.singleCocktailName,
+      searchName: r.searchName,
+      searchTokens: r.searchTokens ? JSON.parse(r.searchTokens) : [],
+      photoUri: r.photoUri,
+      inBar: !!r.inBar,
+      inShoppingList: !!r.inShoppingList,
+    }))
+    .sort(sortByName);
+  console.log(
+    "[ingredientsStorage] getAllIngredientsTx rows",
+    list.length
+  );
+  return list;
+}
+
 export async function getIngredientsByIds(ids) {
   const list = Array.isArray(ids) ? ids.filter((id) => id != null) : [];
   if (list.length === 0) return [];

--- a/src/storage/ingredientsStorage.js
+++ b/src/storage/ingredientsStorage.js
@@ -123,33 +123,37 @@ async function upsertIngredient(item) {
   });
 }
 
-export async function saveAllIngredients(ingredients) {
+export async function saveAllIngredientsTx(tx, ingredients) {
   const list = Array.isArray(ingredients) ? ingredients : [];
-  await initDatabase();
-  await withExclusiveWriteAsync(async (tx) => {
-    console.log("[ingredientsStorage] saveAllIngredients start", list.length);
-    await tx.runAsync("DELETE FROM ingredients");
-    for (const item of list) {
-      await tx.runAsync(
-        `INSERT OR REPLACE INTO ingredients (
+  console.log("[ingredientsStorage] saveAllIngredients start", list.length);
+  await tx.runAsync("DELETE FROM ingredients");
+  for (const item of list) {
+    await tx.runAsync(
+      `INSERT OR REPLACE INTO ingredients (
           id, name, description, tags, baseIngredientId, usageCount,
           singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        String(item.id),
-        item.name ?? null,
-        item.description ?? null,
-        item.tags ? JSON.stringify(item.tags) : null,
-        item.baseIngredientId ?? null,
-        item.usageCount ?? 0,
-        item.singleCocktailName ?? null,
-        item.searchName ?? null,
-        item.searchTokens ? JSON.stringify(item.searchTokens) : null,
-        item.photoUri ?? null,
-        item.inBar ? 1 : 0,
-        item.inShoppingList ? 1 : 0
-      );
-    }
-    console.log("[ingredientsStorage] saveAllIngredients done");
+      String(item.id),
+      item.name ?? null,
+      item.description ?? null,
+      item.tags ? JSON.stringify(item.tags) : null,
+      item.baseIngredientId ?? null,
+      item.usageCount ?? 0,
+      item.singleCocktailName ?? null,
+      item.searchName ?? null,
+      item.searchTokens ? JSON.stringify(item.searchTokens) : null,
+      item.photoUri ?? null,
+      item.inBar ? 1 : 0,
+      item.inShoppingList ? 1 : 0
+    );
+  }
+  console.log("[ingredientsStorage] saveAllIngredients done");
+}
+
+export async function saveAllIngredients(ingredients) {
+  await initDatabase();
+  await withExclusiveWriteAsync(async (tx) => {
+    await saveAllIngredientsTx(tx, ingredients);
   });
 }
 

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -10,6 +10,7 @@ export function initDatabase() {
   if (!initPromise) {
     initPromise = db.execAsync(`
       PRAGMA foreign_keys = ON;
+      PRAGMA busy_timeout = 5000;
       CREATE TABLE IF NOT EXISTS cocktails (
         id INTEGER PRIMARY KEY NOT NULL,
         name TEXT,


### PR DESCRIPTION
## Summary
- ensure ingredient storage writes run through `withExclusiveWriteAsync` to prevent database lock contention

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b87ab0b15083269b8898d3bbee19ff