### PR TITLE
feat: sync cocktail details after edit

### DIFF
--- a/src/screens/Cocktails/EditCocktailScreen.js
+++ b/src/screens/Cocktails/EditCocktailScreen.js
@@ -376,11 +376,6 @@ export default function EditCocktailScreen() {
 
       initialHashRef.current = serialize();
       setDirty(false);
-      if (!stay) {
-        skipPromptRef.current = true;
-        navigation.goBack();
-      }
-
       InteractionManager.runAfterInteractions(async () => {
         const updated = await saveCocktail(cocktail);
         // Debug: read freshly saved cocktail from DB and log it
@@ -410,10 +405,16 @@ export default function EditCocktailScreen() {
           applyUsageMapToIngredients(
             globalIngredients,
             nextUsage,
-            nextCocktails
-          )
-        );
-        if (stay) setSaving(false);
+          nextCocktails
+        )
+      );
+        route.params?.onChange?.(updated);
+        if (stay) {
+          setSaving(false);
+        } else {
+          skipPromptRef.current = true;
+          navigation.goBack();
+        }
       });
 
       return cocktail;
@@ -437,6 +438,7 @@ export default function EditCocktailScreen() {
       setIngredients,
       saving,
       showInfo,
+      route,
     ]
   );
 


### PR DESCRIPTION
## Summary
- pass onChange callback when editing a cocktail to update local state
- invoke onChange after saving a cocktail before leaving the edit screen
- avoid reloading cocktail from DB and use local state on details screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e394a03c8326a7c7aa0913e769a9