### PR TITLE
Optimize list updates for cocktails and ingredients

### DIFF
--- a/src/data/cocktails.ts
+++ b/src/data/cocktails.ts
@@ -1,6 +1,7 @@
 // src/storage/cocktailsStorage.js
 import { normalizeSearch } from "../utils/normalizeSearch";
 import { sortByName } from "../utils/sortByName";
+import { updateArrayItemsById } from "../utils/updateCollections";
 import { CocktailRecord } from "./types";
 import db, {
   query,
@@ -216,12 +217,11 @@ export async function saveCocktail(
   return item as unknown as CocktailRecord;
 }
 
-export function updateCocktailById(list: CocktailRecord[], updated: CocktailRecord): CocktailRecord[] {
-  const index = list.findIndex((c) => c.id === updated.id);
-  if (index === -1) return list;
-  const next = [...list];
-  next[index] = { ...next[index], ...updated };
-  return next;
+export function updateCocktailById(
+  list: CocktailRecord[],
+  updated: CocktailRecord | CocktailRecord[]
+): CocktailRecord[] {
+  return updateArrayItemsById(list, updated);
 }
 
 /** Delete by id */

--- a/src/data/ingredients.ts
+++ b/src/data/ingredients.ts
@@ -6,6 +6,7 @@ import db, {
 import { normalizeSearch } from "../utils/normalizeSearch";
 import { WORD_SPLIT_RE } from "../utils/wordPrefixMatch";
 import { sortByName } from "../utils/sortByName";
+import { updateMapItemsById } from "../utils/updateCollections";
 import { IngredientRecord } from "./types";
 
 const now = () => Date.now();
@@ -175,11 +176,7 @@ export async function saveAllIngredients(ingredients, tx) {
 }
 
 export function updateIngredientById(map, updated) {
-  const prev = map.get(updated.id);
-  if (!prev) return map;
-  const next = new Map(map);
-  next.set(updated.id, { ...prev, ...updated });
-  return next;
+  return updateMapItemsById(map, updated);
 }
 
 function sanitizeIngredient(i: Partial<IngredientRecord>): IngredientRecord {

--- a/src/domain/cocktails.ts
+++ b/src/domain/cocktails.ts
@@ -1,3 +1,5 @@
+import { updateArrayItemsById } from "../utils/updateCollections";
+
 let data;
 export function __setDataLayer(mock) {
   data = mock;
@@ -33,11 +35,7 @@ export async function searchCocktails(query) {
 }
 
 export function updateCocktailById(list, updated) {
-  const index = list.findIndex((c) => c.id === updated.id);
-  if (index === -1) return list;
-  const next = [...list];
-  next[index] = { ...next[index], ...updated };
-  return next;
+  return updateArrayItemsById(list, updated);
 }
 export function removeCocktail(list, id) {
   return list.filter((item) => item.id !== id);

--- a/src/domain/ingredients.ts
+++ b/src/domain/ingredients.ts
@@ -1,3 +1,5 @@
+import { updateMapItemsById } from "../utils/updateCollections";
+
 let data;
 export function __setDataLayer(mock) {
   data = mock;
@@ -51,11 +53,7 @@ export function buildIndex(list) {
   }, {});
 }
 export function updateIngredientById(map, updated) {
-  const prev = map.get(updated.id);
-  if (!prev) return map;
-  const next = new Map(map);
-  next.set(updated.id, { ...prev, ...updated });
-  return next;
+  return updateMapItemsById(map, updated);
 }
 export function getIngredientById(id, index) {
   return index ? index[id] : null;

--- a/src/screens/Ingredients/IngredientDetailsScreen.tsx
+++ b/src/screens/Ingredients/IngredientDetailsScreen.tsx
@@ -448,10 +448,7 @@ export default function IngredientDetailsScreen() {
 
       let nextList;
       setIngredients((list) => {
-        nextList = list;
-        updates.forEach((item) => {
-          nextList = updateIngredientById(nextList, item);
-        });
+        nextList = updateIngredientById(list, updates);
         return nextList;
       });
 

--- a/src/utils/updateCollections.ts
+++ b/src/utils/updateCollections.ts
@@ -1,0 +1,106 @@
+type Key = string | number | symbol;
+
+const arrayIndexCache: WeakMap<
+  ReadonlyArray<Record<string, any>>,
+  Map<Key, Map<any, number>>
+> = new WeakMap();
+
+function getIndexMap<T extends Record<string, any>>(
+  list: ReadonlyArray<T>,
+  key: Key
+): Map<any, number> {
+  let cached = arrayIndexCache.get(list);
+  if (!cached) {
+    cached = new Map();
+    arrayIndexCache.set(list, cached);
+  }
+
+  if (!cached.has(key)) {
+    const indexMap = new Map<any, number>();
+    list.forEach((item, idx) => {
+      const id = item?.[key as keyof T];
+      if (id != null) {
+        indexMap.set(id, idx);
+      }
+    });
+    cached.set(key, indexMap);
+  }
+
+  return cached.get(key)!;
+}
+
+function cloneIndexCache(
+  source: Map<Key, Map<any, number>> | undefined,
+  key: Key,
+  map: Map<any, number>
+) {
+  if (!source) {
+    return new Map([[key, map]]);
+  }
+  const next = new Map<Key, Map<any, number>>();
+  source.forEach((value, cacheKey) => {
+    next.set(cacheKey, cacheKey === key ? map : value);
+  });
+  if (!next.has(key)) {
+    next.set(key, map);
+  }
+  return next;
+}
+
+export function updateArrayItemsById<T extends Record<string, any>>(
+  list: ReadonlyArray<T>,
+  updates: Partial<T> | Array<Partial<T>>,
+  key: Key = "id"
+): T[] {
+  if (!Array.isArray(list) || list.length === 0) return list as T[];
+  const updateList = Array.isArray(updates) ? updates : [updates];
+  if (updateList.length === 0) return list as T[];
+
+  const indexMap = getIndexMap(list, key);
+  let next: T[] | null = null;
+
+  updateList.forEach((update) => {
+    const id = update?.[key as keyof typeof update];
+    if (id == null) return;
+    const idx = indexMap.get(id);
+    if (idx == null) return;
+    if (!next) next = list.slice() as T[];
+    const prev = next[idx];
+    next[idx] = { ...prev, ...update } as T;
+  });
+
+  if (!next) return list as T[];
+
+  const previousCache = arrayIndexCache.get(list);
+  arrayIndexCache.set(next, cloneIndexCache(previousCache, key, indexMap));
+  arrayIndexCache.delete(list);
+
+  return next;
+}
+
+export function updateMapItemsById<T extends Record<string, any>>(
+  map: Map<any, T>,
+  updates: Partial<T> | Array<Partial<T>>,
+  key: Key = "id"
+): Map<any, T> {
+  if (!(map instanceof Map) || map.size === 0) return map;
+  const updateList = Array.isArray(updates) ? updates : [updates];
+  if (updateList.length === 0) return map;
+
+  let next: Map<any, T> | null = null;
+
+  updateList.forEach((update) => {
+    const id = update?.[key as keyof typeof update];
+    if (id == null) return;
+    const source = next ?? map;
+    const prev = source.get(id);
+    if (!prev) return;
+    if (!next) {
+      next = new Map(map);
+    }
+    next.set(id, { ...prev, ...update });
+  });
+
+  return next ?? map;
+}
+


### PR DESCRIPTION
## Summary
- add shared utilities that cache indexes to update cocktail arrays and ingredient maps efficiently
- reuse the optimized helpers in the domain and data layers for cocktails and ingredients
- batch ingredient unlink operations to avoid repeated map cloning when applying multiple updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69028aa9fb5883268fbb9eb72ed6be6d