### PR TITLE
Optimize ingredient list recomputation

### DIFF
--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
@@ -40,6 +40,7 @@ export default function AllIngredientsScreen() {
   // Use refs to buffer DB writes without triggering re-renders on each toggle
   const pendingUpdatesRef = React.useRef([]);
   const flushTimerRef = React.useRef(null);
+  const filteredRef = useRef([]);
 
   useEffect(() => {
     if (isFocused) setTab("ingredients", "All");
@@ -94,6 +95,7 @@ export default function AllIngredientsScreen() {
   }, [flushPending]);
 
   const filtered = useMemo(() => {
+    if (!isFocused) return filteredRef.current;
     const q = normalizeSearch(searchDebounced);
     let data = ingredients;
     if (q) data = data.filter((i) => i.searchName.includes(q));
@@ -103,8 +105,10 @@ export default function AllIngredientsScreen() {
           Array.isArray(i.tags) &&
           i.tags.some((t) => selectedTagIds.includes(t.id))
       );
-    return [...data].sort(sortByName);
-  }, [ingredients, searchDebounced, selectedTagIds]);
+    const res = [...data].sort(sortByName);
+    filteredRef.current = res;
+    return res;
+  }, [ingredients, searchDebounced, selectedTagIds, isFocused]);
 
   const toggleInBar = useCallback(
     (id) => {

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
@@ -54,6 +54,7 @@ export default function MyIngredientsScreen() {
   const pendingUpdatesRef = React.useRef([]);
   const flushTimerRef = React.useRef(null);
   const [availableMap, setAvailableMap] = useState(new Map());
+  const filteredRef = useRef([]);
 
   useEffect(() => {
     if (isFocused) setTab("ingredients", "My");
@@ -140,6 +141,7 @@ export default function MyIngredientsScreen() {
   }, [cocktails, usageMap, ignoreGarnish, allowSubstitutes, ingredients.length]);
 
   const filtered = useMemo(() => {
+    if (!isFocused) return filteredRef.current;
     const q = normalizeSearch(searchDebounced);
     let data = ingredients.filter((i) => i.inBar);
     if (q) data = data.filter((i) => i.searchName.includes(q));
@@ -149,8 +151,10 @@ export default function MyIngredientsScreen() {
           Array.isArray(i.tags) &&
           i.tags.some((t) => selectedTagIds.includes(t.id))
       );
-    return [...data].sort(sortByName);
-  }, [ingredients, searchDebounced, selectedTagIds]);
+    const res = [...data].sort(sortByName);
+    filteredRef.current = res;
+    return res;
+  }, [ingredients, searchDebounced, selectedTagIds, isFocused]);
 
   const toggleInBar = useCallback(
     (id) => {

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.js
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
@@ -40,6 +40,7 @@ export default function ShoppingIngredientsScreen() {
   // Buffer DB writes to avoid extra renders
   const pendingUpdatesRef = React.useRef([]);
   const flushTimerRef = React.useRef(null);
+  const filteredRef = useRef([]);
 
   useEffect(() => {
     if (isFocused) setTab("ingredients", "Shopping");
@@ -96,6 +97,7 @@ export default function ShoppingIngredientsScreen() {
   }, [flushPending]);
 
   const filtered = useMemo(() => {
+    if (!isFocused) return filteredRef.current;
     const q = normalizeSearch(searchDebounced);
     let data = ingredients.filter((i) => i.inShoppingList);
     if (q) data = data.filter((i) => i.searchName.includes(q));
@@ -105,8 +107,10 @@ export default function ShoppingIngredientsScreen() {
           Array.isArray(i.tags) &&
           i.tags.some((t) => selectedTagIds.includes(t.id))
       );
-    return [...data].sort(sortByName);
-  }, [ingredients, searchDebounced, selectedTagIds]);
+    const res = [...data].sort(sortByName);
+    filteredRef.current = res;
+    return res;
+  }, [ingredients, searchDebounced, selectedTagIds, isFocused]);
 
   const removeFromList = useCallback(
     (id) => {


### PR DESCRIPTION
## Summary
- Skip ingredient list filtering when list screens are not focused
- Cache filtered ingredient arrays to avoid unnecessary recomputation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba0872253c83269de06629a2507326