### PR TITLE
Render empty lists during loading

### DIFF
--- a/src/screens/Cocktails/AllCocktailsScreen.tsx
+++ b/src/screens/Cocktails/AllCocktailsScreen.tsx
@@ -179,13 +179,6 @@ export default function AllCocktailsScreen() {
 
   const keyExtractor = useCallback((item) => String(item.id), []);
 
-  if (loading)
-    return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
-      </View>
-    );
-
   return (
     <TabSwipe navigation={navigation}>
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -211,11 +204,17 @@ export default function AllCocktailsScreen() {
         initialNumToRender={12}
         getItemType={() => "COCKTAIL"}
         ListEmptyComponent={
-          <View style={{ padding: 24 }}>
-            <Text style={{ color: theme.colors.onSurfaceVariant }}>
-              No cocktails found
-            </Text>
-          </View>
+          loading ? (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator size="large" color={theme.colors.primary} />
+            </View>
+          ) : (
+            <View style={{ padding: 24 }}>
+              <Text style={{ color: theme.colors.onSurfaceVariant }}>
+                No cocktails found
+              </Text>
+            </View>
+          )
         }
         contentContainerStyle={{
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.tsx
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.tsx
@@ -188,13 +188,6 @@ export default function FavoriteCocktailsScreen() {
 
   const keyExtractor = useCallback((item) => String(item.id), []);
 
-  if (loading)
-    return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
-      </View>
-    );
-
   return (
     <TabSwipe navigation={navigation}>
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -220,11 +213,17 @@ export default function FavoriteCocktailsScreen() {
         initialNumToRender={12}
         getItemType={() => "COCKTAIL"}
         ListEmptyComponent={
-          <View style={{ padding: 24 }}>
-            <Text style={{ color: theme.colors.onSurfaceVariant }}>
-              No cocktails found
-            </Text>
-          </View>
+          loading ? (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator size="large" color={theme.colors.primary} />
+            </View>
+          ) : (
+            <View style={{ padding: 24 }}>
+              <Text style={{ color: theme.colors.onSurfaceVariant }}>
+                No cocktails found
+              </Text>
+            </View>
+          )
         }
         contentContainerStyle={{
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,

--- a/src/screens/Cocktails/MyCocktailsScreen.tsx
+++ b/src/screens/Cocktails/MyCocktailsScreen.tsx
@@ -349,13 +349,6 @@ export default function MyCocktailsScreen() {
     return `t${index}`;
   }, []);
 
-  if (loading)
-    return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
-      </View>
-    );
-
   return (
     <TabSwipe navigation={navigation}>
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -387,11 +380,17 @@ export default function MyCocktailsScreen() {
             : "TEXT"
         }
         ListEmptyComponent={
-          <View style={{ padding: 24 }}>
-            <Text style={{ color: theme.colors.onSurfaceVariant }}>
-              No cocktails available
-            </Text>
-          </View>
+          loading ? (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator size="large" color={theme.colors.primary} />
+            </View>
+          ) : (
+            <View style={{ padding: 24 }}>
+              <Text style={{ color: theme.colors.onSurfaceVariant }}>
+                No cocktails available
+              </Text>
+            </View>
+          )
         }
         contentContainerStyle={{
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,

--- a/src/screens/Ingredients/AllIngredientsScreen.tsx
+++ b/src/screens/Ingredients/AllIngredientsScreen.tsx
@@ -155,17 +155,6 @@ export default function AllIngredientsScreen() {
 
   const keyExtractor = useCallback((item) => String(item.id), []);
 
-  if (loading) {
-    return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
-        <Text style={{ marginTop: 12, color: theme.colors.onSurface }}>
-          Loading ingredients...
-        </Text>
-      </View>
-    );
-  }
-
   return (
     <TabSwipe navigation={navigation}>
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -191,11 +180,20 @@ export default function AllIngredientsScreen() {
         initialNumToRender={12}
         getItemType={() => "ING"}
         ListEmptyComponent={
-          <View style={{ padding: 24 }}>
-            <Text style={{ color: theme.colors.onSurfaceVariant }}>
-              No ingredients found
-            </Text>
-          </View>
+          loading ? (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator size="large" color={theme.colors.primary} />
+              <Text style={{ marginTop: 12, color: theme.colors.onSurface }}>
+                Loading ingredients...
+              </Text>
+            </View>
+          ) : (
+            <View style={{ padding: 24 }}>
+              <Text style={{ color: theme.colors.onSurfaceVariant }}>
+                No ingredients found
+              </Text>
+            </View>
+          )
         }
         contentContainerStyle={{
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,

--- a/src/screens/Ingredients/MyIngredientsScreen.tsx
+++ b/src/screens/Ingredients/MyIngredientsScreen.tsx
@@ -203,17 +203,6 @@ export default function MyIngredientsScreen() {
 
   const keyExtractor = useCallback((item) => String(item.id), []);
 
-  if (loading) {
-    return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
-        <Text style={{ marginTop: 12, color: theme.colors.onSurface }}>
-          Loading ingredients...
-        </Text>
-      </View>
-    );
-  }
-
   return (
     <TabSwipe navigation={navigation}>
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -239,11 +228,20 @@ export default function MyIngredientsScreen() {
         initialNumToRender={12}
         getItemType={() => "ING"}
         ListEmptyComponent={
-          <View style={{ padding: 24 }}>
-            <Text style={{ color: theme.colors.onSurfaceVariant }}>
-              No ingredients found
-            </Text>
-          </View>
+          loading ? (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator size="large" color={theme.colors.primary} />
+              <Text style={{ marginTop: 12, color: theme.colors.onSurface }}>
+                Loading ingredients...
+              </Text>
+            </View>
+          ) : (
+            <View style={{ padding: 24 }}>
+              <Text style={{ color: theme.colors.onSurfaceVariant }}>
+                No ingredients found
+              </Text>
+            </View>
+          )
         }
         contentContainerStyle={{
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,

--- a/src/screens/Ingredients/ShoppingIngredientsScreen.tsx
+++ b/src/screens/Ingredients/ShoppingIngredientsScreen.tsx
@@ -141,17 +141,6 @@ export default function ShoppingIngredientsScreen() {
 
   const keyExtractor = useCallback((item) => String(item.id), []);
 
-  if (loading) {
-    return (
-      <View style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
-        <Text style={{ marginTop: 12, color: theme.colors.onSurface }}>
-          Loading ingredients...
-        </Text>
-      </View>
-    );
-  }
-
   return (
     <TabSwipe navigation={navigation}>
       <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
@@ -177,11 +166,20 @@ export default function ShoppingIngredientsScreen() {
         initialNumToRender={12}
         getItemType={() => "ING"}
         ListEmptyComponent={
-          <View style={{ padding: 24 }}>
-            <Text style={{ color: theme.colors.onSurfaceVariant }}>
-              No ingredients found
-            </Text>
-          </View>
+          loading ? (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator size="large" color={theme.colors.primary} />
+              <Text style={{ marginTop: 12, color: theme.colors.onSurface }}>
+                Loading ingredients...
+              </Text>
+            </View>
+          ) : (
+            <View style={{ padding: 24 }}>
+              <Text style={{ color: theme.colors.onSurfaceVariant }}>
+                No ingredients found
+              </Text>
+            </View>
+          )
         }
         contentContainerStyle={{
           paddingBottom: 56 + (tabsOnTop ? 0 : 56) + insets.bottom,


### PR DESCRIPTION
## Summary
- Render ingredient and cocktail lists immediately and handle loading via `ListEmptyComponent`
- Remove early activity-indicator returns from list screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09098730c8326b0d08779584845a3