### PR TITLE
Use IngredientUsage context for ingredient lists

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.tsx
+++ b/src/screens/Cocktails/AddCocktailScreen.tsx
@@ -667,7 +667,7 @@ export default function AddCocktailScreen() {
 
       const allowSubs = await getAllowSubstitutes();
       const nextCocktails = [...cocktails, created];
-      const nextUsage = updateUsageMap(globalIngredients, nextCocktails, {
+      const nextUsage = await updateUsageMap(globalIngredients, nextCocktails, {
         prevCocktails: cocktails,
         changedCocktailIds: [created.id],
         allowSubstitutes: !!allowSubs,

--- a/src/screens/Cocktails/AddCocktailScreen.tsx
+++ b/src/screens/Cocktails/AddCocktailScreen.tsx
@@ -69,7 +69,6 @@ import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import { applyUsageMapToIngredients } from "../../domain/ingredientUsage";
 import { getAllowSubstitutes } from "../../data/settings";
-import { getAllIngredients } from "../../domain/ingredients";
 
 /* ---------- GlasswareMenu через popup-menu (Popover) ---------- */
 const GlassPopover = memo(function GlassPopover({ selectedGlass, onSelect }) {
@@ -590,10 +589,7 @@ export default function AddCocktailScreen() {
 
     try {
     // Resolve missing selectedId by exact name match (unique)
-    let allKnown = [];
-    try {
-      allKnown = await getAllIngredients();
-    } catch {}
+    const allKnown = globalIngredients;
     const bySearch = new Map();
     allKnown.forEach((i) => {
       const key = i.searchName || normalizeSearch(i.name || "");

--- a/src/screens/Cocktails/AllCocktailsScreen.tsx
+++ b/src/screens/Cocktails/AllCocktailsScreen.tsx
@@ -13,7 +13,6 @@ import TopTabBar from "../../components/TopTabBar";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { getAllCocktails } from "../../domain/cocktails";
-import { getAllIngredients } from "../../domain/ingredients";
 import {
   getIgnoreGarnish,
   addIgnoreGarnishListener,
@@ -47,7 +46,6 @@ export default function AllCocktailsScreen() {
   const insets = useSafeAreaInsets();
 
   const [cocktails, setCocktails] = useState([]);
-  const [ingredients, setIngredients] = useState([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [searchDebounced, setSearchDebounced] = useState("");
@@ -87,17 +85,13 @@ export default function AllCocktailsScreen() {
       if (firstLoad.current) setLoading(true);
       const cocktailPromise =
         globalCocktails.length ? Promise.resolve(globalCocktails) : getAllCocktails();
-      const ingredientPromise =
-        globalIngredients.length ? Promise.resolve(globalIngredients) : getAllIngredients();
-      const [cocktailsList, ingredientsList, ig, allowSubs] = await Promise.all([
+      const [cocktailsList, ig, allowSubs] = await Promise.all([
         cocktailPromise,
-        ingredientPromise,
         getIgnoreGarnish(),
         getAllowSubstitutes(),
       ]);
       if (cancel) return;
       setCocktails(Array.isArray(cocktailsList) ? cocktailsList : []);
-      setIngredients(Array.isArray(ingredientsList) ? ingredientsList : []);
       setIgnoreGarnish(!!ig);
       setAllowSubstitutes(!!allowSubs);
       if (firstLoad.current) {
@@ -112,10 +106,10 @@ export default function AllCocktailsScreen() {
       subIg.remove();
       subAs.remove();
     };
-  }, [isFocused, globalCocktails, globalIngredients]);
+  }, [isFocused, globalCocktails]);
 
   const filtered = useMemo(() => {
-    const { ingMap, findBrand } = buildIngredientIndex(ingredients || []);
+    const { ingMap, findBrand } = buildIngredientIndex(globalIngredients || []);
     const q = normalizeSearch(searchDebounced);
     let list = cocktails;
     if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
@@ -144,7 +138,7 @@ export default function AllCocktailsScreen() {
       .sort(sortByName);
   }, [
     cocktails,
-    ingredients,
+    globalIngredients,
     searchDebounced,
     selectedTagIds,
     ignoreGarnish,

--- a/src/screens/Cocktails/EditCocktailScreen.tsx
+++ b/src/screens/Cocktails/EditCocktailScreen.tsx
@@ -377,7 +377,7 @@ export default function EditCocktailScreen() {
         }
         const nextCocktails = updateCocktailById(cocktails, updated);
         const allowSubs = await getAllowSubstitutes();
-        const nextUsage = updateUsageMap(globalIngredients, nextCocktails, {
+        const nextUsage = await updateUsageMap(globalIngredients, nextCocktails, {
           prevCocktails: cocktails,
           changedCocktailIds: [updated.id],
           allowSubstitutes: !!allowSubs,
@@ -1296,7 +1296,7 @@ export default function EditCocktailScreen() {
           InteractionManager.runAfterInteractions(async () => {
             await deleteCocktail(cocktailId);
             const allowSubs = await getAllowSubstitutes();
-            const nextUsage = updateUsageMap(globalIngredients, nextCocktails, {
+            const nextUsage = await updateUsageMap(globalIngredients, nextCocktails, {
               prevCocktails: cocktails,
               changedCocktailIds: [cocktailId],
               allowSubstitutes: !!allowSubs,

--- a/src/screens/Cocktails/EditCocktailScreen.tsx
+++ b/src/screens/Cocktails/EditCocktailScreen.tsx
@@ -291,10 +291,7 @@ export default function EditCocktailScreen() {
       setSaving(true);
 
       // Resolve missing selectedId by exact name match (unique)
-      let allKnown = [];
-      try {
-        allKnown = await getAllIngredients();
-      } catch {}
+      const allKnown = globalIngredients;
       const bySearch = new Map();
       allKnown.forEach((i) => {
         const key = i.searchName || normalizeSearch(i.name || "");

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.tsx
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.tsx
@@ -13,7 +13,6 @@ import TopTabBar from "../../components/TopTabBar";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { getAllCocktails } from "../../domain/cocktails";
-import { getAllIngredients } from "../../domain/ingredients";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import {
   getIgnoreGarnish,
@@ -51,7 +50,6 @@ export default function FavoriteCocktailsScreen() {
     useIngredientUsage();
 
   const [cocktails, setCocktails] = useState([]);
-  const [ingredients, setIngredients] = useState([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [searchDebounced, setSearchDebounced] = useState("");
@@ -90,19 +88,14 @@ export default function FavoriteCocktailsScreen() {
       if (firstLoad.current) setLoading(true);
       const cocktailPromise =
         globalCocktails.length ? Promise.resolve(globalCocktails) : getAllCocktails();
-      const ingredientPromise =
-        globalIngredients.length ? Promise.resolve(globalIngredients) : getAllIngredients();
-      const [cocktailsList, ingredientsList, ig, favMin, allowSubs] =
-        await Promise.all([
-          cocktailPromise,
-          ingredientPromise,
-          getIgnoreGarnish(),
-          getFavoritesMinRating(),
-          getAllowSubstitutes(),
-        ]);
+      const [cocktailsList, ig, favMin, allowSubs] = await Promise.all([
+        cocktailPromise,
+        getIgnoreGarnish(),
+        getFavoritesMinRating(),
+        getAllowSubstitutes(),
+      ]);
       if (cancel) return;
       setCocktails(Array.isArray(cocktailsList) ? cocktailsList : []);
-      setIngredients(Array.isArray(ingredientsList) ? ingredientsList : []);
       setIgnoreGarnish(!!ig);
       setMinRating(favMin || 0);
       setAllowSubstitutes(!!allowSubs);
@@ -120,10 +113,10 @@ export default function FavoriteCocktailsScreen() {
       subFav.remove();
       subAs.remove();
     };
-  }, [isFocused, globalCocktails, globalIngredients]);
+  }, [isFocused, globalCocktails]);
 
   const filtered = useMemo(() => {
-    const { ingMap, findBrand } = buildIngredientIndex(ingredients || []);
+    const { ingMap, findBrand } = buildIngredientIndex(globalIngredients || []);
     const q = normalizeSearch(searchDebounced);
     let list = cocktails.filter((c) => c.rating > 0 && c.rating >= minRating);
     if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
@@ -152,7 +145,7 @@ export default function FavoriteCocktailsScreen() {
       .sort(sortByName);
   }, [
     cocktails,
-    ingredients,
+    globalIngredients,
     searchDebounced,
     selectedTagIds,
     ignoreGarnish,

--- a/src/screens/Cocktails/MyCocktailsScreen.tsx
+++ b/src/screens/Cocktails/MyCocktailsScreen.tsx
@@ -13,7 +13,7 @@ import TopTabBar from "../../components/TopTabBar";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { getAllCocktails } from "../../domain/cocktails";
-import { getAllIngredients, setIngredientsInShoppingList } from "../../domain/ingredients";
+import { setIngredientsInShoppingList } from "../../domain/ingredients";
 import {
   getIgnoreGarnish,
   addIgnoreGarnishListener,
@@ -100,21 +100,13 @@ export default function MyCocktailsScreen() {
       if (firstLoad.current) setLoading(true);
       const cocktailPromise =
         globalCocktails.length ? Promise.resolve(globalCocktails) : getAllCocktails();
-      const ingredientPromise =
-        globalIngredients.length ? Promise.resolve(globalIngredients) : getAllIngredients();
-      const [cocktailsList, ingredientsList, ig, allowSubs] = await Promise.all([
+      const [cocktailsList, ig, allowSubs] = await Promise.all([
         cocktailPromise,
-        ingredientPromise,
         getIgnoreGarnish(),
         getAllowSubstitutes(),
       ]);
       if (cancel) return;
       setCocktails(Array.isArray(cocktailsList) ? cocktailsList : []);
-      setIngredients(
-        new Map(
-          (Array.isArray(ingredientsList) ? ingredientsList : []).map((i) => [i.id, i])
-        )
-      );
       setIgnoreGarnish(!!ig);
       setAllowSubstitutes(!!allowSubs);
       if (firstLoad.current) {
@@ -129,7 +121,13 @@ export default function MyCocktailsScreen() {
       subIg.remove();
       subAs.remove();
     };
-  }, [isFocused, globalCocktails, globalIngredients]);
+  }, [isFocused, globalCocktails]);
+
+  useEffect(() => {
+    setIngredients(
+      new Map((Array.isArray(globalIngredients) ? globalIngredients : []).map((i) => [i.id, i]))
+    );
+  }, [globalIngredients]);
 
   useEffect(() => {
     const unsub = navigation.addListener("blur", () => {

--- a/src/screens/Ingredients/IngredientDetailsScreen.tsx
+++ b/src/screens/Ingredients/IngredientDetailsScreen.tsx
@@ -371,15 +371,16 @@ export default function IngredientDetailsScreen() {
     const updated = { ...ingredient, inBar: !ingredient.inBar };
     // Optimistic local update for instant UI feedback
     setIngredient(updated);
-    // Defer heavier global updates and DB write to allow UI to update first
+    // Write to DB first to avoid blocking the transaction with rendering work
     setTimeout(() => {
-      setIngredients((list) =>
-        updateIngredientById(list, {
-          id: updated.id,
-          inBar: updated.inBar,
-        })
-      );
-      updateIngredientFields(updated.id, { inBar: updated.inBar });
+      updateIngredientFields(updated.id, { inBar: updated.inBar }).then(() => {
+        setIngredients((list) =>
+          updateIngredientById(list, {
+            id: updated.id,
+            inBar: updated.inBar,
+          })
+        );
+      });
     }, 0);
   }, [ingredient, setIngredients]);
 
@@ -391,16 +392,17 @@ export default function IngredientDetailsScreen() {
     };
     // Optimistic local update for instant icon change
     setIngredient(updated);
-    // Defer global list update and DB write to allow UI to update first
+    // Write to DB before updating global list to keep the transaction fast
     setTimeout(() => {
-      setIngredients((list) =>
-        updateIngredientById(list, {
-          id: updated.id,
-          inShoppingList: updated.inShoppingList,
-        })
-      );
       updateIngredientFields(updated.id, {
         inShoppingList: updated.inShoppingList,
+      }).then(() => {
+        setIngredients((list) =>
+          updateIngredientById(list, {
+            id: updated.id,
+            inShoppingList: updated.inShoppingList,
+          })
+        );
       });
     }, 0);
   }, [ingredient, setIngredients]);

--- a/src/screens/Ingredients/IngredientDetailsScreen.tsx
+++ b/src/screens/Ingredients/IngredientDetailsScreen.tsx
@@ -27,13 +27,10 @@ import {
 import { goBack } from "../../utils/navigation";
 
 import {
-  getAllIngredients,
   saveIngredient,
   updateIngredientById,
   updateIngredientFields,
 } from "../../domain/ingredients";
-
-import { getAllCocktails } from "../../domain/cocktails";
 import { mapCocktailsByIngredient } from "../../domain/ingredientUsage";
 import { sortByName } from "../../utils/sortByName";
 import { MaterialIcons } from "@expo/vector-icons";
@@ -313,14 +310,13 @@ export default function IngredientDetailsScreen() {
     }, [handleGoBack])
   );
 
-  const load = useCallback(
-    async (refresh = false) => {
-      const [all, cocktails, ig, allowSubs] = await Promise.all([
-        !refresh && ingredients.length ? ingredients : getAllIngredients(),
-        !refresh && cocktailsCtx.length ? cocktailsCtx : getAllCocktails(),
+  const load = useCallback(async () => {
+      const [ig, allowSubs] = await Promise.all([
         getIgnoreGarnish(),
         getAllowSubstitutes(),
       ]);
+      const all = ingredients;
+      const cocktails = cocktailsCtx;
       const loaded = ingredientsById.get(id) || all.find((i) => i.id === id);
       setIngredient((prev) => (loaded ? { ...prev, ...loaded } : prev));
       const byId = new Map(all.map((i) => [i.id, i]));
@@ -346,10 +342,8 @@ export default function IngredientDetailsScreen() {
     [id, ingredientsById, ingredients, cocktailsCtx]
   );
 
-  const shouldLoad = !ingredients.length || !cocktailsCtx.length;
   useFocusEffect(
     useCallback(() => {
-      if (!shouldLoad) return;
       let cancelled = false;
       (async () => {
         try {
@@ -359,7 +353,7 @@ export default function IngredientDetailsScreen() {
       return () => {
         cancelled = true;
       };
-    }, [load, shouldLoad])
+    }, [load])
   );
 
   useEffect(() => {

--- a/src/screens/Ingredients/IngredientDetailsScreen.tsx
+++ b/src/screens/Ingredients/IngredientDetailsScreen.tsx
@@ -437,20 +437,16 @@ export default function IngredientDetailsScreen() {
         }
       });
 
-      getAllowSubstitutes().then((allow) => {
-        updateUsageMap(Array.from(nextList.values()), cocktailsCtx, {
+      InteractionManager.runAfterInteractions(async () => {
+        for (const item of updates) {
+          await saveIngredient(item);
+        }
+        const allow = await getAllowSubstitutes();
+        await updateUsageMap(Array.from(nextList.values()), cocktailsCtx, {
           prevIngredients: ingredients,
           changedIngredientIds: changedIds,
           allowSubstitutes: !!allow,
         });
-      });
-
-      InteractionManager.runAfterInteractions(() => {
-        (async () => {
-          for (const item of updates) {
-            await saveIngredient(item);
-          }
-        })();
       });
     },
     [


### PR DESCRIPTION
## Summary
- Use `IngredientUsage` context to supply ingredient data in cocktail and ingredient screens
- Drop direct `getAllIngredients` calls and rely on context updates for current lists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c16e12a4048326ba815320a297e91e