### PR TITLE
Show import message only when importing default data

### DIFF
--- a/App.js
+++ b/App.js
@@ -41,11 +41,12 @@ const ShakerStack = createNativeStackNavigator();
 
 function InitialDataLoader({ children }) {
   useIngredientsData();
-  const { loading } = useIngredientUsage();
+  const { loading, importing } = useIngredientUsage();
   if (loading) {
-    return (
-      <SplashScreen message={'Importing default data…\nThis may take a moment'} />
-    );
+    const message = importing
+      ? 'Importing default data…\nThis may take a moment'
+      : undefined;
+    return <SplashScreen message={message} />;
   }
   return children;
 }

--- a/src/context/IngredientUsageContext.js
+++ b/src/context/IngredientUsageContext.js
@@ -22,6 +22,8 @@ const IngredientUsageContext = createContext({
   setCocktails: () => {},
   loading: true,
   setLoading: () => {},
+  importing: false,
+  setImporting: () => {},
   baseIngredients: [],
   ingredientTags: [],
   setIngredientTags: () => {},
@@ -35,6 +37,7 @@ export function IngredientUsageProvider({ children }) {
   const [loading, setLoading] = useState(true);
   const [baseIngredients, setBaseIngredients] = useState([]);
   const [ingredientTags, setIngredientTags] = useState([]);
+  const [importing, setImporting] = useState(false);
 
   const ingredients = useMemo(
     () => Array.from(ingredientsMap.values()),
@@ -101,6 +104,8 @@ export function IngredientUsageProvider({ children }) {
         setCocktails,
         loading,
         setLoading,
+        importing,
+        setImporting,
         baseIngredients,
         ingredientTags,
         setIngredientTags,

--- a/src/hooks/useIngredientsData.js
+++ b/src/hooks/useIngredientsData.js
@@ -30,11 +30,13 @@ export default function useIngredientsData() {
     ingredientTags,
     setIngredientTags,
     ingredientsByTag,
+    setImporting,
   } = useContext(IngredientUsageContext);
 
   const load = useCallback(
     async (force = false) => {
       setLoading(true);
+      setImporting(false);
       try {
         const [already, ingInitial, cocksInitial, allowSubs, customTags] =
           await Promise.all([
@@ -55,6 +57,7 @@ export default function useIngredientsData() {
           cocks.length === 0;
 
         if (needImport) {
+          setImporting(true);
           console.log(
             "Importing default data… This one-time operation may take a moment"
           );
@@ -106,6 +109,7 @@ export default function useIngredientsData() {
         if (changed) setIngredientTags(nextTags);
       } finally {
         setLoading(false);
+        setImporting(false);
       }
     },
     [
@@ -114,6 +118,7 @@ export default function useIngredientsData() {
       setUsageMap,
       setLoading,
       setIngredientTags,
+      setImporting,
       ingredientTags,
     ]
   );


### PR DESCRIPTION
## Summary
- track `importing` state in IngredientUsageContext
- toggle importing flag in useIngredientsData around sample data import
- only show "Importing default data" splash message when default data import runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b96d5470508326a20412cff4de9b53