### PR TITLE
Optimize cocktail rating update performance

### DIFF
--- a/src/data/cocktails.ts
+++ b/src/data/cocktails.ts
@@ -216,6 +216,22 @@ export async function saveCocktail(
   return item as unknown as CocktailRecord;
 }
 
+export async function updateCocktailRating(
+  id: number,
+  rating: number
+): Promise<Pick<CocktailRecord, "id" | "rating" | "updatedAt">> {
+  await initDatabase();
+  const value = Math.min(5, Math.max(0, Number(rating ?? 0)));
+  const updatedAt = Date.now();
+  await withWriteTransactionAsync((tx) =>
+    tx.runAsync(
+      `UPDATE cocktails SET rating = ?, updatedAt = ? WHERE id = ?`,
+      [value, updatedAt, id]
+    )
+  );
+  return { id, rating: value, updatedAt };
+}
+
 export function updateCocktailById(list: CocktailRecord[], updated: CocktailRecord): CocktailRecord[] {
   const index = list.findIndex((c) => c.id === updated.id);
   if (index === -1) return list;

--- a/src/domain/cocktails.ts
+++ b/src/domain/cocktails.ts
@@ -22,6 +22,9 @@ export async function addCocktail(cocktail) {
 export async function saveCocktail(updated) {
   return (await ensure()).saveCocktail(updated);
 }
+export async function updateCocktailRating(id, rating) {
+  return (await ensure()).updateCocktailRating(id, rating);
+}
 export async function deleteCocktail(id) {
   return (await ensure()).deleteCocktail(id);
 }

--- a/src/screens/Cocktails/CocktailDetailsScreen.tsx
+++ b/src/screens/Cocktails/CocktailDetailsScreen.tsx
@@ -29,8 +29,8 @@ import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
 import {
   getCocktailById,
-  saveCocktail,
   updateCocktailById,
+  updateCocktailRating,
 } from "../../domain/cocktails";
 import {
   getIngredientsByIds,
@@ -240,17 +240,28 @@ export default function CocktailDetailsScreen() {
     async (value) => {
       if (!cocktail) return;
       const prev = cocktail;
-      const newRating = cocktail.rating === value ? 0 : value;
-      const updated = { ...cocktail, rating: newRating };
-      setCocktail(updated);
+      const nextRating = prev.rating === value ? 0 : value;
+      const normalized = Math.min(5, Math.max(0, Number(nextRating ?? 0)));
+      const optimistic = {
+        ...prev,
+        rating: normalized,
+        updatedAt: Date.now(),
+      };
+      setCocktail(optimistic);
       setGlobalCocktails((prevList) =>
-        Array.isArray(prevList) ? updateCocktailById(prevList, updated) : prevList
+        Array.isArray(prevList)
+          ? updateCocktailById(prevList, optimistic)
+          : prevList
       );
       try {
-        const saved = await saveCocktail(updated);
-        setCocktail(saved);
+        const saved = await updateCocktailRating(prev.id, normalized);
+        if (!saved) return;
+        const persisted = { ...optimistic, ...saved };
+        setCocktail(persisted);
         setGlobalCocktails((prevList) =>
-          Array.isArray(prevList) ? updateCocktailById(prevList, saved) : prevList
+          Array.isArray(prevList)
+            ? updateCocktailById(prevList, persisted)
+            : prevList
         );
       } catch (e) {
         setCocktail(prev);

--- a/src/screens/Cocktails/CocktailDetailsScreen.tsx
+++ b/src/screens/Cocktails/CocktailDetailsScreen.tsx
@@ -209,6 +209,11 @@ export default function CocktailDetailsScreen() {
   const [keepAwake, setKeepAwake] = useState(false);
   const [allowSubstitutes, setAllowSubstitutes] = useState(false);
   const showImperialLocked = useRef(false);
+  const skipNextGlobalSyncRef = useRef<{
+    remaining: number;
+    rating: number;
+    minUpdatedAt: number;
+  } | null>(null);
 
   const { ingMap, byBase, bySearch } = useMemo(
     () => buildIngredientIndex(ingredients),
@@ -242,10 +247,16 @@ export default function CocktailDetailsScreen() {
       const prev = cocktail;
       const nextRating = prev.rating === value ? 0 : value;
       const normalized = Math.min(5, Math.max(0, Number(nextRating ?? 0)));
+      const timestamp = Date.now();
       const optimistic = {
         ...prev,
         rating: normalized,
-        updatedAt: Date.now(),
+        updatedAt: timestamp,
+      };
+      skipNextGlobalSyncRef.current = {
+        remaining: 2,
+        rating: normalized,
+        minUpdatedAt: timestamp,
       };
       setCocktail(optimistic);
       setGlobalCocktails((prevList) =>
@@ -255,7 +266,10 @@ export default function CocktailDetailsScreen() {
       );
       try {
         const saved = await updateCocktailRating(prev.id, normalized);
-        if (!saved) return;
+        if (!saved) {
+          skipNextGlobalSyncRef.current = null;
+          return;
+        }
         const persisted = { ...optimistic, ...saved };
         setCocktail(persisted);
         setGlobalCocktails((prevList) =>
@@ -265,6 +279,12 @@ export default function CocktailDetailsScreen() {
         );
       } catch (e) {
         setCocktail(prev);
+        skipNextGlobalSyncRef.current = {
+          remaining: 1,
+          rating: prev.rating,
+          minUpdatedAt:
+            typeof prev.updatedAt === "number" ? prev.updatedAt : Date.now(),
+        };
         setGlobalCocktails((prevList) =>
           Array.isArray(prevList) ? updateCocktailById(prevList, prev) : prevList
         );
@@ -478,6 +498,20 @@ export default function CocktailDetailsScreen() {
   useEffect(() => {
     const updated = globalCocktails.find((c) => c.id === id);
     if (!updated) return;
+
+    const skipSync = skipNextGlobalSyncRef.current;
+    if (
+      skipSync &&
+      skipSync.remaining > 0 &&
+      updated.rating === skipSync.rating &&
+      updated.updatedAt >= skipSync.minUpdatedAt
+    ) {
+      skipSync.remaining -= 1;
+      if (skipSync.remaining <= 0) {
+        skipNextGlobalSyncRef.current = null;
+      }
+      return;
+    }
 
     const missingIngredient = (updated.ingredients || []).some(
       (r) =>


### PR DESCRIPTION
## Summary
- add a dedicated SQLite helper that updates only a cocktail's rating to avoid rewriting ingredient rows
- expose the new helper through the domain layer and use it in the cocktail details screen for faster optimistic rating updates

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68efd3630b5c8326a4c1584309b9d741