### PR TITLE
feat: log all sql queries

### DIFF
--- a/src/data/__mocks__/expo-sqlite.ts
+++ b/src/data/__mocks__/expo-sqlite.ts
@@ -1,12 +1,23 @@
+let tracer;
+
 export function openDatabaseSync() {
   return {
-    execAsync: async () => {},
-    getAllAsync: async () => [],
-    runAsync: async () => {},
+    execAsync: async (sql, params) => {
+      tracer?.(sql, params);
+    },
+    getAllAsync: async (sql, params) => {
+      tracer?.(sql, params);
+      return [];
+    },
+    runAsync: async (sql, params) => {
+      tracer?.(sql, params);
+    },
     withTransactionAsync: async (cb) => cb(),
   };
 }
-export function setTracer() {}
+export function setTracer(fn) {
+  tracer = fn;
+}
 export function withTransactionAsync(_db, cb) {
   return cb();
 }

--- a/src/data/sqlite.ts
+++ b/src/data/sqlite.ts
@@ -4,9 +4,13 @@ import * as SQLite from "expo-sqlite";
 const readDb = SQLite.openDatabaseSync("yourbar.db");
 const writeDb = SQLite.openDatabaseSync("yourbar.db");
 
-// Disable verbose SQL query logging if the tracer API is available.
+// Log every SQL query with a timestamp (including milliseconds) if the tracer API is available.
 if (typeof SQLite.setTracer === "function") {
-  SQLite.setTracer(() => {});
+  SQLite.setTracer((sql, params) => {
+    const ts = new Date().toISOString();
+    const paramsStr = params && params.length ? ` | params: ${JSON.stringify(params)}` : "";
+    console.log(`[sqlite] ${ts} | query: ${sql}${paramsStr}`);
+  });
 }
 
 let initPromise;


### PR DESCRIPTION
## Summary
- log SQL queries with timestamp using SQLite tracer
- ensure mock database triggers tracer during tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d17af3e88326aa4537ff91c5852e