### PR TITLE
Update ingredient availability incrementally

### DIFF
--- a/src/screens/Ingredients/AllIngredientsScreen.tsx
+++ b/src/screens/Ingredients/AllIngredientsScreen.tsx
@@ -21,11 +21,7 @@ import useIngredientsData from "../../hooks/useIngredientsData";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { normalizeSearch } from "../../utils/normalizeSearch";
 import { sortByName } from "../../utils/sortByName";
-import {
-  getIgnoreGarnish,
-  getAllowSubstitutes,
-} from "../../data/settings";
-import { initIngredientsAvailability } from "../../domain/ingredientsAvailabilityCache";
+import { updateIngredientAvailability } from "../../domain/ingredientsAvailabilityCache";
 
 export default function AllIngredientsScreen() {
   const theme = useTheme();
@@ -35,8 +31,7 @@ export default function AllIngredientsScreen() {
   const tabsOnTop = useTabsOnTop();
   const insets = useSafeAreaInsets();
 
-  const { ingredients, loading, setIngredients, cocktails, usageMap } =
-    useIngredientsData();
+  const { ingredients, loading, setIngredients } = useIngredientsData();
   const [search, setSearch] = useState("");
   const [searchDebounced, setSearchDebounced] = useState("");
   const [navigatingId, setNavigatingId] = useState(null);
@@ -86,14 +81,12 @@ export default function AllIngredientsScreen() {
         return next;
       });
       try {
-        const [ignore, allow] = await Promise.all([
-          getIgnoreGarnish(),
-          getAllowSubstitutes(),
-        ]);
-        initIngredientsAvailability(updatedList, cocktails, usageMap, ignore, allow);
+        ids.forEach((id) => {
+          updateIngredientAvailability(id, updatedList);
+        });
       } catch {}
     }
-  }, [setIngredients, cocktails, usageMap]);
+  }, [setIngredients]);
 
   useEffect(() => {
     if (!isFocused) {

--- a/src/screens/Ingredients/MyIngredientsScreen.tsx
+++ b/src/screens/Ingredients/MyIngredientsScreen.tsx
@@ -26,7 +26,10 @@ import {
 } from "../../data/settings";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { normalizeSearch } from "../../utils/normalizeSearch";
-import { initIngredientsAvailability } from "../../domain/ingredientsAvailabilityCache";
+import {
+  initIngredientsAvailability,
+  updateIngredientAvailability,
+} from "../../domain/ingredientsAvailabilityCache";
 import { sortByName } from "../../utils/sortByName";
 
 export default function MyIngredientsScreen() {
@@ -111,22 +114,13 @@ export default function MyIngredientsScreen() {
         updatedList = Array.from(next.values());
         return next;
       });
-      const map = initIngredientsAvailability(
-        updatedList,
-        cocktails,
-        usageMap,
-        ignoreGarnish,
-        allowSubstitutes
-      );
+      let map;
+      ids.forEach((id) => {
+        map = updateIngredientAvailability(id, updatedList);
+      });
       setAvailableMap(new Map(map));
     }
-  }, [
-    setIngredients,
-    cocktails,
-    usageMap,
-    ignoreGarnish,
-    allowSubstitutes,
-  ]);
+  }, [setIngredients]);
 
   useEffect(() => {
     if (!isFocused) {


### PR DESCRIPTION
## Summary
- switch ingredient screens to use updateIngredientAvailability instead of full cache init
- drop redundant settings fetches when toggling ingredients

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c18ed5d18483268f34897a2a3e2de1