### PR TITLE
Defer ingredient list grouping for snappier toggles

### DIFF
--- a/src/context/IngredientUsageContext.js
+++ b/src/context/IngredientUsageContext.js
@@ -9,7 +9,6 @@ import React, {
 } from "react";
 import { updateUsageMap as updateUsageMapUtil } from "../utils/ingredientUsage";
 import { sortByName } from "../utils/sortByName";
-import { groupIngredientsByTag } from "../utils/groupIngredientsByTag";
 
 const IngredientUsageContext = createContext({
   usageMap: {},
@@ -27,7 +26,6 @@ const IngredientUsageContext = createContext({
   baseIngredients: [],
   ingredientTags: [],
   setIngredientTags: () => {},
-  ingredientsByTag: new Map(),
 });
 
 export function IngredientUsageProvider({ children }) {
@@ -42,11 +40,6 @@ export function IngredientUsageProvider({ children }) {
   const ingredients = useMemo(
     () => Array.from(ingredientsMap.values()),
     [ingredientsMap]
-  );
-
-  const ingredientsByTag = useMemo(
-    () => groupIngredientsByTag(ingredients, ingredientTags),
-    [ingredients, ingredientTags]
   );
 
   const setIngredients = useCallback((next) => {
@@ -109,7 +102,6 @@ export function IngredientUsageProvider({ children }) {
         baseIngredients,
         ingredientTags,
         setIngredientTags,
-        ingredientsByTag,
       }}
     >
       {children}

--- a/src/hooks/useIngredientsData.js
+++ b/src/hooks/useIngredientsData.js
@@ -29,7 +29,6 @@ export default function useIngredientsData() {
     baseIngredients,
     ingredientTags,
     setIngredientTags,
-    ingredientsByTag,
     setImporting,
   } = useContext(IngredientUsageContext);
 
@@ -143,7 +142,6 @@ export default function useIngredientsData() {
     cocktails,
     usageMap,
     ingredientTags,
-    ingredientsByTag,
     refresh,
     loading,
     setIngredients,

--- a/src/screens/ShakerScreen.js
+++ b/src/screens/ShakerScreen.js
@@ -8,6 +8,7 @@ import HeaderWithSearch from "../components/HeaderWithSearch";
 import IngredientRow, { INGREDIENT_ROW_HEIGHT } from "../components/IngredientRow";
 import useIngredientsData from "../hooks/useIngredientsData";
 import { normalizeSearch } from "../utils/normalizeSearch";
+import { groupIngredientsByTag } from "../utils/groupIngredientsByTag";
 import {
   buildIngredientIndex,
   getCocktailIngredientInfo,
@@ -29,16 +30,17 @@ export default function ShakerScreen({ navigation }) {
     usageMap,
     loading,
     ingredientTags,
-    ingredientsByTag,
   } = useIngredientsData();
+  const grouped = useMemo(
+    () => groupIngredientsByTag(ingredients, ingredientTags),
+    [ingredients, ingredientTags]
+  );
   const [expanded, setExpanded] = useState({});
   const [selectedIds, setSelectedIds] = useState([]);
   const [search, setSearch] = useState("");
   const [inStockOnly, setInStockOnly] = useState(true);
   const [allowSubstitutes, setAllowSubstitutes] = useState(false);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
-
-  const grouped = ingredientsByTag;
 
   const filteredGrouped = useMemo(() => {
     const q = normalizeSearch(search);


### PR DESCRIPTION
## Summary
- Remove global `ingredientsByTag` map so toggling an ingredient doesn't recompute all tag lists
- Build the tag grouped ingredient map only inside Shaker screen when opened

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba0cdd75788326851dfe3dc62f1bd8