### PR TITLE
Migrate ingredients data layer to reactive store

### DIFF
--- a/scripts/importIngredients.js
+++ b/scripts/importIngredients.js
@@ -8,7 +8,6 @@ import {
   getAllIngredients,
   saveAllIngredients,
 } from "../src/data/ingredients";
-import { initDatabase } from "../src/data/sqlite";
 
 const IMPORT_FLAG_KEY = "ingredients_imported_flag";
 
@@ -64,7 +63,6 @@ function normalize(raw) {
 
 export async function importIngredients({ force = false } = {}) {
   try {
-    await initDatabase();
     // щоб не перезаливати на кожному старті
     if (!force) {
       const already = await AsyncStorage.getItem(IMPORT_FLAG_KEY);

--- a/src/data/backup.ts
+++ b/src/data/backup.ts
@@ -8,7 +8,6 @@ import { Image } from 'react-native';
 import { ASSET_MAP } from '../../scripts/assetMap';
 import { getAllIngredients, saveAllIngredients } from './ingredients';
 import { getAllCocktails, replaceAllCocktails } from './cocktails';
-import { withWriteTransactionAsync } from './sqlite';
 import { stripFalse } from './stripFalse';
 import { normalizeImportData } from './normalizeBackupData';
 
@@ -158,10 +157,8 @@ export async function importAllData() {
     });
     const data = JSON.parse(contents);
     const { ingredients, cocktails } = normalizeImportData(data, resolvePhoto);
-    await withWriteTransactionAsync(async (tx) => {
-      await saveAllIngredients(ingredients, tx);
-      await replaceAllCocktails(cocktails, tx);
-    });
+    await saveAllIngredients(ingredients);
+    await replaceAllCocktails(cocktails);
     return true;
   } catch (e) {
     console.error('Import failed', e);

--- a/src/data/cocktails.ts
+++ b/src/data/cocktails.ts
@@ -240,7 +240,7 @@ export function removeCocktail(list: CocktailRecord[], id: number): CocktailReco
 /** Replace whole storage (use carefully) */
 export async function replaceAllCocktails(
   cocktails: CocktailRecord[],
-  tx: any
+  tx?: any
 ): Promise<CocktailRecord[]> {
   const normalized = Array.isArray(cocktails)
     ? cocktails.map(sanitizeCocktail)

--- a/src/data/ingredients.legacy.ts
+++ b/src/data/ingredients.legacy.ts
@@ -1,0 +1,352 @@
+import db, {
+  query,
+  initDatabase,
+  withWriteTransactionAsync,
+} from "./sqlite";
+import { normalizeSearch } from "../utils/normalizeSearch";
+import { WORD_SPLIT_RE } from "../utils/wordPrefixMatch";
+import { sortByName } from "../utils/sortByName";
+import { IngredientRecord } from "./types";
+
+const now = () => Date.now();
+const genId = () => now();
+
+// Supports optional LIMIT/OFFSET for pagination to avoid loading the entire table
+export async function getAllIngredients({
+  limit,
+  offset,
+}: { limit?: number; offset?: number } = {}): Promise<IngredientRecord[]> {
+  await initDatabase();
+  let sql =
+    "SELECT id, name, description, tags, baseIngredientId, usageCount, singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList FROM ingredients ORDER BY name";
+  const params: string[] = [];
+  if (typeof limit === "number") {
+    sql += " LIMIT ?";
+    params.push(String(limit));
+  }
+  if (typeof offset === "number") {
+    sql += " OFFSET ?";
+    params.push(String(offset));
+  }
+  const res = await query(sql, params);
+  const list = res.rows._array.map((r) => ({
+    id: Number(r.id),
+    name: r.name,
+    description: r.description,
+    tags: r.tags ? JSON.parse(r.tags) : [],
+    baseIngredientId: r.baseIngredientId != null ? Number(r.baseIngredientId) : null,
+    usageCount: r.usageCount ?? 0,
+    singleCocktailName: r.singleCocktailName,
+    searchName: r.searchName,
+    searchTokens: r.searchTokens ? JSON.parse(r.searchTokens) : [],
+    photoUri: r.photoUri,
+    inBar: !!r.inBar,
+    inShoppingList: !!r.inShoppingList,
+  }));
+  return list;
+}
+
+export async function getIngredientsByIds(ids: number[]): Promise<IngredientRecord[]> {
+  const list = Array.isArray(ids) ? ids.filter((id) => id != null) : [];
+  if (list.length === 0) return [];
+  const placeholders = list.map(() => "?").join(", ");
+  await initDatabase();
+  const res = await query(
+    `SELECT id, name, description, tags, baseIngredientId, usageCount, singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList FROM ingredients WHERE id IN (${placeholders})`,
+    list.map((id) => String(id))
+  );
+  const rows = res.rows._array
+    .map((r) => ({
+      id: Number(r.id),
+      name: r.name,
+      description: r.description,
+      tags: r.tags ? JSON.parse(r.tags) : [],
+      baseIngredientId: r.baseIngredientId != null ? Number(r.baseIngredientId) : null,
+      usageCount: r.usageCount ?? 0,
+      singleCocktailName: r.singleCocktailName,
+      searchName: r.searchName,
+      searchTokens: r.searchTokens ? JSON.parse(r.searchTokens) : [],
+      photoUri: r.photoUri,
+      inBar: !!r.inBar,
+      inShoppingList: !!r.inShoppingList,
+    }))
+    .sort(sortByName);
+  return rows;
+}
+
+export async function getIngredientsByBaseIds(baseIds: number[], { inBarOnly = false }: { inBarOnly?: boolean } = {}): Promise<IngredientRecord[]> {
+  const list = Array.isArray(baseIds) ? baseIds.filter((id) => id != null) : [];
+  if (list.length === 0) return [];
+  const placeholders = list.map(() => "?").join(", ");
+  await initDatabase();
+  const res = await query(
+    `SELECT id, name, description, tags, baseIngredientId, usageCount, singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList FROM ingredients WHERE baseIngredientId IN (${placeholders})${inBarOnly ? ' AND inBar = 1' : ''}`,
+    list.map((id) => String(id))
+  );
+  const rows = res.rows._array
+    .map((r) => ({
+      id: Number(r.id),
+      name: r.name,
+      description: r.description,
+      tags: r.tags ? JSON.parse(r.tags) : [],
+      baseIngredientId: r.baseIngredientId != null ? Number(r.baseIngredientId) : null,
+      usageCount: r.usageCount ?? 0,
+      singleCocktailName: r.singleCocktailName,
+      searchName: r.searchName,
+      searchTokens: r.searchTokens ? JSON.parse(r.searchTokens) : [],
+      photoUri: r.photoUri,
+      inBar: !!r.inBar,
+      inShoppingList: !!r.inShoppingList,
+    }))
+    .sort(sortByName);
+  return rows;
+}
+
+export function buildIndex(list: IngredientRecord[]): Record<number, IngredientRecord> {
+  return list.reduce((acc, item) => {
+    acc[item.id] = item;
+    return acc;
+  }, {});
+}
+
+async function upsertIngredient(item: IngredientRecord): Promise<void> {
+  await initDatabase();
+  await withWriteTransactionAsync(async (tx) => {
+    await tx.runAsync(
+      `INSERT OR REPLACE INTO ingredients (
+        id, name, description, tags, baseIngredientId, usageCount,
+        singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      String(item.id),
+      item.name ?? null,
+      item.description ?? null,
+      item.tags ? JSON.stringify(item.tags) : null,
+      item.baseIngredientId ?? null,
+      item.usageCount ?? 0,
+      item.singleCocktailName ?? null,
+      item.searchName ?? null,
+      item.searchTokens ? JSON.stringify(item.searchTokens) : null,
+      item.photoUri ?? null,
+      item.inBar ? 1 : 0,
+      item.inShoppingList ? 1 : 0
+    );
+  });
+}
+
+export async function saveAllIngredients(ingredients, tx) {
+  const list = Array.isArray(ingredients) ? ingredients : [];
+  await initDatabase();
+  const run = async (innerTx) => {
+    await innerTx.runAsync("DELETE FROM ingredients");
+    if (list.length) {
+      const placeholders = list
+        .map(() =>
+          "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        .join(", ");
+      const params = list.flatMap((item) => [
+        String(item.id),
+        item.name ?? null,
+        item.description ?? null,
+        item.tags ? JSON.stringify(item.tags) : null,
+        item.baseIngredientId ?? null,
+        item.usageCount ?? 0,
+        item.singleCocktailName ?? null,
+        item.searchName ?? null,
+        item.searchTokens ? JSON.stringify(item.searchTokens) : null,
+        item.photoUri ?? null,
+        item.inBar ? 1 : 0,
+        item.inShoppingList ? 1 : 0,
+      ]);
+      await innerTx.runAsync(
+        `INSERT OR REPLACE INTO ingredients (
+          id, name, description, tags, baseIngredientId, usageCount,
+          singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
+        ) VALUES ${placeholders}`,
+        params
+      );
+    }
+  };
+  if (tx) {
+    await run(tx);
+  } else {
+    await withWriteTransactionAsync(run);
+  }
+}
+
+export function updateIngredientById(map, updated) {
+  const prev = map.get(updated.id);
+  if (!prev) return map;
+  const next = new Map(map);
+  next.set(updated.id, { ...prev, ...updated });
+  return next;
+}
+
+function sanitizeIngredient(i: Partial<IngredientRecord>): IngredientRecord {
+  const id = Number(i?.id ?? genId());
+  const name = String(i?.name ?? "").trim();
+  const searchName = normalizeSearch(name);
+  const searchTokens = searchName.split(WORD_SPLIT_RE).filter(Boolean);
+  return {
+    id,
+    name,
+    description: i?.description ?? null,
+    tags: Array.isArray(i?.tags) ? i.tags : [],
+    baseIngredientId: i?.baseIngredientId ?? null,
+    usageCount: Number(i?.usageCount ?? 0),
+    singleCocktailName: i?.singleCocktailName ?? null,
+    searchName,
+    searchTokens,
+    photoUri: i?.photoUri ?? null,
+    inBar: !!i?.inBar,
+    inShoppingList: !!i?.inShoppingList,
+  };
+}
+
+export async function addIngredient(ingredient) {
+  const item = sanitizeIngredient({ ...ingredient, id: ingredient?.id ?? genId() });
+  await upsertIngredient(item);
+  return item;
+}
+
+export async function saveIngredient(updated) {
+  await initDatabase();
+  if (!updated?.id) return;
+  const name = String(updated.name ?? "").trim();
+  const searchName = normalizeSearch(name);
+  let item;
+  if (
+    updated.searchName === searchName &&
+    Array.isArray(updated.searchTokens)
+  ) {
+    item = {
+      id: Number(updated.id),
+      name,
+      description: updated.description ?? null,
+      tags: Array.isArray(updated.tags) ? updated.tags : [],
+      baseIngredientId: updated.baseIngredientId ?? null,
+      usageCount: Number(updated.usageCount ?? 0),
+      singleCocktailName: updated.singleCocktailName ?? null,
+      searchName,
+      searchTokens: updated.searchTokens,
+      photoUri: updated.photoUri ?? null,
+      inBar: !!updated.inBar,
+      inShoppingList: !!updated.inShoppingList,
+    };
+  } else {
+    item = sanitizeIngredient({ ...updated, name });
+  }
+  await upsertIngredient(item);
+  return item;
+}
+
+export async function updateIngredientFields(id, fields) {
+  await initDatabase();
+  if (!id || !fields || typeof fields !== "object") return;
+  const entries = Object.entries(fields);
+  if (!entries.length) return;
+
+  const converters = {
+    name: (v) => v ?? null,
+    description: (v) => v ?? null,
+    tags: (v) => (v ? JSON.stringify(v) : null),
+    baseIngredientId: (v) => v ?? null,
+    usageCount: (v) => Number(v ?? 0),
+    singleCocktailName: (v) => v ?? null,
+    searchName: (v) => v ?? null,
+    searchTokens: (v) => (v ? JSON.stringify(v) : null),
+    photoUri: (v) => v ?? null,
+    inBar: (v) => (v ? 1 : 0),
+    inShoppingList: (v) => (v ? 1 : 0),
+  };
+
+  const parts = [];
+  const params = [];
+  for (const [key, value] of entries) {
+    if (converters[key]) {
+      parts.push(`${key} = ?`);
+      params.push(converters[key](value));
+    }
+  }
+  if (!parts.length) return;
+  params.push(String(id));
+  const sql = `UPDATE ingredients SET ${parts.join(", ")} WHERE id = ?`;
+  await withWriteTransactionAsync(async (tx) => {
+    await tx.runAsync(sql, params);
+  });
+}
+
+export async function flushPendingIngredients(list) {
+  const items = Array.isArray(list) ? list : [];
+  if (!items.length) return;
+  await initDatabase();
+  await withWriteTransactionAsync(async (tx) => {
+    for (const u of items) {
+      const item = sanitizeIngredient(u);
+      await tx.runAsync(
+        `INSERT OR REPLACE INTO ingredients (
+          id, name, description, tags, baseIngredientId, usageCount,
+          singleCocktailName, searchName, searchTokens, photoUri, inBar, inShoppingList
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        String(item.id),
+        item.name ?? null,
+        item.description ?? null,
+        item.tags ? JSON.stringify(item.tags) : null,
+        item.baseIngredientId ?? null,
+        item.usageCount ?? 0,
+        item.singleCocktailName ?? null,
+        item.searchName ?? null,
+        item.searchTokens ? JSON.stringify(item.searchTokens) : null,
+        item.photoUri ?? null,
+        item.inBar ? 1 : 0,
+        item.inShoppingList ? 1 : 0
+      );
+    }
+  });
+}
+
+export async function setIngredientsInShoppingList(ids, inShoppingList) {
+  const list = Array.isArray(ids)
+    ? Array.from(new Set(ids.filter((id) => id != null)))
+    : [];
+  if (!list.length) return;
+  await initDatabase();
+  const placeholders = list.map(() => "?").join(", ");
+  const value = inShoppingList ? 1 : 0;
+  await withWriteTransactionAsync(async (tx) => {
+    await tx.runAsync(
+      `UPDATE ingredients SET inShoppingList = ? WHERE id IN (${placeholders})`,
+      [value, ...list.map((id) => String(id))]
+    );
+  });
+}
+
+export async function toggleIngredientsInBar(ids) {
+  const list = Array.isArray(ids)
+    ? Array.from(new Set(ids.filter((id) => id != null)))
+    : [];
+  if (!list.length) return;
+  await initDatabase();
+  const placeholders = list.map(() => "?").join(", ");
+  await withWriteTransactionAsync(async (tx) => {
+    await tx.runAsync(
+      `UPDATE ingredients SET inBar = 1 - inBar WHERE id IN (${placeholders})`,
+      list.map((id) => String(id))
+    );
+  });
+}
+
+export function getIngredientById(id, index) {
+  return index ? index[id] : null;
+}
+
+export async function deleteIngredient(id) {
+  await initDatabase();
+  await withWriteTransactionAsync(async (tx) => {
+    await tx.runAsync("DELETE FROM ingredients WHERE id = ?", [String(id)]);
+  });
+}
+
+export function removeIngredient(list, id) {
+  return list.filter((item) => item.id !== id);
+}

--- a/src/data/storage.ts
+++ b/src/data/storage.ts
@@ -1,0 +1,41 @@
+declare const require: (name: string) => any;
+
+export interface StorageLike {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+}
+
+let storage: StorageLike;
+
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const module = require("@react-native-async-storage/async-storage");
+  const asyncStorage = module?.default ?? module;
+  if (
+    asyncStorage &&
+    typeof asyncStorage.getItem === "function" &&
+    typeof asyncStorage.setItem === "function"
+  ) {
+    storage = asyncStorage as StorageLike;
+  }
+} catch (error) {
+  // ignore, fall back to in-memory storage
+}
+
+if (!storage) {
+  const memory = new Map<string, string>();
+  storage = {
+    async getItem(key) {
+      return memory.has(key) ? memory.get(key)! : null;
+    },
+    async setItem(key, value) {
+      memory.set(key, value);
+    },
+    async removeItem(key) {
+      memory.delete(key);
+    },
+  };
+}
+
+export default storage;

--- a/src/domain/ingredients.ts
+++ b/src/domain/ingredients.ts
@@ -13,6 +13,9 @@ async function ensure() {
 export async function getAllIngredients(opts?: { limit?: number; offset?: number }) {
   return (await ensure()).getAllIngredients(opts);
 }
+export async function observeAllIngredients(listener) {
+  return (await ensure()).observeAllIngredients(listener);
+}
 export async function getIngredientsByIds(ids) {
   return (await ensure()).getIngredientsByIds(ids);
 }


### PR DESCRIPTION
## Summary
- replace the SQLite-backed ingredients module with a reactive store that persists through AsyncStorage (with an in-memory fallback), supports observers, and migrates existing records
- update domain services and backup/import scripts to use the new reactive APIs while keeping the legacy layer available for one-time import

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3d16c2fa88326b5e0b572fd2e0a96