### PR TITLE
Use microtask for faster ingredient persistence

### DIFF
--- a/src/screens/Ingredients/IngredientDetailsScreen.tsx
+++ b/src/screens/Ingredients/IngredientDetailsScreen.tsx
@@ -17,7 +17,6 @@ import {
   ActivityIndicator,
   Platform,
   BackHandler,
-  InteractionManager,
 } from "react-native";
 import {
   useNavigation,
@@ -473,12 +472,10 @@ export default function IngredientDetailsScreen() {
         });
       });
 
-      InteractionManager.runAfterInteractions(() => {
-        (async () => {
-          for (const item of updates) {
-            await saveIngredient(item);
-          }
-        })();
+      queueMicrotask(async () => {
+        for (const item of updates) {
+          await saveIngredient(item);
+        }
       });
     },
     [


### PR DESCRIPTION
## Summary
- remove InteractionManager wrapper and persist ingredient updates with `queueMicrotask`

## Testing
- `npm test`
- `node - <<'NODE'
function makeProfiler(id){const startTime=Date.now();const startedAt=new Date(startTime).toISOString();return{step(label){const now=Date.now();console.log(`[${new Date(now).toISOString()}] ${id} ${label} start=${startedAt} +${now-startTime}ms`);}}}
const profiler=makeProfiler('[IngredientDetails] toggleShopping');
const startCpu=Date.now();while(Date.now()-startCpu<80){};profiler.step('CPU work finished');const afterCpu=Date.now();setTimeout(()=>{profiler.step('global update');setTimeout(()=>{const delay=Date.now()-afterCpu;profiler.step(`persist inShoppingList=true (delay=${delay}ms)`);queueMicrotask(()=>{profiler.step('persist done');});},0);},0);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c1c6c1f9bc8326bbae5dc518dcf64d