### PR TITLE
fix: remove unsupported StatusBar background color

### DIFF
--- a/App.js
+++ b/App.js
@@ -181,7 +181,7 @@ export default function App() {
     return (
       <GestureHandlerRootView style={{ flex: 1 }}>
         <SafeAreaProvider>
-          <StatusBar style="dark" backgroundColor="#fff" hidden={false} />
+          <StatusBar style="dark" hidden={false} />
           <SafeAreaView style={{ flex: 1, backgroundColor: "#fff" }}>
             <SplashScreen />
           </SafeAreaView>
@@ -195,7 +195,7 @@ export default function App() {
       <PaperProvider theme={AppTheme}>
         <MenuProvider>
           <SafeAreaProvider>
-            <StatusBar style="dark" backgroundColor="#fff" hidden={false} />
+            <StatusBar style="dark" hidden={false} />
             <SafeAreaView style={{ flex: 1, backgroundColor: "#fff" }}>
               <IngredientUsageProvider>
                 <InitialDataLoader>


### PR DESCRIPTION
## Summary
- remove StatusBar backgroundColor prop to avoid edge-to-edge warning

## Testing
- `/usr/bin/npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b96f9f9b9483269b377e8631ee3d1d