### PR TITLE
Serialize cocktail writes to prevent database lock

### DIFF
--- a/src/storage/cocktailsStorage.js
+++ b/src/storage/cocktailsStorage.js
@@ -1,22 +1,11 @@
 // src/storage/cocktailsStorage.js
 import { normalizeSearch } from "../utils/normalizeSearch";
 import { sortByName } from "../utils/sortByName";
-import db, {
+import {
   query,
   initDatabase,
   withExclusiveWriteAsync,
-  waitForSelects,
 } from "./sqlite";
-
-// Serialize write operations to avoid `database is locked` on Android.
-let writeQueue = Promise.resolve();
-function enqueueWrite(fn) {
-  writeQueue = writeQueue.then(fn, fn);
-  return writeQueue.catch((e) => {
-    console.warn("[cocktailsStorage] write error", e);
-    // swallow to keep chain alive
-  });
-}
 
 // --- utils ---
 
@@ -109,48 +98,45 @@ async function readAll() {
 async function upsertCocktail(item) {
   await initDatabase();
   // console.log("[cocktailsStorage] upsertCocktail start", item.id);
-  await enqueueWrite(async () => {
-    await waitForSelects();
-    await withExclusiveWriteAsync(async (tx) => {
+  await withExclusiveWriteAsync(async (tx) => {
+    await tx.runAsync(
+      `INSERT OR REPLACE INTO cocktails (
+        id, name, photoUri, glassId, rating, tags, description, instructions, createdAt, updatedAt
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      item.id,
+      item.name,
+      item.photoUri ?? null,
+      item.glassId ?? null,
+      item.rating ?? 0,
+      item.tags ? JSON.stringify(item.tags) : null,
+      item.description ?? null,
+      item.instructions ?? null,
+      item.createdAt ?? null,
+      item.updatedAt ?? null
+    );
+    await tx.runAsync(
+      `DELETE FROM cocktail_ingredients WHERE cocktailId = ?`,
+      item.id
+    );
+    for (const ing of item.ingredients) {
       await tx.runAsync(
-        `INSERT OR REPLACE INTO cocktails (
-          id, name, photoUri, glassId, rating, tags, description, instructions, createdAt, updatedAt
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO cocktail_ingredients (
+          cocktailId, orderNum, ingredientId, name, amount, unitId, garnish, optional,
+          allowBaseSubstitution, allowBrandedSubstitutes, substitutes
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         item.id,
-        item.name,
-        item.photoUri ?? null,
-        item.glassId ?? null,
-        item.rating ?? 0,
-        item.tags ? JSON.stringify(item.tags) : null,
-        item.description ?? null,
-        item.instructions ?? null,
-        item.createdAt ?? null,
-        item.updatedAt ?? null
+        ing.order,
+        ing.ingredientId != null ? String(ing.ingredientId) : null,
+        ing.name ?? null,
+        ing.amount ?? null,
+        ing.unitId ?? null,
+        ing.garnish ? 1 : 0,
+        ing.optional ? 1 : 0,
+        ing.allowBaseSubstitution ? 1 : 0,
+        ing.allowBrandedSubstitutes ? 1 : 0,
+        ing.substitutes ? JSON.stringify(ing.substitutes) : null
       );
-      await tx.runAsync(
-        `DELETE FROM cocktail_ingredients WHERE cocktailId = ?`,
-        item.id
-      );
-      for (const ing of item.ingredients) {
-        await tx.runAsync(
-          `INSERT INTO cocktail_ingredients (
-            cocktailId, orderNum, ingredientId, name, amount, unitId, garnish, optional,
-            allowBaseSubstitution, allowBrandedSubstitutes, substitutes
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-          item.id,
-          ing.order,
-          ing.ingredientId != null ? String(ing.ingredientId) : null,
-          ing.name ?? null,
-          ing.amount ?? null,
-          ing.unitId ?? null,
-          ing.garnish ? 1 : 0,
-          ing.optional ? 1 : 0,
-          ing.allowBaseSubstitution ? 1 : 0,
-          ing.allowBrandedSubstitutes ? 1 : 0,
-          ing.substitutes ? JSON.stringify(ing.substitutes) : null
-        );
-      }
-    });
+    }
   });
   // console.log("[cocktailsStorage] upsertCocktail end", item.id);
 }
@@ -232,12 +218,9 @@ export function updateCocktailById(list, updated) {
 /** Delete by id */
 export async function deleteCocktail(id) {
   await initDatabase();
-  await enqueueWrite(async () => {
-    await waitForSelects();
-    await withExclusiveWriteAsync(async (tx) => {
-      await tx.runAsync("DELETE FROM cocktail_ingredients WHERE cocktailId = ?", id);
-      await tx.runAsync("DELETE FROM cocktails WHERE id = ?", id);
-    });
+  await withExclusiveWriteAsync(async (tx) => {
+    await tx.runAsync("DELETE FROM cocktail_ingredients WHERE cocktailId = ?", id);
+    await tx.runAsync("DELETE FROM cocktails WHERE id = ?", id);
   });
 }
 
@@ -294,10 +277,7 @@ export async function replaceAllCocktails(cocktails, tx) {
   if (tx) {
     await run(tx);
   } else {
-    await enqueueWrite(async () => {
-      await waitForSelects();
-      await withExclusiveWriteAsync(run);
-    });
+    await withExclusiveWriteAsync(run);
   }
   return normalized;
 }

--- a/src/storage/sqlite.js
+++ b/src/storage/sqlite.js
@@ -85,6 +85,8 @@ export function withExclusiveWriteAsync(work) {
   if (typeof work !== "function") throw new Error("work must be a function");
   const runner = async () => {
     await initPromise;
+    // Ensure no concurrent reads are active before starting a write
+    await waitForSelects();
     return SQLite.withExclusiveTransactionAsync
       ? SQLite.withExclusiveTransactionAsync(db, work)
       : db.withExclusiveTransactionAsync(work);


### PR DESCRIPTION
## Summary
- ensure global SQLite writes wait for active reads before starting
- simplify cocktail storage by using global exclusive writes for add, delete, and replace actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b97a0f1883268aceb4ab77baf937