### PR TITLE
Use IngredientUsageContext for ingredient data

### DIFF
--- a/src/screens/Cocktails/AddCocktailScreen.tsx
+++ b/src/screens/Cocktails/AddCocktailScreen.tsx
@@ -69,7 +69,6 @@ import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import { applyUsageMapToIngredients } from "../../domain/ingredientUsage";
 import { getAllowSubstitutes } from "../../data/settings";
-import { getAllIngredients } from "../../domain/ingredients";
 
 /* ---------- GlasswareMenu через popup-menu (Popover) ---------- */
 const GlassPopover = memo(function GlassPopover({ selectedGlass, onSelect }) {
@@ -590,10 +589,7 @@ export default function AddCocktailScreen() {
 
     try {
     // Resolve missing selectedId by exact name match (unique)
-    let allKnown = [];
-    try {
-      allKnown = await getAllIngredients();
-    } catch {}
+    const allKnown = globalIngredients;
     const bySearch = new Map();
     allKnown.forEach((i) => {
       const key = i.searchName || normalizeSearch(i.name || "");

--- a/src/screens/Cocktails/EditCocktailScreen.tsx
+++ b/src/screens/Cocktails/EditCocktailScreen.tsx
@@ -291,10 +291,7 @@ export default function EditCocktailScreen() {
       setSaving(true);
 
       // Resolve missing selectedId by exact name match (unique)
-      let allKnown = [];
-      try {
-        allKnown = await getAllIngredients();
-      } catch {}
+      const allKnown = globalIngredients;
       const bySearch = new Map();
       allKnown.forEach((i) => {
         const key = i.searchName || normalizeSearch(i.name || "");


### PR DESCRIPTION
## Summary
- Fetch cocktails and ingredients from IngredientUsageContext instead of hitting SQLite in cocktail and ingredient detail screens
- Use context-provided ingredient lists when saving cocktails
- Recompute ingredient details from context when data or settings change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17c54a6fc8326bbafc53c57eff39f