### PR TITLE
Optimize cocktail list rendering and rating updates

### DIFF
--- a/src/hooks/useCocktailSearchResults.ts
+++ b/src/hooks/useCocktailSearchResults.ts
@@ -1,0 +1,133 @@
+import { useMemo, useRef } from "react";
+import { buildIngredientIndex, getCocktailIngredientInfo } from "../domain/cocktailIngredients";
+import { normalizeSearch } from "../utils/normalizeSearch";
+import { sortByName } from "../utils/sortByName";
+
+interface Options {
+  cocktails?: any[];
+  ingredients?: any[];
+  search?: string;
+  selectedTagIds?: number[];
+  allowSubstitutes?: boolean;
+  ignoreGarnish?: boolean;
+  filter?: (cocktail: any) => boolean;
+}
+
+interface CacheEntry {
+  base: any;
+  ingredientsRef: any[] | undefined;
+  indexRef: {
+    ingMap: Map<string, any>;
+    byBase: Map<string, any[]>;
+  } | null;
+  allowSubstitutes: boolean;
+  ignoreGarnish: boolean;
+  meta: {
+    name: string | undefined;
+    photoUri: string | undefined;
+    glassId: number | string | undefined;
+    tagsRef: any;
+  };
+}
+
+export default function useCocktailSearchResults({
+  cocktails = [],
+  ingredients = [],
+  search = "",
+  selectedTagIds = [],
+  allowSubstitutes = false,
+  ignoreGarnish = false,
+  filter,
+}: Options) {
+  const cacheRef = useRef<Map<number, CacheEntry>>(new Map());
+  const normalizedSearch = useMemo(() => normalizeSearch(search || ""), [search]);
+  const ingredientIndex = useMemo(() => buildIngredientIndex(ingredients || []), [ingredients]);
+
+  return useMemo(() => {
+    const cache = cacheRef.current;
+    const nextCache = new Map<number, CacheEntry>();
+
+    const results = (cocktails || [])
+      .filter((cocktail) => {
+        if (typeof filter === "function" && !filter(cocktail)) return false;
+        if (selectedTagIds.length > 0) {
+          if (
+            !Array.isArray(cocktail.tags) ||
+            !cocktail.tags.some((t: any) => selectedTagIds.includes(t.id))
+          ) {
+            return false;
+          }
+        }
+        if (!normalizedSearch) return true;
+        const name =
+          cocktail.searchName || normalizeSearch(String(cocktail.name || ""));
+        return name.includes(normalizedSearch);
+      })
+      .map((cocktail) => {
+        const cached = cache.get(cocktail.id);
+        const meta = {
+          name: cocktail.name,
+          photoUri: cocktail.photoUri,
+          glassId: cocktail.glassId,
+          tagsRef: cocktail.tags,
+        };
+        const shouldReuse =
+          cached &&
+          cached.ingredientsRef === cocktail.ingredients &&
+          cached.indexRef?.ingMap === ingredientIndex.ingMap &&
+          cached.indexRef?.byBase === ingredientIndex.byBase &&
+          cached.allowSubstitutes === allowSubstitutes &&
+          cached.ignoreGarnish === ignoreGarnish &&
+          cached.meta.name === meta.name &&
+          cached.meta.photoUri === meta.photoUri &&
+          cached.meta.glassId === meta.glassId &&
+          cached.meta.tagsRef === meta.tagsRef;
+
+        if (shouldReuse) {
+          let base = cached.base;
+          if (base.rating !== cocktail.rating) {
+            base = { ...base, rating: cocktail.rating };
+          }
+          if (base.favorite !== cocktail.favorite) {
+            base = { ...base, favorite: cocktail.favorite };
+          }
+          if (base.photoUri !== cocktail.photoUri || base.name !== cocktail.name) {
+            base = { ...base, name: cocktail.name, photoUri: cocktail.photoUri };
+          }
+          nextCache.set(cocktail.id, { ...cached, base, meta });
+          return base;
+        }
+
+        const details = getCocktailIngredientInfo(cocktail, {
+          ingMap: ingredientIndex.ingMap,
+          findBrand: ingredientIndex.findBrand,
+          allowSubstitutes,
+          ignoreGarnish,
+        });
+        const base = { ...cocktail, ...details };
+        nextCache.set(cocktail.id, {
+          base,
+          ingredientsRef: cocktail.ingredients,
+          indexRef: {
+            ingMap: ingredientIndex.ingMap,
+            byBase: ingredientIndex.byBase,
+          },
+          allowSubstitutes,
+          ignoreGarnish,
+          meta,
+        });
+        return base;
+      });
+
+    cacheRef.current = nextCache;
+    return results.sort(sortByName);
+  }, [
+    allowSubstitutes,
+    cocktails,
+    filter,
+    ignoreGarnish,
+    ingredientIndex,
+    normalizedSearch,
+    selectedTagIds,
+  ]);
+}

--- a/src/screens/Cocktails/AllCocktailsScreen.tsx
+++ b/src/screens/Cocktails/AllCocktailsScreen.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { View, Text, StyleSheet } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
@@ -28,12 +23,7 @@ import CocktailRow, {
 import ListSkeleton from "../../components/ListSkeleton";
 import TabSwipe from "../../components/TabSwipe";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
-import { normalizeSearch } from "../../utils/normalizeSearch";
-import {
-  buildIngredientIndex,
-  getCocktailIngredientInfo,
-} from "../../domain/cocktailIngredients";
-import { sortByName } from "../../utils/sortByName";
+import useCocktailSearchResults from "../../hooks/useCocktailSearchResults";
 
 export default function AllCocktailsScreen() {
   const theme = useTheme();
@@ -43,9 +33,6 @@ export default function AllCocktailsScreen() {
   const tabsOnTop = useTabsOnTop();
   const insets = useSafeAreaInsets();
 
-  const [cocktails, setCocktails] = useState([]);
-  const [ingredients, setIngredients] = useState([]);
-  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [searchDebounced, setSearchDebounced] = useState("");
   const [navigatingId, setNavigatingId] = useState(null);
@@ -53,11 +40,7 @@ export default function AllCocktailsScreen() {
   const [availableTags, setAvailableTags] = useState([]);
   const [ignoreGarnish, setIgnoreGarnish] = useState(false);
   const [allowSubstitutes, setAllowSubstitutes] = useState(false);
-  const {
-    cocktails: globalCocktails = [],
-    ingredients: globalIngredients = [],
-    loading: globalLoading,
-  } = useIngredientUsage();
+  const { cocktails = [], ingredients = [], loading } = useIngredientUsage();
 
   useEffect(() => {
     if (isFocused) setTab("cocktails", "All");
@@ -80,18 +63,6 @@ export default function AllCocktailsScreen() {
   }, [search]);
 
   useEffect(() => {
-    setCocktails(globalCocktails);
-  }, [globalCocktails]);
-
-  useEffect(() => {
-    setIngredients(globalIngredients);
-  }, [globalIngredients]);
-
-  useEffect(() => {
-    setLoading(globalLoading);
-  }, [globalLoading]);
-
-  useEffect(() => {
     if (!isFocused) return;
     let cancel = false;
     (async () => {
@@ -112,42 +83,14 @@ export default function AllCocktailsScreen() {
     };
   }, [isFocused]);
 
-  const filtered = useMemo(() => {
-    const { ingMap, findBrand } = buildIngredientIndex(ingredients || []);
-    const q = normalizeSearch(searchDebounced);
-    let list = cocktails;
-    if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
-    if (selectedTagIds.length > 0)
-      list = list.filter(
-        (c) =>
-          Array.isArray(c.tags) &&
-          c.tags.some((t) => selectedTagIds.includes(t.id))
-      );
-    return list
-      .map((c) => {
-        const { ingredientLine, isAllAvailable, hasBranded } =
-          getCocktailIngredientInfo(c, {
-            ingMap,
-            findBrand,
-            allowSubstitutes,
-            ignoreGarnish,
-          });
-        return {
-          ...c,
-          ingredientLine,
-          isAllAvailable,
-          hasBranded,
-      };
-      })
-      .sort(sortByName);
-  }, [
+  const filtered = useCocktailSearchResults({
     cocktails,
     ingredients,
-    searchDebounced,
+    search: searchDebounced,
     selectedTagIds,
-    ignoreGarnish,
     allowSubstitutes,
-  ]);
+    ignoreGarnish,
+  });
 
   const handlePress = useCallback(
     (id) => {
@@ -160,7 +103,7 @@ export default function AllCocktailsScreen() {
 
   const renderItem = useCallback(
     ({ item }) => (
-        <CocktailRow
+      <CocktailRow
         id={item.id}
         name={item.name}
         photoUri={item.photoUri}

--- a/src/screens/Cocktails/CocktailDetailsScreen.tsx
+++ b/src/screens/Cocktails/CocktailDetailsScreen.tsx
@@ -6,6 +6,7 @@ import React, {
   useMemo,
   useRef,
   memo,
+  useTransition,
 } from "react";
 import {
   View,
@@ -236,6 +237,8 @@ export default function CocktailDetailsScreen() {
     navigation.navigate("AddCocktail", { initialCocktail: cocktail });
   }, [navigation, cocktail]);
 
+  const [, startRatingTransition] = useTransition();
+
   const handleRate = useCallback(
     async (value) => {
       if (!cocktail) return;
@@ -243,23 +246,29 @@ export default function CocktailDetailsScreen() {
       const newRating = cocktail.rating === value ? 0 : value;
       const updated = { ...cocktail, rating: newRating };
       setCocktail(updated);
-      setGlobalCocktails((prevList) =>
-        Array.isArray(prevList) ? updateCocktailById(prevList, updated) : prevList
-      );
+      startRatingTransition(() => {
+        setGlobalCocktails((prevList) =>
+          Array.isArray(prevList) ? updateCocktailById(prevList, updated) : prevList
+        );
+      });
       try {
         const saved = await saveCocktail(updated);
         setCocktail(saved);
-        setGlobalCocktails((prevList) =>
-          Array.isArray(prevList) ? updateCocktailById(prevList, saved) : prevList
-        );
+        startRatingTransition(() => {
+          setGlobalCocktails((prevList) =>
+            Array.isArray(prevList) ? updateCocktailById(prevList, saved) : prevList
+          );
+        });
       } catch (e) {
         setCocktail(prev);
-        setGlobalCocktails((prevList) =>
-          Array.isArray(prevList) ? updateCocktailById(prevList, prev) : prevList
-        );
+        startRatingTransition(() => {
+          setGlobalCocktails((prevList) =>
+            Array.isArray(prevList) ? updateCocktailById(prevList, prev) : prevList
+          );
+        });
       }
     },
-    [cocktail, setGlobalCocktails]
+    [cocktail, setGlobalCocktails, startRatingTransition]
   );
 
   useLayoutEffect(() => {

--- a/src/screens/Cocktails/FavoriteCocktailsScreen.tsx
+++ b/src/screens/Cocktails/FavoriteCocktailsScreen.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { View, Text, StyleSheet } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
@@ -12,6 +7,7 @@ import TopTabBar from "../../components/TopTabBar";
 import { useTabMemory } from "../../context/TabMemoryContext";
 import useTabsOnTop from "../../hooks/useTabsOnTop";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
+import useCocktailSearchResults from "../../hooks/useCocktailSearchResults";
 import {
   getIgnoreGarnish,
   addIgnoreGarnishListener,
@@ -30,12 +26,6 @@ import CocktailRow, {
 } from "../../components/CocktailRow";
 import ListSkeleton from "../../components/ListSkeleton";
 import TabSwipe from "../../components/TabSwipe";
-import { normalizeSearch } from "../../utils/normalizeSearch";
-import { sortByName } from "../../utils/sortByName";
-import {
-  buildIngredientIndex,
-  getCocktailIngredientInfo,
-} from "../../domain/cocktailIngredients";
 
 export default function FavoriteCocktailsScreen() {
   const theme = useTheme();
@@ -44,15 +34,7 @@ export default function FavoriteCocktailsScreen() {
   const { setTab } = useTabMemory();
   const tabsOnTop = useTabsOnTop();
   const insets = useSafeAreaInsets();
-  const {
-    cocktails: globalCocktails = [],
-    ingredients: globalIngredients = [],
-    loading: globalLoading,
-  } = useIngredientUsage();
-
-  const [cocktails, setCocktails] = useState([]);
-  const [ingredients, setIngredients] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const { cocktails = [], ingredients = [], loading } = useIngredientUsage();
   const [search, setSearch] = useState("");
   const [searchDebounced, setSearchDebounced] = useState("");
   const [navigatingId, setNavigatingId] = useState(null);
@@ -83,18 +65,6 @@ export default function FavoriteCocktailsScreen() {
   }, [search]);
 
   useEffect(() => {
-    setCocktails(globalCocktails);
-  }, [globalCocktails]);
-
-  useEffect(() => {
-    setIngredients(globalIngredients);
-  }, [globalIngredients]);
-
-  useEffect(() => {
-    setLoading(globalLoading);
-  }, [globalLoading]);
-
-  useEffect(() => {
     if (!isFocused) return;
     let cancel = false;
     (async () => {
@@ -119,43 +89,15 @@ export default function FavoriteCocktailsScreen() {
     };
   }, [isFocused]);
 
-  const filtered = useMemo(() => {
-    const { ingMap, findBrand } = buildIngredientIndex(ingredients || []);
-    const q = normalizeSearch(searchDebounced);
-    let list = cocktails.filter((c) => c.rating > 0 && c.rating >= minRating);
-    if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
-    if (selectedTagIds.length > 0)
-      list = list.filter(
-        (c) =>
-          Array.isArray(c.tags) &&
-          c.tags.some((t) => selectedTagIds.includes(t.id))
-      );
-    return list
-      .map((c) => {
-        const { ingredientLine, isAllAvailable, hasBranded } =
-          getCocktailIngredientInfo(c, {
-            ingMap,
-            findBrand,
-            allowSubstitutes,
-            ignoreGarnish,
-          });
-        return {
-          ...c,
-          isAllAvailable,
-          hasBranded,
-          ingredientLine,
-        };
-      })
-      .sort(sortByName);
-  }, [
+  const filtered = useCocktailSearchResults({
     cocktails,
     ingredients,
-    searchDebounced,
+    search: searchDebounced,
     selectedTagIds,
-    ignoreGarnish,
-    minRating,
     allowSubstitutes,
-  ]);
+    ignoreGarnish,
+    filter: (cocktail) => cocktail.rating > 0 && cocktail.rating >= minRating,
+  });
 
   const handlePress = useCallback(
     (id) => {

--- a/src/screens/Cocktails/MyCocktailsScreen.tsx
+++ b/src/screens/Cocktails/MyCocktailsScreen.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View, Text, StyleSheet } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { useNavigation, useIsFocused } from "@react-navigation/native";
@@ -31,12 +25,7 @@ import IngredientRow, { INGREDIENT_ROW_HEIGHT } from "../../components/Ingredien
 import ListSkeleton from "../../components/ListSkeleton";
 import TabSwipe from "../../components/TabSwipe";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
-import { normalizeSearch } from "../../utils/normalizeSearch";
-import {
-  buildIngredientIndex,
-  getCocktailIngredientInfo,
-} from "../../domain/cocktailIngredients";
-import { sortByName } from "../../utils/sortByName";
+import useCocktailSearchResults from "../../hooks/useCocktailSearchResults";
 
 const ITEM_HEIGHT = Math.max(COCKTAIL_ROW_HEIGHT, INGREDIENT_ROW_HEIGHT);
 
@@ -48,9 +37,6 @@ export default function MyCocktailsScreen() {
   const tabsOnTop = useTabsOnTop();
   const insets = useSafeAreaInsets();
 
-  const [cocktails, setCocktails] = useState([]);
-  const [ingredients, setIngredients] = useState(new Map());
-  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [searchDebounced, setSearchDebounced] = useState("");
   const [navigatingId, setNavigatingId] = useState(null);
@@ -61,11 +47,16 @@ export default function MyCocktailsScreen() {
   // Local memory of shopping-list changes
   const [shoppingListChanges, setShoppingListChanges] = useState(new Map());
   const {
-    cocktails: globalCocktails = [],
-    ingredients: globalIngredients = [],
-    loading: globalLoading,
+    cocktails = [],
+    ingredients = [],
+    loading,
     setIngredients: setGlobalIngredients,
   } = useIngredientUsage();
+
+  const ingredientMap = useMemo(
+    () => new Map(ingredients.map((i) => [i.id, i])),
+    [ingredients]
+  );
 
   const shoppingListChangesRef = useRef(shoppingListChanges);
   useEffect(() => {
@@ -91,18 +82,6 @@ export default function MyCocktailsScreen() {
     const h = setTimeout(() => setSearchDebounced(search), 300);
     return () => clearTimeout(h);
   }, [search]);
-
-  useEffect(() => {
-    setCocktails(globalCocktails);
-  }, [globalCocktails]);
-
-  useEffect(() => {
-    setIngredients(new Map(globalIngredients.map((i) => [i.id, i])));
-  }, [globalIngredients]);
-
-  useEffect(() => {
-    setLoading(globalLoading);
-  }, [globalLoading]);
 
   useEffect(() => {
     if (!isFocused) return;
@@ -141,18 +120,6 @@ export default function MyCocktailsScreen() {
         if (toRemove.length) await setIngredientsInShoppingList(toRemove, false);
       })();
       if (toAdd.length || toRemove.length) {
-        setIngredients((prev) => {
-          const next = new Map(prev);
-          toAdd.forEach((id) => {
-            const ing = next.get(id);
-            if (ing) next.set(id, { ...ing, inShoppingList: true });
-          });
-          toRemove.forEach((id) => {
-            const ing = next.get(id);
-            if (ing) next.set(id, { ...ing, inShoppingList: false });
-          });
-          return next;
-        });
         setGlobalIngredients?.((prev) => {
           const next = new Map(prev);
           toAdd.forEach((id) => {
@@ -168,50 +135,16 @@ export default function MyCocktailsScreen() {
       }
     });
     return unsub;
-  }, [navigation, setIngredients, setGlobalIngredients]);
+  }, [navigation, setGlobalIngredients]);
 
-  const processed = useMemo(() => {
-    const ingredientArr = Array.from(ingredients.values());
-    const { ingMap, findBrand } = buildIngredientIndex(ingredientArr);
-    const q = normalizeSearch(searchDebounced);
-    let list = cocktails;
-    if (q) list = list.filter((c) => normalizeSearch(c.name).includes(q));
-    if (selectedTagIds.length > 0)
-      list = list.filter(
-        (c) =>
-          Array.isArray(c.tags) &&
-          c.tags.some((t) => selectedTagIds.includes(t.id))
-      );
-    return list
-      .map((c) => {
-        const {
-          ingredientLine,
-          isAllAvailable,
-          hasBranded,
-          missingIngredientIds,
-        } = getCocktailIngredientInfo(c, {
-          ingMap,
-          findBrand,
-          allowSubstitutes,
-          ignoreGarnish,
-        });
-        return {
-          ...c,
-          ingredientLine,
-          isAllAvailable,
-          hasBranded,
-          missingIngredientIds,
-        };
-      })
-      .sort(sortByName);
-  }, [
+  const processed = useCocktailSearchResults({
     cocktails,
     ingredients,
-    searchDebounced,
+    search: searchDebounced,
     selectedTagIds,
-    ignoreGarnish,
     allowSubstitutes,
-  ]);
+    ignoreGarnish,
+  });
 
   const { available, suggestions } = useMemo(() => {
     const avail = processed.filter((c) => c.isAllAvailable);
@@ -226,13 +159,13 @@ export default function MyCocktailsScreen() {
     }
     const sugg = Array.from(map.entries())
       .map(([id, cocks]) => ({
-        ingredient: ingredients.get(Number(id)) || ingredients.get(id),
+        ingredient: ingredientMap.get(Number(id)) || ingredientMap.get(id),
         cocktails: cocks,
       }))
       .filter((s) => s.ingredient && !s.ingredient.inBar)
       .sort((a, b) => b.cocktails.length - a.cocktails.length);
     return { available: avail, suggestions: sugg };
-  }, [processed, ingredients]);
+  }, [processed, ingredientMap]);
 
   const listData = useMemo(() => {
     const data = available.map((c) => ({ type: "cocktail", item: c }));
@@ -267,7 +200,7 @@ export default function MyCocktailsScreen() {
       requestAnimationFrame(() => {
         setShoppingListChanges((prev) => {
           const next = new Map(prev);
-          const original = ingredients.get(id)?.inShoppingList || false;
+          const original = ingredientMap.get(id)?.inShoppingList || false;
           const current = next.has(id) ? next.get(id) : original;
           const updated = !current;
           if (updated === original) next.delete(id);
@@ -276,7 +209,7 @@ export default function MyCocktailsScreen() {
         });
       });
     },
-    [ingredients]
+    [ingredientMap]
   );
 
   const renderItem = useCallback(


### PR DESCRIPTION
## Summary
- add a shared hook that memoizes cocktail search results and caches ingredient lookups
- refactor the All, Favorite, and My cocktails screens to use the shared hook and drop redundant local copies of context data
- wrap cocktail rating updates in a transition so background recomputation no longer blocks the UI

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f02c292b9483268c8451b30cfedfbb