### PR TITLE
feat: cache ingredient maps

### DIFF
--- a/src/hooks/useIngredientsData.js
+++ b/src/hooks/useIngredientsData.js
@@ -69,8 +69,17 @@ export default function useIngredientsData() {
         }
 
         const sorted = [...ing].sort(sortByName);
+        const byId = new Map(sorted.map((i) => [i.id, i]));
+        const byBase = new Map();
+        sorted.forEach((i) => {
+          const baseId = i.baseIngredientId ?? i.id;
+          if (!byBase.has(baseId)) byBase.set(baseId, []);
+          byBase.get(baseId).push(i);
+        });
         const map = mapCocktailsByIngredient(sorted, cocks, {
           allowSubstitutes: !!allowSubs,
+          byId,
+          byBase,
         });
         const cocktailMap = new Map(cocks.map((c) => [c.id, c.name]));
         const withUsage = sorted.map((item) => {


### PR DESCRIPTION
## Summary
- cache ingredient `byId` and `byBase` maps in context
- reuse precomputed ingredient maps in usage calculations
- update detail screens and data loaders to supply cached maps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb02e2b2708326b529001142483c93