### PR TITLE
feat: extract available ingredient hook

### DIFF
--- a/src/hooks/useAvailableByIngredient.ts
+++ b/src/hooks/useAvailableByIngredient.ts
@@ -1,0 +1,62 @@
+import { useEffect, useMemo, useState } from "react";
+import { InteractionManager } from "react-native";
+import {
+  buildIngredientIndex,
+  getCocktailIngredientInfo,
+} from "../domain/cocktailIngredients";
+
+export default function useAvailableByIngredient(
+  ingredients: any,
+  cocktails: any,
+  usageMap: Record<string, number[]>,
+  allowSubstitutes: boolean,
+  ignoreGarnish: boolean
+) {
+  const compute = useMemo(() => {
+    return () => {
+      if (!Array.isArray(ingredients) || !Array.isArray(cocktails)) {
+        return new Map();
+      }
+      const { ingMap, findBrand } = buildIngredientIndex(ingredients);
+      const nameMap = new Map(cocktails.map((c: any) => [c.id, c.name]));
+      const availableSet = new Set<number>();
+      cocktails.forEach((c: any) => {
+        const { isAllAvailable } = getCocktailIngredientInfo(c, {
+          ingMap,
+          findBrand,
+          allowSubstitutes,
+          ignoreGarnish,
+        });
+        if (isAllAvailable) availableSet.add(c.id);
+      });
+      const map = new Map<number, { count: number; name: string | null }>();
+      ingredients.forEach((ing: any) => {
+        const list = usageMap[ing.id] || [];
+        const avail = list.filter((id: number) => availableSet.has(id));
+        map.set(ing.id, {
+          count: avail.length,
+          name: avail.length === 1 ? (nameMap.get(avail[0]) as string) : null,
+        });
+      });
+      return map;
+    };
+  }, [ingredients, cocktails, usageMap, allowSubstitutes, ignoreGarnish]);
+
+  const [result, setResult] = useState(
+    new Map<number, { count: number; name: string | null }>()
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    const task = InteractionManager.runAfterInteractions(() => {
+      const map = compute();
+      if (!cancelled) setResult(map);
+    });
+    return () => {
+      cancelled = true;
+      task.cancel();
+    };
+  }, [compute]);
+
+  return result;
+}

--- a/src/screens/ShakerScreen.tsx
+++ b/src/screens/ShakerScreen.tsx
@@ -7,11 +7,8 @@ import { MaterialIcons } from "@expo/vector-icons";
 import HeaderWithSearch from "../components/HeaderWithSearch";
 import IngredientRow, { INGREDIENT_ROW_HEIGHT } from "../components/IngredientRow";
 import useIngredientsData from "../hooks/useIngredientsData";
+import useAvailableByIngredient from "../hooks/useAvailableByIngredient";
 import { normalizeSearch } from "../utils/normalizeSearch";
-import {
-  buildIngredientIndex,
-  getCocktailIngredientInfo,
-} from "../domain/cocktailIngredients";
 import {
   getAllowSubstitutes,
   addAllowSubstitutesListener,
@@ -113,33 +110,13 @@ export default function ShakerScreen({ navigation }: ShakerScreenProps): JSX.Ele
     };
   }, []);
 
-  const availableByIngredient = useMemo(() => {
-    if (!Array.isArray(ingredients) || !Array.isArray(cocktails)) {
-      return new Map();
-    }
-    const { ingMap, findBrand } = buildIngredientIndex(ingredients);
-    const nameMap = new Map(cocktails.map((c) => [c.id, c.name]));
-    const availableSet = new Set();
-    cocktails.forEach((c) => {
-      const { isAllAvailable } = getCocktailIngredientInfo(c, {
-        ingMap,
-        findBrand,
-        allowSubstitutes,
-        ignoreGarnish,
-      });
-      if (isAllAvailable) availableSet.add(c.id);
-    });
-    const map = new Map();
-    ingredients.forEach((ing) => {
-      const list = usageMap[ing.id] || [];
-      const avail = list.filter((id) => availableSet.has(id));
-      map.set(ing.id, {
-        count: avail.length,
-        name: avail.length === 1 ? nameMap.get(avail[0]) : null,
-      });
-    });
-    return map;
-  }, [ingredients, cocktails, usageMap, allowSubstitutes, ignoreGarnish]);
+  const availableByIngredient = useAvailableByIngredient(
+    ingredients,
+    cocktails,
+    usageMap,
+    allowSubstitutes,
+    ignoreGarnish
+  );
 
   const renderItem = useCallback(
     ({ item }) => {


### PR DESCRIPTION
## Summary
- refactor ShakerScreen to use new `useAvailableByIngredient` hook
- memoize expensive availability calculations and run after interactions

## Testing
- `npm test` *(fails: Type 'unknown[]' is not assignable to type 'CocktailRecord[]')*


------
https://chatgpt.com/codex/tasks/task_e_68c0603937c08326b8d80cc4f316a7a9