### PR TITLE
Defer shopping list updates on My Cocktails screen

### DIFF
--- a/src/screens/Cocktails/MyCocktailsScreen.js
+++ b/src/screens/Cocktails/MyCocktailsScreen.js
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
+import { View, Text, StyleSheet, ActivityIndicator, InteractionManager } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
 import HeaderWithSearch from "../../components/HeaderWithSearch";
@@ -259,17 +259,17 @@ export default function MyCocktailsScreen() {
         return updateIngredientById(prev, updated);
       });
       if (updated) {
-        // Defer global context update a tick to prioritize UI
-        requestAnimationFrame(() => {
+        pendingUpdatesRef.current.push(updated);
+        // Defer heavy updates until after interactions complete
+        InteractionManager.runAfterInteractions(() => {
           setGlobalIngredients((list) =>
             updateIngredientById(list, {
               id,
               inShoppingList: updated.inShoppingList,
             })
           );
+          scheduleFlush();
         });
-        pendingUpdatesRef.current.push(updated);
-        scheduleFlush();
       }
     },
     [setGlobalIngredients, setIngredients, scheduleFlush]


### PR DESCRIPTION
## Summary
- use InteractionManager to defer global shopping-list updates in My Cocktails screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb07ba58108326b2e2528066f5eac2