### PR TITLE
Use WAL journal mode with normal sync

### DIFF
--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -10,6 +10,8 @@ const pendingSelects = new Set();
 export function initDatabase() {
   if (!initPromise) {
     initPromise = db.execAsync(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA synchronous = NORMAL;
       PRAGMA foreign_keys = ON;
       CREATE TABLE IF NOT EXISTS cocktails (
         id INTEGER PRIMARY KEY NOT NULL,


### PR DESCRIPTION
## Summary
- set SQLite to WAL journal mode and synchronous NORMAL during init

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8cf4d378c832691cdd3032a9b891d