### PR TITLE
chore: align profile logging with SQL format

### DIFF
--- a/src/components/CocktailIngredientRow.tsx
+++ b/src/components/CocktailIngredientRow.tsx
@@ -122,7 +122,8 @@ const CocktailIngredientRow = memo(function CocktailIngredientRow({
     const startedAt = new Date(start).toISOString();
     if (!nameAnchorRef.current) {
       const duration = Date.now() - start;
-      console.log(`[recalcPlacement] start=${startedAt} duration=${duration}ms`);
+      const endedAt = new Date().toISOString();
+      console.log(`[${endedAt}] recalcPlacement start=${startedAt} duration=${duration}ms`);
       return;
     }
     nameAnchorRef.current.measureInWindow((x, y, w, h) => {
@@ -156,7 +157,8 @@ const CocktailIngredientRow = memo(function CocktailIngredientRow({
       setNameWidth(w || nameWidth);
 
       const duration = Date.now() - start;
-      console.log(`[recalcPlacement] start=${startedAt} duration=${duration}ms`);
+      const endedAt = new Date().toISOString();
+      console.log(`[${endedAt}] recalcPlacement start=${startedAt} duration=${duration}ms`);
     });
   }, [kbHeight, suggestions.length, nameWidth]);
 

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -5,7 +5,8 @@ export function profile<T>(id: string, fn: () => T): T {
     return fn();
   } finally {
     const duration = Date.now() - startTime;
-    console.log(`[${id}] start=${startedAt} duration=${duration}ms`);
+    const endedAt = new Date().toISOString();
+    console.log(`[${endedAt}] ${id} start=${startedAt} duration=${duration}ms`);
   }
 }
 
@@ -16,6 +17,7 @@ export async function profileAsync<T>(id: string, fn: () => Promise<T>): Promise
     return await fn();
   } finally {
     const duration = Date.now() - startTime;
-    console.log(`[${id}] start=${startedAt} duration=${duration}ms`);
+    const endedAt = new Date().toISOString();
+    console.log(`[${endedAt}] ${id} start=${startedAt} duration=${duration}ms`);
   }
 }


### PR DESCRIPTION
## Summary
- log profiling messages with timestamp-first format like SQL logs
- update ingredient placement logs to match SQL-style timestamps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1b278b87883269e5e264dc4533782