### PR TITLE
Refactor sqlite connections with read/write separation and queue

### DIFF
--- a/src/data/sqlite.test.ts
+++ b/src/data/sqlite.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { initDatabase, query, withWriteTransactionAsync } from './sqlite';
+
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('reads run in parallel with writes', async () => {
+  await initDatabase();
+  const events: string[] = [];
+  let signalWriteStart: () => void;
+  const writeStarted = new Promise<void>((res) => (signalWriteStart = res));
+
+  const write = withWriteTransactionAsync(async () => {
+    signalWriteStart();
+    events.push('write-start');
+    await delay(100);
+    events.push('write-end');
+  });
+
+  await writeStarted; // ensure write has begun
+  const read1 = query('SELECT 1').then(() => events.push('read-1'));
+  const read2 = query('SELECT 1').then(() => events.push('read-2'));
+  await Promise.all([read1, read2]);
+  await write;
+
+  assert.deepEqual(events, ['write-start', 'read-1', 'read-2', 'write-end']);
+});
+
+test('write transactions are sequential', async () => {
+  await initDatabase();
+  const events: string[] = [];
+  const t1 = withWriteTransactionAsync(async () => {
+    events.push('t1-start');
+    await delay(50);
+    events.push('t1-end');
+  });
+  const t2 = withWriteTransactionAsync(async () => {
+    events.push('t2-start');
+    await delay(10);
+    events.push('t2-end');
+  });
+  await Promise.all([t1, t2]);
+  assert.deepEqual(events, ['t1-start', 't1-end', 't2-start', 't2-end']);
+});


### PR DESCRIPTION
## Summary
- separate read and write SQLite connections
- serialize writes with a simple promise queue
- route SELECT queries to read connection and others through write transactions
- add concurrency tests for sqlite operations

## Testing
- `npm test` *(fails: test suite is empty)*

------
https://chatgpt.com/codex/tasks/task_e_68c099883a088326b8e7c0d0e8b9ffc1