### PR TITLE
Optimize shopping status updates

### DIFF
--- a/src/data/ingredients.ts
+++ b/src/data/ingredients.ts
@@ -286,6 +286,22 @@ export async function flushPendingIngredients(list) {
   });
 }
 
+export async function setIngredientsInShoppingList(ids, inShoppingList) {
+  const list = Array.isArray(ids)
+    ? Array.from(new Set(ids.filter((id) => id != null)))
+    : [];
+  if (!list.length) return;
+  await initDatabase();
+  const placeholders = list.map(() => "?").join(", ");
+  const value = inShoppingList ? 1 : 0;
+  await withWriteTransactionAsync(async (tx) => {
+    await tx.runAsync(
+      `UPDATE ingredients SET inShoppingList = ? WHERE id IN (${placeholders})`,
+      [value, ...list.map((id) => String(id))]
+    );
+  });
+}
+
 export async function toggleIngredientsInBar(ids) {
   const list = Array.isArray(ids)
     ? Array.from(new Set(ids.filter((id) => id != null)))

--- a/src/domain/ingredients.ts
+++ b/src/domain/ingredients.ts
@@ -34,6 +34,9 @@ export async function updateIngredientFields(id, fields) {
 export async function flushPendingIngredients(list) {
   return (await ensure()).flushPendingIngredients(list);
 }
+export async function setIngredientsInShoppingList(ids, inShoppingList) {
+  return (await ensure()).setIngredientsInShoppingList(ids, inShoppingList);
+}
 export async function toggleIngredientsInBar(ids) {
   return (await ensure()).toggleIngredientsInBar(ids);
 }

--- a/src/screens/Cocktails/MyCocktailsScreen.tsx
+++ b/src/screens/Cocktails/MyCocktailsScreen.tsx
@@ -15,7 +15,7 @@ import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { getAllCocktails } from "../../domain/cocktails";
 import {
   getAllIngredients,
-  flushPendingIngredients,
+  setIngredientsInShoppingList,
   updateIngredientById,
 } from "../../domain/ingredients";
 import {
@@ -91,7 +91,15 @@ export default function MyCocktailsScreen() {
     const list = pendingUpdatesRef.current;
     if (list && list.length) {
       pendingUpdatesRef.current = [];
-      flushPendingIngredients(list).catch(() => {});
+      const add = [];
+      const remove = [];
+      list.forEach((u) => {
+        (u.inShoppingList ? add : remove).push(u.id);
+      });
+      if (add.length)
+        setIngredientsInShoppingList(add, true).catch(() => {});
+      if (remove.length)
+        setIngredientsInShoppingList(remove, false).catch(() => {});
     }
   }, []);
 
@@ -270,7 +278,10 @@ export default function MyCocktailsScreen() {
               inShoppingList: updated.inShoppingList,
             })
           );
-          pendingUpdatesRef.current.push(updated);
+          pendingUpdatesRef.current.push({
+            id,
+            inShoppingList: updated.inShoppingList,
+          });
           scheduleFlush();
         }
       });

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.tsx
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.tsx
@@ -12,7 +12,7 @@ import IngredientRow, {
 } from "../../components/IngredientRow";
 import TabSwipe from "../../components/TabSwipe";
 import { useTabMemory } from "../../context/TabMemoryContext";
-import { flushPendingIngredients } from "../../domain/ingredients";
+import { setIngredientsInShoppingList } from "../../domain/ingredients";
 import { getAllTags } from "../../data/ingredientTags";
 import { BUILTIN_INGREDIENT_TAGS } from "../../constants/ingredientTags";
 import useIngredientsData from "../../hooks/useIngredientsData";
@@ -64,24 +64,19 @@ export default function ShoppingIngredientsScreen() {
     const ids = Array.from(pendingIdsRef.current);
     if (!ids.length) return;
     pendingIdsRef.current = new Set();
-    let items = [];
     setIngredients((prev) => {
       const next = new Map(prev);
       ids.forEach((id) => {
         const item = next.get(id);
         if (item) {
-          const updated = { ...item, inShoppingList: false };
-          next.set(id, updated);
-          items.push(updated);
+          next.set(id, { ...item, inShoppingList: false });
         }
       });
       return next;
     });
-    if (items.length) {
-      try {
-        await flushPendingIngredients(items);
-      } catch {}
-    }
+    try {
+      await setIngredientsInShoppingList(ids, false);
+    } catch {}
   }, [setIngredients]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- batch update shopping status with new `setIngredientsInShoppingList`
- use field-only updates on ShoppingIngredients and MyCocktails screens

## Testing
- `npm test` *(fails: TypeScript errors in cocktails.ts and settings.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c0798e9cb88326bb64d8e489e53c3a