### PR TITLE
Avoid reload on shopping flag toggle

### DIFF
--- a/src/screens/Ingredients/IngredientDetailsScreen.tsx
+++ b/src/screens/Ingredients/IngredientDetailsScreen.tsx
@@ -4,6 +4,7 @@ import React, {
   useLayoutEffect,
   useCallback,
   memo,
+  useRef,
 } from "react";
 import {
   View,
@@ -193,11 +194,16 @@ export default function IngredientDetailsScreen() {
   const [usedCocktails, setUsedCocktails] = useState(initialUsed);
   const [unlinkBaseVisible, setUnlinkBaseVisible] = useState(false);
   const [unlinkChildTarget, setUnlinkChildTarget] = useState(null);
+  const skipReload = useRef(0);
 
   useEffect(() => {
     const current =
       ingredientsById.get(id) || route.params?.initialIngredient || null;
     if (!current) return;
+    if (skipReload.current > 0) {
+      skipReload.current--;
+      return;
+    }
     setIngredient((prev) => ({ ...prev, ...current }));
     const { children, base, used } = buildDetails(
       ingredients,
@@ -340,6 +346,10 @@ export default function IngredientDetailsScreen() {
 
   const isFocused = useIsFocused();
   useEffect(() => {
+    if (skipReload.current > 0) {
+      skipReload.current--;
+      return;
+    }
     if (isFocused) {
       load();
     }
@@ -374,6 +384,7 @@ export default function IngredientDetailsScreen() {
 
   const toggleInShoppingList = useCallback(() => {
     if (!ingredient) return;
+    skipReload.current = 2;
     const updated = {
       ...ingredient,
       inShoppingList: !ingredient.inShoppingList,


### PR DESCRIPTION
## Summary
- Skip reloading ingredient details when only `inShoppingList` changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c193c81a5483269e12a16744076187