### PR TITLE
feat: incremental ingredient usage map updates

### DIFF
--- a/src/context/IngredientUsageContext.js
+++ b/src/context/IngredientUsageContext.js
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useMemo,
 } from "react";
-import { updateUsageMap as updateUsageMapUtil } from "../utils/ingredientUsage";
+import { updateUsageMap as updateUsageMapIncremental } from "../utils/ingredientUsage";
 import { sortByName } from "../utils/sortByName";
 import { groupIngredientsByTag } from "../utils/groupIngredientsByTag";
 
@@ -59,10 +59,13 @@ export function IngredientUsageProvider({ children }) {
   }, []);
 
   const updateUsageMap = useCallback(
-    (ingredients, cocktails, options) => {
-      setUsageMap((prev) =>
-        updateUsageMapUtil(prev, ingredients, cocktails, options)
-      );
+    (ingredients, cocktails, options = {}) => {
+      let next;
+      setUsageMap((prev) => {
+        next = updateUsageMapIncremental(prev, ingredients, cocktails, options);
+        return next;
+      });
+      return next;
     },
     []
   );

--- a/src/screens/Cocktails/AddCocktailScreen.js
+++ b/src/screens/Cocktails/AddCocktailScreen.js
@@ -67,10 +67,7 @@ import TinyDivider from "../../components/TinyDivider";
 import CocktailIngredientRow from "../../components/CocktailIngredientRow";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
-import {
-  addCocktailToUsageMap,
-  applyUsageMapToIngredients,
-} from "../../utils/ingredientUsage";
+import { applyUsageMapToIngredients } from "../../utils/ingredientUsage";
 import { getAllowSubstitutes } from "../../storage/settingsStorage";
 import { getAllIngredients } from "../../storage/ingredientsStorage";
 
@@ -206,8 +203,7 @@ export default function AddCocktailScreen() {
   const route = useRoute();
   const isFocused = useIsFocused();
   const { getTab } = useTabMemory();
-  const { cocktails, setCocktails, usageMap, setUsageMap } =
-    useIngredientUsage();
+  const { cocktails, setCocktails, updateUsageMap } = useIngredientUsage();
   const { ingredients: globalIngredients = [], setIngredients } =
     useIngredientsData();
   const initialCocktail = route.params?.initialCocktail;
@@ -674,18 +670,16 @@ export default function AddCocktailScreen() {
       }
 
       const allowSubs = await getAllowSubstitutes();
-      setCocktails((prev) => {
-        const next = [...prev, created];
-        const nextUsage = addCocktailToUsageMap(
-          usageMap,
-          globalIngredients,
-          created,
-          { allowSubstitutes: !!allowSubs }
-        );
-        setUsageMap(nextUsage);
-        setIngredients(applyUsageMapToIngredients(globalIngredients, nextUsage, next));
-        return next;
+      const nextCocktails = [...cocktails, created];
+      const nextUsage = updateUsageMap(globalIngredients, nextCocktails, {
+        prevCocktails: cocktails,
+        changedCocktailIds: [created.id],
+        allowSubstitutes: !!allowSubs,
       });
+      setCocktails(nextCocktails);
+      setIngredients(
+        applyUsageMapToIngredients(globalIngredients, nextUsage, nextCocktails)
+      );
 
       if (fromIngredientFlow) {
         navigation.replace("CocktailDetails", {
@@ -712,10 +706,10 @@ export default function AddCocktailScreen() {
     instructions,
     glassId,
     ings,
-    usageMap,
+    cocktails,
     globalIngredients,
     setCocktails,
-    setUsageMap,
+    updateUsageMap,
     setIngredients,
     navigation,
     fromIngredientFlow,

--- a/src/screens/Ingredients/IngredientDetailsScreen.js
+++ b/src/screens/Ingredients/IngredientDetailsScreen.js
@@ -420,6 +420,7 @@ export default function IngredientDetailsScreen() {
 
       getAllowSubstitutes().then((allow) => {
         updateUsageMap(Array.from(nextList.values()), cocktailsCtx, {
+          prevIngredients: ingredients,
           changedIngredientIds: changedIds,
           allowSubstitutes: !!allow,
         });


### PR DESCRIPTION
## Summary
- update ingredient usage map incrementally using add/remove helpers
- use incremental updates in IngredientUsageContext
- refresh usage map on cocktail edits/additions without full rebuild

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baffb487008326856f3923fe24c410