### PR TITLE
feat: add loading save button for ingredient screens

### DIFF
--- a/src/components/SaveButton.js
+++ b/src/components/SaveButton.js
@@ -1,0 +1,46 @@
+import React from "react";
+import { Pressable, Text, ActivityIndicator, StyleSheet } from "react-native";
+import { useTheme } from "react-native-paper";
+import { withAlpha } from "../utils/color";
+
+export default function SaveButton({ title, saving, onPress }) {
+  const theme = useTheme();
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={saving}
+      android_ripple={{ color: withAlpha(theme.colors.onPrimary, 0.15) }}
+      style={[
+        styles.button,
+        {
+          backgroundColor: theme.colors.primary,
+          opacity: saving ? 0.7 : 1,
+        },
+      ]}
+    >
+      <Text style={{ color: theme.colors.onPrimary, fontWeight: "bold" }}>
+        {title}
+      </Text>
+      {saving && (
+        <ActivityIndicator
+          size="small"
+          color={theme.colors.onPrimary}
+          style={{ marginLeft: 8 }}
+        />
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    marginTop: 24,
+    paddingVertical: 12,
+    borderRadius: 10,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+  },
+});

--- a/src/screens/Ingredients/AddIngredientScreen.js
+++ b/src/screens/Ingredients/AddIngredientScreen.js
@@ -16,7 +16,6 @@ import {
   ScrollView,
   FlatList,
   InteractionManager,
-  ActivityIndicator,
   Pressable,
   BackHandler,
   Dimensions,
@@ -43,6 +42,7 @@ import TagPill from "../../components/TagPill";
 import IngredientBaseRow, {
   INGREDIENT_BASE_ROW_HEIGHT,
 } from "../../components/IngredientBaseRow";
+import SaveButton from "../../components/SaveButton";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import useIngredientTags from "../../hooks/useIngredientTags";
 import { normalizeSearch } from "../../utils/normalizeSearch";
@@ -659,29 +659,11 @@ export default function AddIngredientScreen() {
           multiline
         />
 
-        <Pressable
-          style={[
-            styles.saveButton,
-            {
-              backgroundColor: theme.colors.primary,
-              opacity: saving ? 0.7 : 1,
-            },
-          ]}
+        <SaveButton
+          title="Save Ingredient"
+          saving={saving}
           onPress={handleSave}
-          disabled={saving}
-          android_ripple={{ color: withAlpha(theme.colors.onPrimary, 0.15) }}
-        >
-          <Text style={{ color: theme.colors.onPrimary, fontWeight: "bold" }}>
-            Save Ingredient
-          </Text>
-          {saving && (
-            <ActivityIndicator
-              size="small"
-              color={theme.colors.onPrimary}
-              style={{ marginLeft: 8 }}
-            />
-          )}
-        </Pressable>
+        />
       </ScrollView>
     </View>
       <IngredientTagsModal
@@ -751,13 +733,4 @@ const styles = StyleSheet.create({
     resizeMode: "contain",
   },
 
-  saveButton: {
-    marginTop: 24,
-    paddingVertical: 12,
-    alignItems: "center",
-    flexDirection: "row",
-    justifyContent: "center",
-    gap: 8,
-    borderRadius: 8,
-  },
 });

--- a/src/screens/Ingredients/EditIngredientScreen.js
+++ b/src/screens/Ingredients/EditIngredientScreen.js
@@ -44,6 +44,7 @@ import TagPill from "../../components/TagPill";
 import IngredientBaseRow, {
   INGREDIENT_BASE_ROW_HEIGHT,
 } from "../../components/IngredientBaseRow";
+import SaveButton from "../../components/SaveButton";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import useIngredientTags from "../../hooks/useIngredientTags";
@@ -762,29 +763,11 @@ export default function EditIngredientScreen() {
           multiline
         />
 
-        <Pressable
-          style={[
-            styles.saveButton,
-            {
-              backgroundColor: theme.colors.primary,
-              opacity: saving ? 0.7 : 1,
-            },
-          ]}
+        <SaveButton
+          title="Save Changes"
+          saving={saving}
           onPress={() => handleSave(false)}
-          disabled={saving}
-          android_ripple={{ color: theme.colors.onPrimary }}
-        >
-          <Text style={{ color: theme.colors.onPrimary, fontWeight: "bold" }}>
-            Save Changes
-          </Text>
-          {saving && (
-            <ActivityIndicator
-              size="small"
-              color={theme.colors.onPrimary}
-              style={{ marginLeft: 8 }}
-            />
-          )}
-        </Pressable>
+        />
 
       </ScrollView>
     </View>
@@ -920,13 +903,4 @@ const styles = StyleSheet.create({
   },
   menuImg: { width: 40, height: 40, aspectRatio: 1, borderRadius: 8, resizeMode: "contain" },
 
-  saveButton: {
-    marginTop: 24,
-    paddingVertical: 12,
-    alignItems: "center",
-    flexDirection: "row",
-    justifyContent: "center",
-    gap: 8,
-    borderRadius: 8,
-  },
 });


### PR DESCRIPTION
## Summary
- replace ingredient save buttons with reusable component that disables and shows progress
- ensure save operations for ingredients mirror cocktail save behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb07df82e48326a2ac8c1cf2f6bba5