### PR TITLE
Optimize ingredient availability recalculations

### DIFF
--- a/src/context/IngredientUsageContext.tsx
+++ b/src/context/IngredientUsageContext.tsx
@@ -10,6 +10,7 @@ import React, {
 import { updateUsageMap as updateUsageMapIncremental } from "../domain/ingredientUsage";
 import { sortByName } from "../utils/sortByName";
 import { groupIngredientsByTag } from "../domain/groupIngredientsByTag";
+import { makeIngredientAvailabilityKey } from "../utils/ingredientKeys";
 
 const IngredientUsageContext = createContext({
   usageMap: {},
@@ -29,6 +30,7 @@ const IngredientUsageContext = createContext({
   ingredientTags: [],
   setIngredientTags: () => {},
   ingredientsByTag: new Map(),
+  ingredientAvailabilityKey: 0,
 });
 
 export function IngredientUsageProvider({ children }) {
@@ -42,6 +44,11 @@ export function IngredientUsageProvider({ children }) {
   const ingredients = useMemo(
     () => Array.from(ingredientsMap.values()),
     [ingredientsMap]
+  );
+
+  const ingredientAvailabilityKey = useMemo(
+    () => makeIngredientAvailabilityKey(ingredients),
+    [ingredients]
   );
 
   const ingredientsById = useMemo(() => ingredientsMap, [ingredientsMap]);
@@ -155,12 +162,13 @@ export function IngredientUsageProvider({ children }) {
         setLoading,
         importing,
         setImporting,
-        baseIngredients,
-        ingredientTags,
-        setIngredientTags,
-        ingredientsByTag,
-      }}
-    >
+      baseIngredients,
+      ingredientTags,
+      setIngredientTags,
+      ingredientsByTag,
+      ingredientAvailabilityKey,
+    }}
+  >
       {children}
     </IngredientUsageContext.Provider>
   );

--- a/src/hooks/useAvailabilityIngredientsSnapshot.ts
+++ b/src/hooks/useAvailabilityIngredientsSnapshot.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Returns a cached reference to the most recent list of ingredients relevant
+ * for availability calculations. The reference only updates when the provided
+ * key changes, allowing callers to skip expensive recomputations triggered by
+ * unrelated field edits (e.g. shopping list toggles).
+ */
+export default function useAvailabilityIngredientsSnapshot<T>(
+  ingredients: T,
+  availabilityKey: number
+): T {
+  const ref = useRef<T>(ingredients);
+  const keyRef = useRef<number>(availabilityKey);
+
+  useEffect(() => {
+    if (keyRef.current !== availabilityKey) {
+      ref.current = ingredients;
+      keyRef.current = availabilityKey;
+    }
+  }, [ingredients, availabilityKey]);
+
+  return ref.current;
+}

--- a/src/hooks/useAvailableByIngredient.ts
+++ b/src/hooks/useAvailableByIngredient.ts
@@ -10,7 +10,8 @@ export default function useAvailableByIngredient(
   cocktails: any,
   usageMap: Record<string, number[]>,
   allowSubstitutes: boolean,
-  ignoreGarnish: boolean
+  ignoreGarnish: boolean,
+  ingredientKey?: number
 ) {
   const compute = useMemo(() => {
     return () => {
@@ -40,7 +41,7 @@ export default function useAvailableByIngredient(
       });
       return map;
     };
-  }, [ingredients, cocktails, usageMap, allowSubstitutes, ignoreGarnish]);
+  }, [ingredients, cocktails, usageMap, allowSubstitutes, ignoreGarnish, ingredientKey]);
 
   const [result, setResult] = useState(
     new Map<number, { count: number; name: string | null }>()

--- a/src/presentation/ShakerScreen.tsx
+++ b/src/presentation/ShakerScreen.tsx
@@ -8,6 +8,8 @@ import HeaderWithSearch from "../components/HeaderWithSearch";
 import IngredientRow, { INGREDIENT_ROW_HEIGHT } from "../components/IngredientRow";
 import useIngredientsData from "../hooks/useIngredientsData";
 import useAvailableByIngredient from "../hooks/useAvailableByIngredient";
+import useAvailabilityIngredientsSnapshot from "../hooks/useAvailabilityIngredientsSnapshot";
+import { makeIngredientAvailabilityKey } from "../utils/ingredientKeys";
 import {
   getAllowSubstitutes,
   addAllowSubstitutesListener,
@@ -85,12 +87,23 @@ export default function ShakerScreen({ navigation }: ShakerScreenProps) {
     };
   }, []);
 
+  const ingredientsKey = useMemo(
+    () => makeIngredientAvailabilityKey(ingredients),
+    [ingredients]
+  );
+
+  const ingredientsForAvailability = useAvailabilityIngredientsSnapshot(
+    ingredients || [],
+    ingredientsKey
+  );
+
   const availableByIngredient = useAvailableByIngredient(
-    ingredients,
+    ingredientsForAvailability,
     cocktails,
     usageMap,
     allowSubstitutes,
-    ignoreGarnish
+    ignoreGarnish,
+    ingredientsKey
   );
 
   const renderItem = useCallback(
@@ -167,11 +180,18 @@ export default function ShakerScreen({ navigation }: ShakerScreenProps) {
       computeAvailableCocktails({
         recipeIds,
         cocktails: cocktails || [],
-        ingredients: ingredients || [],
+        ingredients: ingredientsForAvailability,
         allowSubstitutes,
         ignoreGarnish,
       }),
-    [recipeIds, cocktails, ingredients, allowSubstitutes, ignoreGarnish]
+    [
+      recipeIds,
+      cocktails,
+      ingredientsKey,
+      allowSubstitutes,
+      ignoreGarnish,
+      ingredientsForAvailability,
+    ]
   );
 
   const handleClear = (): void => setSelectedIds([]);

--- a/src/screens/Cocktails/AllCocktailsScreen.tsx
+++ b/src/screens/Cocktails/AllCocktailsScreen.tsx
@@ -34,6 +34,8 @@ import {
   getCocktailIngredientInfo,
 } from "../../domain/cocktailIngredients";
 import { sortByName } from "../../utils/sortByName";
+import { makeIngredientAvailabilityKey } from "../../utils/ingredientKeys";
+import useAvailabilityIngredientsSnapshot from "../../hooks/useAvailabilityIngredientsSnapshot";
 
 export default function AllCocktailsScreen() {
   const theme = useTheme();
@@ -112,8 +114,18 @@ export default function AllCocktailsScreen() {
     };
   }, [isFocused]);
 
+  const ingredientsKey = useMemo(
+    () => makeIngredientAvailabilityKey(ingredients),
+    [ingredients]
+  );
+
+  const ingredientsForAvailability = useAvailabilityIngredientsSnapshot(
+    ingredients || [],
+    ingredientsKey
+  );
+
   const filtered = useMemo(() => {
-    const { ingMap, findBrand } = buildIngredientIndex(ingredients || []);
+    const { ingMap, findBrand } = buildIngredientIndex(ingredientsForAvailability);
     const q = normalizeSearch(searchDebounced);
     let list = cocktails;
     if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
@@ -142,7 +154,8 @@ export default function AllCocktailsScreen() {
       .sort(sortByName);
   }, [
     cocktails,
-    ingredients,
+    ingredientsForAvailability,
+    ingredientsKey,
     searchDebounced,
     selectedTagIds,
     ignoreGarnish,

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.tsx
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.tsx
@@ -36,6 +36,8 @@ import {
   buildIngredientIndex,
   getCocktailIngredientInfo,
 } from "../../domain/cocktailIngredients";
+import { makeIngredientAvailabilityKey } from "../../utils/ingredientKeys";
+import useAvailabilityIngredientsSnapshot from "../../hooks/useAvailabilityIngredientsSnapshot";
 
 export default function FavoriteCocktailsScreen() {
   const theme = useTheme();
@@ -119,8 +121,18 @@ export default function FavoriteCocktailsScreen() {
     };
   }, [isFocused]);
 
+  const ingredientsKey = useMemo(
+    () => makeIngredientAvailabilityKey(ingredients),
+    [ingredients]
+  );
+
+  const ingredientsForAvailability = useAvailabilityIngredientsSnapshot(
+    ingredients || [],
+    ingredientsKey
+  );
+
   const filtered = useMemo(() => {
-    const { ingMap, findBrand } = buildIngredientIndex(ingredients || []);
+    const { ingMap, findBrand } = buildIngredientIndex(ingredientsForAvailability);
     const q = normalizeSearch(searchDebounced);
     let list = cocktails.filter((c) => c.rating > 0 && c.rating >= minRating);
     if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
@@ -149,7 +161,8 @@ export default function FavoriteCocktailsScreen() {
       .sort(sortByName);
   }, [
     cocktails,
-    ingredients,
+    ingredientsForAvailability,
+    ingredientsKey,
     searchDebounced,
     selectedTagIds,
     ignoreGarnish,

--- a/src/screens/Cocktails/MyCocktailsScreen.tsx
+++ b/src/screens/Cocktails/MyCocktailsScreen.tsx
@@ -37,6 +37,8 @@ import {
   getCocktailIngredientInfo,
 } from "../../domain/cocktailIngredients";
 import { sortByName } from "../../utils/sortByName";
+import { makeIngredientAvailabilityKey } from "../../utils/ingredientKeys";
+import useAvailabilityIngredientsSnapshot from "../../hooks/useAvailabilityIngredientsSnapshot";
 
 const ITEM_HEIGHT = Math.max(COCKTAIL_ROW_HEIGHT, INGREDIENT_ROW_HEIGHT);
 
@@ -170,9 +172,23 @@ export default function MyCocktailsScreen() {
     return unsub;
   }, [navigation, setIngredients, setGlobalIngredients]);
 
+  const ingredientList = useMemo(
+    () => Array.from(ingredients.values()),
+    [ingredients]
+  );
+
+  const ingredientAvailabilityKey = useMemo(
+    () => makeIngredientAvailabilityKey(ingredientList),
+    [ingredientList]
+  );
+
+  const ingredientsForAvailability = useAvailabilityIngredientsSnapshot(
+    ingredientList,
+    ingredientAvailabilityKey
+  );
+
   const processed = useMemo(() => {
-    const ingredientArr = Array.from(ingredients.values());
-    const { ingMap, findBrand } = buildIngredientIndex(ingredientArr);
+    const { ingMap, findBrand } = buildIngredientIndex(ingredientsForAvailability);
     const q = normalizeSearch(searchDebounced);
     let list = cocktails;
     if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
@@ -206,7 +222,8 @@ export default function MyCocktailsScreen() {
       .sort(sortByName);
   }, [
     cocktails,
-    ingredients,
+    ingredientsForAvailability,
+    ingredientAvailabilityKey,
     searchDebounced,
     selectedTagIds,
     ignoreGarnish,

--- a/src/screens/ShakerResultsScreen.tsx
+++ b/src/screens/ShakerResultsScreen.tsx
@@ -20,6 +20,8 @@ import {
   buildIngredientIndex,
   getCocktailIngredientInfo,
 } from "../domain/cocktailIngredients";
+import { makeIngredientAvailabilityKey } from "../utils/ingredientKeys";
+import useAvailabilityIngredientsSnapshot from "../hooks/useAvailabilityIngredientsSnapshot";
 
 export default function ShakerResultsScreen({ route, navigation }) {
   const { availableIds = [], recipeIds = [] } = route.params || {};
@@ -63,8 +65,18 @@ export default function ShakerResultsScreen({ route, navigation }) {
     };
   }, []);
 
+  const ingredientsKey = useMemo(
+    () => makeIngredientAvailabilityKey(ingredients),
+    [ingredients]
+  );
+
+  const ingredientsForAvailability = useAvailabilityIngredientsSnapshot(
+    ingredients || [],
+    ingredientsKey
+  );
+
   const data = useMemo(() => {
-    const { ingMap, findBrand } = buildIngredientIndex(ingredients || []);
+    const { ingMap, findBrand } = buildIngredientIndex(ingredientsForAvailability);
     const availableSet = new Set(availableIds);
     const q = normalizeSearch(search);
     let list = cocktails.filter((c) => recipeIds.includes(c.id));
@@ -97,7 +109,8 @@ export default function ShakerResultsScreen({ route, navigation }) {
     });
   }, [
     cocktails,
-    ingredients,
+    ingredientsForAvailability,
+    ingredientsKey,
     recipeIds,
     availableIds,
     search,

--- a/src/utils/ingredientKeys.ts
+++ b/src/utils/ingredientKeys.ts
@@ -1,0 +1,54 @@
+const FNV_OFFSET = 2166136261 >>> 0;
+const FNV_PRIME = 16777619;
+
+function toNumber(value: any): number {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function hashString(hash: number, input: string): number {
+  for (let idx = 0; idx < input.length; idx += 1) {
+    hash ^= input.charCodeAt(idx);
+    hash = Math.imul(hash, FNV_PRIME);
+  }
+  return hash >>> 0;
+}
+
+function normalizeList(iterable: Iterable<any> | null | undefined) {
+  if (!iterable) return [];
+  const arr = Array.from(iterable);
+  return arr.sort((a, b) => toNumber(a?.id) - toNumber(b?.id));
+}
+
+/**
+ * Builds a stable hash for the parts of ingredient records that influence
+ * cocktail availability and matching logic.
+ *
+ * Fields intentionally excluded: values such as `inShoppingList` or
+ * description/photo metadata. They do not change availability calculations
+ * but previously still caused downstream selectors to recompute.
+ */
+export function makeIngredientAvailabilityKey(
+  iterable: Iterable<any> | null | undefined
+): number {
+  const list = normalizeList(iterable);
+  let hash = FNV_OFFSET;
+  for (const ing of list) {
+    const id = toNumber(ing?.id);
+    const baseId = toNumber(ing?.baseIngredientId ?? ing?.id);
+    const inBar = ing?.inBar ? 1 : 0;
+    hash ^= id;
+    hash = Math.imul(hash, FNV_PRIME);
+    hash ^= baseId;
+    hash = Math.imul(hash, FNV_PRIME);
+    hash ^= inBar;
+    hash = Math.imul(hash, FNV_PRIME);
+    if (ing?.name) {
+      hash = hashString(hash, String(ing.name));
+    }
+    if (ing?.searchName) {
+      hash = hashString(hash, String(ing.searchName));
+    }
+  }
+  return hash >>> 0;
+}


### PR DESCRIPTION
## Summary
- add ingredient availability hashing utilities and snapshot hook to ignore shopping-list only changes
- update cocktail and shaker screens to reuse cached ingredient lists when availability state is unchanged
- expose the availability hash through the ingredient usage context and extend availability calculations to use it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e44d429c3483268cabefe88ae39a4d