### PR TITLE
Avoid blocking rating UI on cocktail save

### DIFF
--- a/src/screens/Cocktails/CocktailDetailsScreen.tsx
+++ b/src/screens/Cocktails/CocktailDetailsScreen.tsx
@@ -236,28 +236,37 @@ export default function CocktailDetailsScreen() {
     navigation.navigate("AddCocktail", { initialCocktail: cocktail });
   }, [navigation, cocktail]);
 
+  const latestRatingRequest = useRef(0);
+
   const handleRate = useCallback(
-    async (value) => {
+    (value) => {
       if (!cocktail) return;
       const prev = cocktail;
       const newRating = cocktail.rating === value ? 0 : value;
       const updated = { ...cocktail, rating: newRating };
+      const requestId = latestRatingRequest.current + 1;
+      latestRatingRequest.current = requestId;
+
       setCocktail(updated);
       setGlobalCocktails((prevList) =>
         Array.isArray(prevList) ? updateCocktailById(prevList, updated) : prevList
       );
-      try {
-        const saved = await saveCocktail(updated);
-        setCocktail(saved);
-        setGlobalCocktails((prevList) =>
-          Array.isArray(prevList) ? updateCocktailById(prevList, saved) : prevList
-        );
-      } catch (e) {
-        setCocktail(prev);
-        setGlobalCocktails((prevList) =>
-          Array.isArray(prevList) ? updateCocktailById(prevList, prev) : prevList
-        );
-      }
+
+      saveCocktail(updated)
+        .then((saved) => {
+          if (latestRatingRequest.current !== requestId) return;
+          setCocktail(saved);
+          setGlobalCocktails((prevList) =>
+            Array.isArray(prevList) ? updateCocktailById(prevList, saved) : prevList
+          );
+        })
+        .catch(() => {
+          if (latestRatingRequest.current !== requestId) return;
+          setCocktail(prev);
+          setGlobalCocktails((prevList) =>
+            Array.isArray(prevList) ? updateCocktailById(prevList, prev) : prevList
+          );
+        });
     },
     [cocktail, setGlobalCocktails]
   );

--- a/src/screens/Cocktails/CocktailDetailsScreen.tsx
+++ b/src/screens/Cocktails/CocktailDetailsScreen.tsx
@@ -27,12 +27,13 @@ import {
 import { goBack } from "../../utils/navigation";
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
-import { getCocktailById } from "../../domain/cocktails";
+import { getCocktailById, saveCocktail, updateCocktailById } from "../../domain/cocktails";
 import {
   getIngredientsByIds,
   getIngredientsByBaseIds,
 } from "../../domain/ingredients";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
+import type { CocktailRecord } from "../../data/types";
 import { getGlassById } from "../../constants/glassware";
 import { withAlpha } from "../../utils/color";
 import {
@@ -194,6 +195,7 @@ export default function CocktailDetailsScreen() {
   const {
     ingredients: globalIngredients = [],
     cocktails: globalCocktails = [],
+    setCocktails: setGlobalCocktails,
   } = useIngredientUsage();
 
   const [cocktail, setCocktail] = useState(initialCocktail || null);
@@ -204,6 +206,11 @@ export default function CocktailDetailsScreen() {
   const [keepAwake, setKeepAwake] = useState(false);
   const [allowSubstitutes, setAllowSubstitutes] = useState(false);
   const showImperialLocked = useRef(false);
+  const ratingSaveRef = useRef<{
+    id: number;
+    prev: CocktailRecord;
+    optimistic: CocktailRecord;
+  } | null>(null);
 
   const { ingMap, byBase, bySearch } = useMemo(
     () => buildIngredientIndex(ingredients),
@@ -231,13 +238,47 @@ export default function CocktailDetailsScreen() {
     navigation.navigate("AddCocktail", { initialCocktail: cocktail });
   }, [navigation, cocktail]);
 
-  const handleRate = useCallback((value) => {
-    setCocktail((prev) => {
-      if (!prev) return prev;
-      const newRating = prev.rating === value ? 0 : value;
-      return { ...prev, rating: newRating };
-    });
-  }, []);
+  const handleRate = useCallback(
+    (value: number) => {
+      if (!cocktail) return;
+
+      const previous = cocktail;
+      const newRating = previous.rating === value ? 0 : value;
+      const optimistic: CocktailRecord = { ...previous, rating: newRating };
+
+      setCocktail(optimistic);
+      setGlobalCocktails((prevList) =>
+        Array.isArray(prevList) ? updateCocktailById(prevList, optimistic) : prevList
+      );
+
+      const requestId = (ratingSaveRef.current?.id ?? 0) + 1;
+      ratingSaveRef.current = { id: requestId, prev: previous, optimistic };
+
+      saveCocktail(optimistic)
+        .then((saved) => {
+          if (!ratingSaveRef.current || ratingSaveRef.current.id !== requestId) {
+            return;
+          }
+          ratingSaveRef.current = { id: requestId, prev: saved, optimistic: saved };
+          setCocktail(saved);
+          setGlobalCocktails((prevList) =>
+            Array.isArray(prevList) ? updateCocktailById(prevList, saved) : prevList
+          );
+        })
+        .catch((error) => {
+          if (!ratingSaveRef.current || ratingSaveRef.current.id !== requestId) {
+            return;
+          }
+          ratingSaveRef.current = null;
+          console.error("Failed to save cocktail rating", error);
+          setCocktail(previous);
+          setGlobalCocktails((prevList) =>
+            Array.isArray(prevList) ? updateCocktailById(prevList, previous) : prevList
+          );
+        });
+    },
+    [cocktail, setGlobalCocktails]
+  );
 
   useLayoutEffect(() => {
     navigation.setOptions({

--- a/src/screens/Cocktails/CocktailDetailsScreen.tsx
+++ b/src/screens/Cocktails/CocktailDetailsScreen.tsx
@@ -27,11 +27,7 @@ import {
 import { goBack } from "../../utils/navigation";
 import { useTheme } from "react-native-paper";
 import { MaterialIcons } from "@expo/vector-icons";
-import {
-  getCocktailById,
-  saveCocktail,
-  updateCocktailById,
-} from "../../domain/cocktails";
+import { getCocktailById } from "../../domain/cocktails";
 import {
   getIngredientsByIds,
   getIngredientsByBaseIds,
@@ -198,7 +194,6 @@ export default function CocktailDetailsScreen() {
   const {
     ingredients: globalIngredients = [],
     cocktails: globalCocktails = [],
-    setCocktails: setGlobalCocktails,
   } = useIngredientUsage();
 
   const [cocktail, setCocktail] = useState(initialCocktail || null);
@@ -236,40 +231,13 @@ export default function CocktailDetailsScreen() {
     navigation.navigate("AddCocktail", { initialCocktail: cocktail });
   }, [navigation, cocktail]);
 
-  const latestRatingRequest = useRef(0);
-
-  const handleRate = useCallback(
-    (value) => {
-      if (!cocktail) return;
-      const prev = cocktail;
-      const newRating = cocktail.rating === value ? 0 : value;
-      const updated = { ...cocktail, rating: newRating };
-      const requestId = latestRatingRequest.current + 1;
-      latestRatingRequest.current = requestId;
-
-      setCocktail(updated);
-      setGlobalCocktails((prevList) =>
-        Array.isArray(prevList) ? updateCocktailById(prevList, updated) : prevList
-      );
-
-      saveCocktail(updated)
-        .then((saved) => {
-          if (latestRatingRequest.current !== requestId) return;
-          setCocktail(saved);
-          setGlobalCocktails((prevList) =>
-            Array.isArray(prevList) ? updateCocktailById(prevList, saved) : prevList
-          );
-        })
-        .catch(() => {
-          if (latestRatingRequest.current !== requestId) return;
-          setCocktail(prev);
-          setGlobalCocktails((prevList) =>
-            Array.isArray(prevList) ? updateCocktailById(prevList, prev) : prevList
-          );
-        });
-    },
-    [cocktail, setGlobalCocktails]
-  );
+  const handleRate = useCallback((value) => {
+    setCocktail((prev) => {
+      if (!prev) return prev;
+      const newRating = prev.rating === value ? 0 : value;
+      return { ...prev, rating: newRating };
+    });
+  }, []);
 
   useLayoutEffect(() => {
     navigation.setOptions({


### PR DESCRIPTION
## Summary
- avoid awaiting the cocktail save when rating changes so the UI updates immediately
- track the latest rating request to ensure only the most recent response syncs state or reverts on failure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f021a2da0c8326acc46697aec3e899