### PR TITLE
Add console profiling for heavy calculations

### DIFF
--- a/src/components/CocktailIngredientRow.tsx
+++ b/src/components/CocktailIngredientRow.tsx
@@ -118,7 +118,13 @@ const CocktailIngredientRow = memo(function CocktailIngredientRow({
 
   // перерахунок placement/maxHeight/позиції (від контейнера навколо інпута)
   const recalcPlacement = useCallback(() => {
-    if (!nameAnchorRef.current) return;
+    const start = Date.now();
+    const startedAt = new Date(start).toISOString();
+    if (!nameAnchorRef.current) {
+      const duration = Date.now() - start;
+      console.log(`[recalcPlacement] start=${startedAt} duration=${duration}ms`);
+      return;
+    }
     nameAnchorRef.current.measureInWindow((x, y, w, h) => {
       const screenH = Dimensions.get("window").height;
       const SAFE = 8;
@@ -148,6 +154,9 @@ const CocktailIngredientRow = memo(function CocktailIngredientRow({
         left: x,
       }));
       setNameWidth(w || nameWidth);
+
+      const duration = Date.now() - start;
+      console.log(`[recalcPlacement] start=${startedAt} duration=${duration}ms`);
     });
   }, [kbHeight, suggestions.length, nameWidth]);
 

--- a/src/domain/ingredientUsage.ts
+++ b/src/domain/ingredientUsage.ts
@@ -1,3 +1,5 @@
+import { profile } from "../utils/profile";
+
 function buildByBase(ingredients) {
   const map = new Map();
   ingredients.forEach((i) => {
@@ -9,164 +11,119 @@ function buildByBase(ingredients) {
 }
 
 export function mapCocktailsByIngredient(ingredients, cocktails, options = {}) {
-  const { allowSubstitutes = false, byId, byBase } = options;
-  const byIdMap = byId || new Map(ingredients.map((i) => [i.id, i]));
-  const byBaseMap = byBase || buildByBase(ingredients);
+  return profile("mapCocktailsByIngredient", () => {
+    const { allowSubstitutes = false, byId, byBase } = options;
+    const byIdMap = byId || new Map(ingredients.map((i) => [i.id, i]));
+    const byBaseMap = byBase || buildByBase(ingredients);
 
-  const usageMap = new Map();
-  const add = (id, cocktailId) => {
-    if (id == null) return;
-    let set = usageMap.get(id);
-    if (!set) {
-      set = new Set();
-      usageMap.set(id, set);
-    }
-    set.add(cocktailId);
-  };
+    const usageMap = new Map();
+    const add = (id, cocktailId) => {
+      if (id == null) return;
+      let set = usageMap.get(id);
+      if (!set) {
+        set = new Set();
+        usageMap.set(id, set);
+      }
+      set.add(cocktailId);
+    };
 
-  cocktails.forEach((c) => {
-    if (!Array.isArray(c.ingredients)) return;
-    c.ingredients.forEach((r) => {
-      if (r.ingredientId == null) return;
-      const ing = byIdMap.get(r.ingredientId);
-      if (!ing) return;
-      const baseId = ing.baseIngredientId ?? ing.id;
-      const group = byBaseMap.get(baseId) || [];
+    cocktails.forEach((c) => {
+      if (!Array.isArray(c.ingredients)) return;
+      c.ingredients.forEach((r) => {
+        if (r.ingredientId == null) return;
+        const ing = byIdMap.get(r.ingredientId);
+        if (!ing) return;
+        const baseId = ing.baseIngredientId ?? ing.id;
+        const group = byBaseMap.get(baseId) || [];
 
-      // direct usage
-      add(ing.id, c.id);
+        // direct usage
+        add(ing.id, c.id);
 
-      if (ing.id === baseId) {
-        // base ingredient used: count all branded versions
-        group.forEach((item) => {
-          if (item.id !== baseId) add(item.id, c.id);
-        });
-      } else {
-        // branded ingredient used: base ingredient always counts
-        add(baseId, c.id);
-        if (allowSubstitutes || r.allowBrandedSubstitutes) {
+        if (ing.id === baseId) {
+          // base ingredient used: count all branded versions
           group.forEach((item) => {
-            if (item.id !== ing.id && item.id !== baseId) add(item.id, c.id);
+            if (item.id !== baseId) add(item.id, c.id);
           });
+        } else {
+          // branded ingredient used: base ingredient always counts
+          add(baseId, c.id);
+          if (allowSubstitutes || r.allowBrandedSubstitutes) {
+            group.forEach((item) => {
+              if (item.id !== ing.id && item.id !== baseId) add(item.id, c.id);
+            });
+          }
         }
-      }
 
-      // explicit substitutes
-      if (Array.isArray(r.substitutes)) {
-        r.substitutes.forEach((s) => add(s.id, c.id));
-      }
+        // explicit substitutes
+        if (Array.isArray(r.substitutes)) {
+          r.substitutes.forEach((s) => add(s.id, c.id));
+        }
+      });
     });
-  });
 
-  const result = {};
-  ingredients.forEach((i) => {
-    const set = usageMap.get(i.id);
-    result[i.id] = set ? Array.from(set) : [];
+    const result = {};
+    ingredients.forEach((i) => {
+      const set = usageMap.get(i.id);
+      result[i.id] = set ? Array.from(set) : [];
+    });
+    return result;
   });
-  return result;
 }
 
 export function calculateIngredientUsage(ingredients, cocktails, options = {}) {
-  const map = mapCocktailsByIngredient(ingredients, cocktails, options);
-  const result = {};
-  ingredients.forEach((i) => {
-    const arr = map[i.id];
-    result[i.id] = Array.isArray(arr) ? arr.length : 0;
+  return profile("calculateIngredientUsage", () => {
+    const map = mapCocktailsByIngredient(ingredients, cocktails, options);
+    const result = {};
+    ingredients.forEach((i) => {
+      const arr = map[i.id];
+      result[i.id] = Array.isArray(arr) ? arr.length : 0;
+    });
+    return result;
   });
-  return result;
 }
 
 export function updateUsageMap(prevMap, ingredients, cocktails, options = {}) {
-  const {
-    changedIngredientIds = [],
-    changedCocktailIds = [],
-    prevCocktails = [],
-    prevIngredients = [],
-    allowSubstitutes = false,
-    byId,
-    byBase,
-    prevById,
-    prevByBase,
-  } = options;
-  let map = { ...prevMap };
+  return profile("updateUsageMap", () => {
+    const {
+      changedIngredientIds = [],
+      changedCocktailIds = [],
+      prevCocktails = [],
+      prevIngredients = [],
+      allowSubstitutes = false,
+      byId,
+      byBase,
+      prevById,
+      prevByBase,
+    } = options;
+    let map = { ...prevMap };
 
-  const prevCocktailsById = new Map(prevCocktails.map((c) => [c.id, c]));
-  const nextCocktailsById = new Map(cocktails.map((c) => [c.id, c]));
-  const prevIngs = prevIngredients.length > 0 ? prevIngredients : ingredients;
-  const nextById = byId || new Map(ingredients.map((i) => [i.id, i]));
-  const nextByBase = byBase || buildByBase(ingredients);
-  const prevByIdMap = prevById || new Map(prevIngs.map((i) => [i.id, i]));
-  const prevByBaseMap = prevByBase || buildByBase(prevIngs);
+    const prevCocktailsById = new Map(prevCocktails.map((c) => [c.id, c]));
+    const nextCocktailsById = new Map(cocktails.map((c) => [c.id, c]));
+    const prevIngs = prevIngredients.length > 0 ? prevIngredients : ingredients;
+    const nextById = byId || new Map(ingredients.map((i) => [i.id, i]));
+    const nextByBase = byBase || buildByBase(ingredients);
+    const prevByIdMap = prevById || new Map(prevIngs.map((i) => [i.id, i]));
+    const prevByBaseMap = prevByBase || buildByBase(prevIngs);
 
-  // Handle changed cocktails (added/edited/removed)
-  changedCocktailIds.forEach((id) => {
-    const prevC = prevCocktailsById.get(id);
-    if (prevC) {
-      map = removeCocktailFromUsageMap(map, prevIngs, prevC, {
-        allowSubstitutes,
-        byId: prevByIdMap,
-        byBase: prevByBaseMap,
-      });
-    } else {
-      // Ensure removed id is not present
-      for (const ingId of Object.keys(map)) {
-        const arr = map[ingId];
-        const idx = arr.indexOf(id);
-        if (idx >= 0) {
-          arr.splice(idx, 1);
-          if (arr.length === 0) delete map[ingId];
-        }
-      }
-    }
-    const nextC = nextCocktailsById.get(id);
-    if (nextC) {
-      map = addCocktailToUsageMap(map, ingredients, nextC, {
-        allowSubstitutes,
-        byId: nextById,
-        byBase: nextByBase,
-      });
-    }
-  });
-
-  // Handle changed ingredients
-  if (changedIngredientIds.length > 0) {
-    const changedSet = new Set(changedIngredientIds);
-    const prevIngsById = prevByIdMap;
-    const nextIngsById = nextById;
-    const affectedCocktails = new Set();
-
-    cocktails.forEach((cocktail) => {
-      if (!Array.isArray(cocktail.ingredients)) return;
-      for (const r of cocktail.ingredients) {
-        const ingPrev = prevIngsById.get(r.ingredientId);
-        const ingNext = nextIngsById.get(r.ingredientId);
-        const basePrev = ingPrev?.baseIngredientId ?? ingPrev?.id;
-        const baseNext = ingNext?.baseIngredientId ?? ingNext?.id;
-        if (
-          changedSet.has(r.ingredientId) ||
-          changedSet.has(basePrev) ||
-          changedSet.has(baseNext)
-        ) {
-          affectedCocktails.add(cocktail.id);
-          break;
-        }
-        if (Array.isArray(r.substitutes)) {
-          if (r.substitutes.some((s) => changedSet.has(s.id))) {
-            affectedCocktails.add(cocktail.id);
-            break;
-          }
-        }
-      }
-    });
-
-    affectedCocktails.forEach((id) => {
-      const prevC = prevCocktailsById.get(id) || nextCocktailsById.get(id);
+    // Handle changed cocktails (added/edited/removed)
+    changedCocktailIds.forEach((id) => {
+      const prevC = prevCocktailsById.get(id);
       if (prevC) {
         map = removeCocktailFromUsageMap(map, prevIngs, prevC, {
           allowSubstitutes,
           byId: prevByIdMap,
           byBase: prevByBaseMap,
         });
+      } else {
+        // Ensure removed id is not present
+        for (const ingId of Object.keys(map)) {
+          const arr = map[ingId];
+          const idx = arr.indexOf(id);
+          if (idx >= 0) {
+            arr.splice(idx, 1);
+            if (arr.length === 0) delete map[ingId];
+          }
+        }
       }
       const nextC = nextCocktailsById.get(id);
       if (nextC) {
@@ -177,98 +134,153 @@ export function updateUsageMap(prevMap, ingredients, cocktails, options = {}) {
         });
       }
     });
-  }
 
-  return map;
+    // Handle changed ingredients
+    if (changedIngredientIds.length > 0) {
+      const changedSet = new Set(changedIngredientIds);
+      const prevIngsById = prevByIdMap;
+      const nextIngsById = nextById;
+      const affectedCocktails = new Set();
+
+      cocktails.forEach((cocktail) => {
+        if (!Array.isArray(cocktail.ingredients)) return;
+        for (const r of cocktail.ingredients) {
+          const ingPrev = prevIngsById.get(r.ingredientId);
+          const ingNext = nextIngsById.get(r.ingredientId);
+          const basePrev = ingPrev?.baseIngredientId ?? ingPrev?.id;
+          const baseNext = ingNext?.baseIngredientId ?? ingNext?.id;
+          if (
+            changedSet.has(r.ingredientId) ||
+            changedSet.has(basePrev) ||
+            changedSet.has(baseNext)
+          ) {
+            affectedCocktails.add(cocktail.id);
+            break;
+          }
+          if (Array.isArray(r.substitutes)) {
+            if (r.substitutes.some((s) => changedSet.has(s.id))) {
+              affectedCocktails.add(cocktail.id);
+              break;
+            }
+          }
+        }
+      });
+
+      affectedCocktails.forEach((id) => {
+        const prevC = prevCocktailsById.get(id) || nextCocktailsById.get(id);
+        if (prevC) {
+          map = removeCocktailFromUsageMap(map, prevIngs, prevC, {
+            allowSubstitutes,
+            byId: prevByIdMap,
+            byBase: prevByBaseMap,
+          });
+        }
+        const nextC = nextCocktailsById.get(id);
+        if (nextC) {
+          map = addCocktailToUsageMap(map, ingredients, nextC, {
+            allowSubstitutes,
+            byId: nextById,
+            byBase: nextByBase,
+          });
+        }
+      });
+    }
+
+    return map;
+  });
 }
 
 export function addCocktailToUsageMap(prevMap, ingredients, cocktail, options = {}) {
-  const { allowSubstitutes = false, byId, byBase } = options;
-  const map = { ...prevMap };
-  const byIdMap = byId || new Map(ingredients.map((i) => [i.id, i]));
-  const byBaseMap = byBase || buildByBase(ingredients);
-  const add = (id) => {
-    if (id == null) return;
-    if (map[id]) {
-      if (!map[id].includes(cocktail.id)) map[id].push(cocktail.id);
-    } else {
-      map[id] = [cocktail.id];
-    }
-  };
-  if (Array.isArray(cocktail.ingredients)) {
-    cocktail.ingredients.forEach((r) => {
-      if (r.ingredientId == null) return;
-      const ing = byIdMap.get(r.ingredientId);
-      if (!ing) return;
-      const baseId = ing.baseIngredientId ?? ing.id;
-      const group = byBaseMap.get(baseId) || [];
-
-      add(ing.id);
-
-      if (ing.id === baseId) {
-        group.forEach((item) => {
-          if (item.id !== baseId) add(item.id);
-        });
+  return profile("addCocktailToUsageMap", () => {
+    const { allowSubstitutes = false, byId, byBase } = options;
+    const map = { ...prevMap };
+    const byIdMap = byId || new Map(ingredients.map((i) => [i.id, i]));
+    const byBaseMap = byBase || buildByBase(ingredients);
+    const add = (id) => {
+      if (id == null) return;
+      if (map[id]) {
+        if (!map[id].includes(cocktail.id)) map[id].push(cocktail.id);
       } else {
-        add(baseId);
-        if (allowSubstitutes || r.allowBrandedSubstitutes) {
-          group.forEach((item) => {
-            if (item.id !== ing.id && item.id !== baseId) add(item.id);
-          });
-        }
+        map[id] = [cocktail.id];
       }
+    };
+    if (Array.isArray(cocktail.ingredients)) {
+      cocktail.ingredients.forEach((r) => {
+        if (r.ingredientId == null) return;
+        const ing = byIdMap.get(r.ingredientId);
+        if (!ing) return;
+        const baseId = ing.baseIngredientId ?? ing.id;
+        const group = byBaseMap.get(baseId) || [];
 
-      if (Array.isArray(r.substitutes)) {
-        r.substitutes.forEach((s) => add(s.id));
-      }
-    });
-  }
-  return map;
+        add(ing.id);
+
+        if (ing.id === baseId) {
+          group.forEach((item) => {
+            if (item.id !== baseId) add(item.id);
+          });
+        } else {
+          add(baseId);
+          if (allowSubstitutes || r.allowBrandedSubstitutes) {
+            group.forEach((item) => {
+              if (item.id !== ing.id && item.id !== baseId) add(item.id);
+            });
+          }
+        }
+
+        if (Array.isArray(r.substitutes)) {
+          r.substitutes.forEach((s) => add(s.id));
+        }
+      });
+    }
+    return map;
+  });
 }
 
 export function removeCocktailFromUsageMap(prevMap, ingredients, cocktail, options = {}) {
-  const { allowSubstitutes = false, byId, byBase } = options;
-  const map = { ...prevMap };
-  if (!cocktail) return map;
-  const byIdMap = byId || new Map(ingredients.map((i) => [i.id, i]));
-  const byBaseMap = byBase || buildByBase(ingredients);
-  const remove = (id) => {
-    if (id == null) return;
-    const arr = map[id];
-    if (!Array.isArray(arr)) return;
-    const idx = arr.indexOf(cocktail.id);
-    if (idx >= 0) arr.splice(idx, 1);
-    if (arr.length === 0) delete map[id];
-  };
-  if (Array.isArray(cocktail.ingredients)) {
-    cocktail.ingredients.forEach((r) => {
-      if (r.ingredientId == null) return;
-      const ing = byIdMap.get(r.ingredientId);
-      if (!ing) return;
-      const baseId = ing.baseIngredientId ?? ing.id;
-      const group = byBaseMap.get(baseId) || [];
+  return profile("removeCocktailFromUsageMap", () => {
+    const { allowSubstitutes = false, byId, byBase } = options;
+    const map = { ...prevMap };
+    if (!cocktail) return map;
+    const byIdMap = byId || new Map(ingredients.map((i) => [i.id, i]));
+    const byBaseMap = byBase || buildByBase(ingredients);
+    const remove = (id) => {
+      if (id == null) return;
+      const arr = map[id];
+      if (!Array.isArray(arr)) return;
+      const idx = arr.indexOf(cocktail.id);
+      if (idx >= 0) arr.splice(idx, 1);
+      if (arr.length === 0) delete map[id];
+    };
+    if (Array.isArray(cocktail.ingredients)) {
+      cocktail.ingredients.forEach((r) => {
+        if (r.ingredientId == null) return;
+        const ing = byIdMap.get(r.ingredientId);
+        if (!ing) return;
+        const baseId = ing.baseIngredientId ?? ing.id;
+        const group = byBaseMap.get(baseId) || [];
 
-      remove(ing.id);
+        remove(ing.id);
 
-      if (ing.id === baseId) {
-        group.forEach((item) => {
-          if (item.id !== baseId) remove(item.id);
-        });
-      } else {
-        remove(baseId);
-        if (allowSubstitutes || r.allowBrandedSubstitutes) {
+        if (ing.id === baseId) {
           group.forEach((item) => {
-            if (item.id !== ing.id && item.id !== baseId) remove(item.id);
+            if (item.id !== baseId) remove(item.id);
           });
+        } else {
+          remove(baseId);
+          if (allowSubstitutes || r.allowBrandedSubstitutes) {
+            group.forEach((item) => {
+              if (item.id !== ing.id && item.id !== baseId) remove(item.id);
+            });
+          }
         }
-      }
 
-      if (Array.isArray(r.substitutes)) {
-        r.substitutes.forEach((s) => remove(s.id));
-      }
-    });
-  }
-  return map;
+        if (Array.isArray(r.substitutes)) {
+          r.substitutes.forEach((s) => remove(s.id));
+        }
+      });
+    }
+    return map;
+  });
 }
 
 export function applyUsageMapToIngredients(ingredients, usageMap, cocktails) {

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -1,0 +1,21 @@
+export function profile<T>(id: string, fn: () => T): T {
+  const startTime = Date.now();
+  const startedAt = new Date(startTime).toISOString();
+  try {
+    return fn();
+  } finally {
+    const duration = Date.now() - startTime;
+    console.log(`[${id}] start=${startedAt} duration=${duration}ms`);
+  }
+}
+
+export async function profileAsync<T>(id: string, fn: () => Promise<T>): Promise<T> {
+  const startTime = Date.now();
+  const startedAt = new Date(startTime).toISOString();
+  try {
+    return await fn();
+  } finally {
+    const duration = Date.now() - startTime;
+    console.log(`[${id}] start=${startedAt} duration=${duration}ms`);
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce utility for profiling synchronous and async operations with action id, start time and duration
- Wrap ingredient usage calculations and updates with profiling to log their execution time
- Log timing for UI placement recalculation to identify costly operations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c19ee1b9c88326876a7fa0884e32e6