### PR TITLE
Defer ingredient updates after interactions

### DIFF
--- a/src/screens/Ingredients/AllIngredientsScreen.js
+++ b/src/screens/Ingredients/AllIngredientsScreen.js
@@ -1,5 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  InteractionManager,
+} from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
 import { useTheme } from "react-native-paper";
@@ -108,17 +114,19 @@ export default function AllIngredientsScreen() {
 
   const toggleInBar = useCallback(
     (id) => {
-      let updated;
-      setIngredients((prev) => {
-        const item = prev.get(id);
-        if (!item) return prev;
-        updated = { ...item, inBar: !item.inBar };
-        return updateIngredientById(prev, updated);
+      InteractionManager.runAfterInteractions(() => {
+        let updated;
+        setIngredients((prev) => {
+          const item = prev.get(id);
+          if (!item) return prev;
+          updated = { ...item, inBar: !item.inBar };
+          return updateIngredientById(prev, updated);
+        });
+        if (updated) {
+          pendingUpdatesRef.current.push(updated);
+          scheduleFlush();
+        }
       });
-      if (updated) {
-        pendingUpdatesRef.current.push(updated);
-        scheduleFlush();
-      }
     },
     [setIngredients, scheduleFlush]
   );

--- a/src/screens/Ingredients/MyIngredientsScreen.js
+++ b/src/screens/Ingredients/MyIngredientsScreen.js
@@ -1,5 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  InteractionManager,
+} from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
 import { useTheme } from "react-native-paper";
@@ -165,12 +171,15 @@ export default function MyIngredientsScreen() {
         return next;
       });
       if (updated) {
-        // Defer availability recompute to after interactions to keep UI snappy
-        requestAnimationFrame(() => {
-          // Use the snapshot captured from the state update
-          const arr = nextSnapshot ? Array.from(nextSnapshot.values()) : ingredients;
-          const map = updateIngredientAvailability(id, arr);
-          setAvailableMap(new Map(map));
+        // Recompute availability after current interactions and frame commit
+        InteractionManager.runAfterInteractions(() => {
+          requestAnimationFrame(() => {
+            const arr = nextSnapshot
+              ? Array.from(nextSnapshot.values())
+              : ingredients;
+            const map = updateIngredientAvailability(id, arr);
+            setAvailableMap(new Map(map));
+          });
         });
         pendingUpdatesRef.current.push(updated);
         scheduleFlush();


### PR DESCRIPTION
## Summary
- recompute ingredient availability after interactions to keep UI responsive
- schedule ingredient toggles asynchronously in the all ingredients list
- retain optimistic state in IngredientRow and defer persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0fb2ef7c8326a3bbb783d358d134