### PR TITLE
feat: add skeleton loaders for saving

### DIFF
--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef } from "react";
+import { Animated, StyleSheet, ViewStyle } from "react-native";
+
+interface Props {
+  width?: number | string;
+  height?: number | string;
+  style?: ViewStyle;
+}
+
+export default function Skeleton({ width = "100%", height = 20, style }: Props) {
+  const opacity = useRef(new Animated.Value(0.3)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.3,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [opacity]);
+
+  return (
+    <Animated.View
+      style={[styles.skeleton, { width, height, opacity }, style]}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  skeleton: {
+    backgroundColor: "#e0e0e0",
+    borderRadius: 4,
+  },
+});

--- a/src/screens/Cocktails/AddCocktailScreen.tsx
+++ b/src/screens/Cocktails/AddCocktailScreen.tsx
@@ -21,7 +21,6 @@ import {
   Dimensions,
   Keyboard,
   BackHandler,
-  ActivityIndicator,
 } from "react-native";
 import Animated, {
   FadeInDown,
@@ -46,6 +45,7 @@ import { HeaderBackButton, useHeaderHeight } from "@react-navigation/elements";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import useInfoDialog from "../../hooks/useInfoDialog";
 import useDebounced from "../../hooks/useDebounced";
+import Skeleton from "../../components/Skeleton";
 
 import {
   Menu,
@@ -322,6 +322,7 @@ export default function AddCocktailScreen() {
     initialCocktail?.glassId || "cocktail_glass"
   );
 
+  // disable the save button and show a skeleton while persisting a cocktail
   const [saving, setSaving] = useState(false);
 
   const createBaseRow = (ing) => ({
@@ -1142,10 +1143,10 @@ export default function AddCocktailScreen() {
               Save cocktail
             </Text>
             {saving && (
-              <ActivityIndicator
-                size="small"
-                color={theme.colors.onPrimary}
-                style={{ marginLeft: 8 }}
+              <Skeleton
+                width={16}
+                height={16}
+                style={{ marginLeft: 8, borderRadius: 8 }}
               />
             )}
           </Pressable>

--- a/src/screens/Cocktails/EditCocktailScreen.tsx
+++ b/src/screens/Cocktails/EditCocktailScreen.tsx
@@ -22,7 +22,6 @@ import {
   Keyboard,
   BackHandler,
   InteractionManager,
-  ActivityIndicator,
 } from "react-native";
 import Animated, {
   FadeInDown,
@@ -43,6 +42,7 @@ import {
 import { useTheme, Portal, Modal } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import { HeaderBackButton, useHeaderHeight } from "@react-navigation/elements";
+import Skeleton from "../../components/Skeleton";
 
 import {
   Menu,
@@ -253,6 +253,7 @@ export default function EditCocktailScreen() {
   const [allIngredients, setAllIngredients] = useState(globalIngredients);
   const [dirty, setDirty] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  // disable the save button and show a skeleton while persisting a cocktail
   const [saving, setSaving] = useState(false);
   const [pendingNav, setPendingNav] = useState(null);
   const initialHashRef = useRef("{}");
@@ -1145,10 +1146,10 @@ export default function EditCocktailScreen() {
               Save changes
             </Text>
             {saving && (
-              <ActivityIndicator
-                size="small"
-                color={theme.colors.onPrimary}
-                style={{ marginLeft: 8 }}
+              <Skeleton
+                width={16}
+                height={16}
+                style={{ marginLeft: 8, borderRadius: 8 }}
               />
             )}
           </Pressable>

--- a/src/screens/Ingredients/AddIngredientScreen.tsx
+++ b/src/screens/Ingredients/AddIngredientScreen.tsx
@@ -16,7 +16,6 @@ import {
   ScrollView,
   FlatList,
   InteractionManager,
-  ActivityIndicator,
   Pressable,
   BackHandler,
   Dimensions,
@@ -40,6 +39,7 @@ import { useTabMemory } from "../../context/TabMemoryContext";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import IngredientTagsModal from "../../components/IngredientTagsModal";
 import TagPill from "../../components/TagPill";
+import Skeleton from "../../components/Skeleton";
 import IngredientBaseRow, {
   INGREDIENT_BASE_ROW_HEIGHT,
 } from "../../components/IngredientBaseRow";
@@ -91,7 +91,7 @@ export default function AddIngredientScreen() {
     const other = BUILTIN_INGREDIENT_TAGS.find((t) => t.id === 10);
     return other ? [other] : [{ id: 10, name: "other", color: TAG_COLORS[15] }];
   });
-  // disable the save button and show a spinner while persisting an ingredient
+  // disable the save button and show a skeleton while persisting an ingredient
   const [savingInProgress, setSavingInProgress] = useState(false);
 
   // tag helpers & modal state
@@ -676,10 +676,10 @@ export default function AddIngredientScreen() {
             Save Ingredient
           </Text>
           {savingInProgress && (
-            <ActivityIndicator
-              size="small"
-              color={theme.colors.onPrimary}
-              style={{ marginLeft: 8 }}
+            <Skeleton
+              width={16}
+              height={16}
+              style={{ marginLeft: 8, borderRadius: 8 }}
             />
           )}
         </Pressable>

--- a/src/screens/Ingredients/EditIngredientScreen.tsx
+++ b/src/screens/Ingredients/EditIngredientScreen.tsx
@@ -41,6 +41,7 @@ import { deleteIngredient, saveIngredient } from "../../domain/ingredients";
 import { MaterialIcons } from "@expo/vector-icons";
 import IngredientTagsModal from "../../components/IngredientTagsModal";
 import TagPill from "../../components/TagPill";
+import Skeleton from "../../components/Skeleton";
 import IngredientBaseRow, {
   INGREDIENT_BASE_ROW_HEIGHT,
 } from "../../components/IngredientBaseRow";
@@ -83,7 +84,7 @@ export default function EditIngredientScreen() {
   const [photoUri, setPhotoUri] = useState(null);
   const [tags, setTags] = useState([]);
   const selectedTagIds = useMemo(() => new Set(tags.map((t) => t.id)), [tags]);
-  // disable save button and display loader while ingredient updates persist
+  // disable save button and show a skeleton while ingredient updates persist
   const [savingInProgress, setSavingInProgress] = useState(false);
 
   // reference lists / tags modal
@@ -780,10 +781,10 @@ export default function EditIngredientScreen() {
             Save Changes
           </Text>
           {savingInProgress && (
-            <ActivityIndicator
-              size="small"
-              color={theme.colors.onPrimary}
-              style={{ marginLeft: 8 }}
+            <Skeleton
+              width={16}
+              height={16}
+              style={{ marginLeft: 8, borderRadius: 8 }}
             />
           )}
         </Pressable>


### PR DESCRIPTION
## Summary
- add generic Skeleton component for pulsing placeholder
- use skeleton loader on ingredient and cocktail save buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0997067cc83269b681b1e8c0568c3