### PR TITLE
feat: speed up ingredient state updates

### DIFF
--- a/src/data/sqlite.ts
+++ b/src/data/sqlite.ts
@@ -108,6 +108,7 @@ export function initDatabase() {
         CREATE INDEX IF NOT EXISTS idx_cocktail_ingredients_ingredientId ON cocktail_ingredients (ingredientId);
         CREATE INDEX IF NOT EXISTS idx_ingredients_searchName ON ingredients (searchName);
         CREATE INDEX IF NOT EXISTS idx_ingredients_inBar ON ingredients (inBar);
+        CREATE INDEX IF NOT EXISTS idx_ingredients_inShoppingList ON ingredients (inShoppingList);
         CREATE INDEX IF NOT EXISTS idx_ingredients_name ON ingredients (name);
         CREATE INDEX IF NOT EXISTS idx_ingredients_baseIngredientId ON ingredients (baseIngredientId);
       `);

--- a/src/domain/ingredientsAvailabilityCache.ts
+++ b/src/domain/ingredientsAvailabilityCache.ts
@@ -74,13 +74,16 @@ export function initIngredientsAvailability(ingredients, cocktails, usageMap, ig
   return cache;
 }
 
-export function updateIngredientAvailability(changedId, ingredients) {
+export function updateIngredientAvailability(changedIds, ingredients) {
   ingredientsMap = new Map(ingredients.map((i) => [String(i.id), i]));
-  const affected = new Set([changedId]);
-  const relatedCocktails = usage[changedId] || [];
-  relatedCocktails.forEach((cid) => {
-    const cocktail = cocktailMap.get(cid);
-    (cocktail?.ingredients || []).forEach((r) => affected.add(r.ingredientId));
+  const list = Array.isArray(changedIds) ? changedIds : [changedIds];
+  const affected = new Set(list);
+  list.forEach((changedId) => {
+    const relatedCocktails = usage[changedId] || [];
+    relatedCocktails.forEach((cid) => {
+      const cocktail = cocktailMap.get(cid);
+      (cocktail?.ingredients || []).forEach((r) => affected.add(r.ingredientId));
+    });
   });
   affected.forEach((id) => {
     cache.set(id, computeForIngredient(id));

--- a/src/screens/Ingredients/AllIngredientsScreen.tsx
+++ b/src/screens/Ingredients/AllIngredientsScreen.tsx
@@ -81,9 +81,7 @@ export default function AllIngredientsScreen() {
         return next;
       });
       try {
-        ids.forEach((id) => {
-          updateIngredientAvailability(id, updatedList);
-        });
+        updateIngredientAvailability(ids, updatedList);
       } catch {}
     }
   }, [setIngredients]);

--- a/src/screens/Ingredients/MyIngredientsScreen.tsx
+++ b/src/screens/Ingredients/MyIngredientsScreen.tsx
@@ -114,10 +114,7 @@ export default function MyIngredientsScreen() {
         updatedList = Array.from(next.values());
         return next;
       });
-      let map;
-      ids.forEach((id) => {
-        map = updateIngredientAvailability(id, updatedList);
-      });
+      const map = updateIngredientAvailability(ids, updatedList);
       setAvailableMap(new Map(map));
     }
   }, [setIngredients]);


### PR DESCRIPTION
## Summary
- index ingredient shopping flag
- recompute ingredient availability in batches
- avoid redundant loops when toggling ingredient state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1d30529908326ad548891c24585cf