### PR TITLE
Use dedicated read-only SQLite connection

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,23 @@
 import { registerRootComponent } from 'expo';
-import { initDatabase } from './src/data/sqlite';
+import { initDatabase, closeDatabases } from './src/data/sqlite';
 import App from './App';
 
 // initialize SQLite tables once at startup
 initDatabase();
+
+// Ensure database connections are closed when the app exits.
+const cleanup = () => {
+  // closeDatabases returns a promise, but process exit handlers can't await.
+  closeDatabases().catch(() => {});
+};
+
+if (typeof globalThis.addEventListener === 'function') {
+  globalThis.addEventListener('beforeunload', cleanup);
+  globalThis.addEventListener('unload', cleanup);
+}
+if (typeof process !== 'undefined' && typeof (process as any).on === 'function') {
+  (process as any).on('exit', cleanup);
+}
 
 // registerRootComponent calls AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,

--- a/src/data/__mocks__/expo-sqlite.ts
+++ b/src/data/__mocks__/expo-sqlite.ts
@@ -4,6 +4,7 @@ export function openDatabaseSync() {
     getAllAsync: async () => [],
     runAsync: async () => {},
     withTransactionAsync: async (cb) => cb(),
+    closeAsync: async () => {},
   };
 }
 export function setTracer() {}


### PR DESCRIPTION
## Summary
- add read-only SQLite connection for SELECT queries
- route SELECT statements through read-only DB and close DBs on exit
- ensure database mock supports closing

## Testing
- `npm test` *(fails: File 'expo/tsconfig.base' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c074f67974832695013fd473c12fb0