### PR TITLE
Replace deprecated image picker options and SafeAreaView usage

### DIFF
--- a/src/components/HeaderWithSearch.tsx
+++ b/src/components/HeaderWithSearch.tsx
@@ -1,11 +1,6 @@
 import React, { useMemo, useState } from "react";
-import {
-  View,
-  TextInput,
-  TouchableOpacity,
-  StyleSheet,
-  SafeAreaView,
-} from "react-native";
+import { View, TextInput, TouchableOpacity, StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useTheme } from "react-native-paper";
 import GeneralMenu from "./GeneralMenu";

--- a/src/components/PlainHeader.tsx
+++ b/src/components/PlainHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView, Platform } from "react-native";
+import { View, Text, TouchableOpacity, StyleSheet, Platform } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import { HEADER_HEIGHT } from "../constants/layout";

--- a/src/screens/Cocktails/AddCocktailScreen.tsx
+++ b/src/screens/Cocktails/AddCocktailScreen.tsx
@@ -450,7 +450,7 @@ export default function AddCocktailScreen() {
       return;
     }
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: "images",
       allowsEditing: true,
       quality: 0.8,
     });

--- a/src/screens/Cocktails/EditCocktailScreen.tsx
+++ b/src/screens/Cocktails/EditCocktailScreen.tsx
@@ -603,7 +603,7 @@ export default function EditCocktailScreen() {
       return;
     }
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: "images",
       allowsEditing: true,
       quality: 0.7,
     });

--- a/src/screens/Ingredients/AddIngredientScreen.tsx
+++ b/src/screens/Ingredients/AddIngredientScreen.tsx
@@ -289,7 +289,7 @@ export default function AddIngredientScreen() {
     }
     await waitForInteractions();
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: "images",
       allowsEditing: true,
       quality: 0.7,
     });

--- a/src/screens/Ingredients/EditIngredientScreen.tsx
+++ b/src/screens/Ingredients/EditIngredientScreen.tsx
@@ -345,7 +345,7 @@ export default function EditIngredientScreen() {
     }
     await waitForInteractions();
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: "images",
       allowsEditing: true,
       quality: 0.7,
     });


### PR DESCRIPTION
## Summary
- replace deprecated ImagePicker.MediaTypeOptions usage with the supported media type string
- migrate SafeAreaView components to react-native-safe-area-context to silence deprecation warning

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e3c833e3048326ad1128f4481160f4