### PR TITLE
Centralize SQLite write synchronization

### DIFF
--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -85,6 +85,8 @@ export function withExclusiveWriteAsync(work) {
   if (typeof work !== "function") throw new Error("work must be a function");
   const runner = async () => {
     await initPromise;
+    // Wait for all pending SELECT queries before starting a write transaction
+    await waitForSelects();
     return SQLite.withExclusiveTransactionAsync
       ? SQLite.withExclusiveTransactionAsync(db, work)
       : db.withExclusiveTransactionAsync(work);


### PR DESCRIPTION
## Summary
- ensure every storage write awaits pending SELECTs with `waitForSelects`
- keep all writes serialized via `withExclusiveWriteAsync`/`enqueueWrite`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b987029c24832691e220f3d8f0bab6