### PR TITLE
Refine ingredient and cocktail state updates

### DIFF
--- a/src/context/IngredientUsageContext.tsx
+++ b/src/context/IngredientUsageContext.tsx
@@ -7,14 +7,51 @@ import React, {
   useRef,
   useMemo,
 } from "react";
-import { updateUsageMap as updateUsageMapIncremental } from "../domain/ingredientUsage";
+import {
+  applyUsageMapToIngredients,
+  updateUsageMap as updateUsageMapIncremental,
+} from "../domain/ingredientUsage";
 import { sortByName } from "../utils/sortByName";
 import { groupIngredientsByTag } from "../domain/groupIngredientsByTag";
+
+function buildByBaseFromArray(list) {
+  const map = new Map();
+  list.forEach((item) => {
+    const baseId = item.baseIngredientId ?? item.id;
+    if (!map.has(baseId)) map.set(baseId, []);
+    map.get(baseId).push(item);
+  });
+  return map;
+}
+
+function toIngredientArray(value) {
+  if (value == null) return [];
+  if (Array.isArray(value)) return value;
+  if (value instanceof Map) return Array.from(value.values());
+  if (typeof value === "object") return Object.values(value);
+  return [];
+}
+
+function toIngredientMap(value, fallback) {
+  if (value == null) return fallback;
+  if (value instanceof Map) return value;
+  if (Array.isArray(value)) return new Map(value.map((i) => [i.id, i]));
+  if (typeof value === "object") {
+    return new Map(Object.values(value).map((i) => [i.id, i]));
+  }
+  return fallback;
+}
 
 const IngredientUsageContext = createContext({
   usageMap: {},
   setUsageMap: () => {},
   updateUsageMap: () => {},
+  applyIngredientCocktailUpdates: () => ({
+    ingredients: [],
+    cocktails: [],
+    usageMap: {},
+    ingredientsMap: new Map(),
+  }),
   ingredients: [],
   ingredientsById: new Map(),
   ingredientsByBase: new Map(),
@@ -61,6 +98,37 @@ export function IngredientUsageProvider({ children }) {
     [ingredients, ingredientTags]
   );
 
+  const cocktailsRef = useRef(cocktails);
+  const ingredientsListRef = useRef(ingredients);
+  const ingredientsMapRef = useRef(ingredientsMap);
+  const ingredientsByBaseRef = useRef(ingredientsByBase);
+  const ingredientsByIdRef = useRef(ingredientsById);
+  const usageMapRef = useRef(usageMap);
+
+  useEffect(() => {
+    cocktailsRef.current = cocktails;
+  }, [cocktails]);
+
+  useEffect(() => {
+    ingredientsListRef.current = ingredients;
+  }, [ingredients]);
+
+  useEffect(() => {
+    ingredientsMapRef.current = ingredientsMap;
+  }, [ingredientsMap]);
+
+  useEffect(() => {
+    ingredientsByBaseRef.current = ingredientsByBase;
+  }, [ingredientsByBase]);
+
+  useEffect(() => {
+    ingredientsByIdRef.current = ingredientsById;
+  }, [ingredientsById]);
+
+  useEffect(() => {
+    usageMapRef.current = usageMap;
+  }, [usageMap]);
+
   const setIngredients = useCallback((next) => {
     setIngredientsMap((prev) => {
       const value = typeof next === "function" ? next(prev) : next;
@@ -70,49 +138,137 @@ export function IngredientUsageProvider({ children }) {
     });
   }, []);
 
+  const applyIngredientCocktailUpdates = useCallback((changes = {}) => {
+    const {
+      ingredients: ingredientsUpdate,
+      cocktails: cocktailsUpdate,
+      usageMap: overrideUsage,
+      changedIngredientIds = [],
+      changedCocktailIds = [],
+      allowSubstitutes = false,
+      prevCocktails,
+      prevIngredients,
+      byId,
+      byBase,
+      prevById,
+      prevByBase,
+    } = changes;
+
+    const prevCocktailsList = prevCocktails || cocktailsRef.current;
+    const prevIngredientsMap = ingredientsMapRef.current;
+    const prevIngredientsList =
+      prevIngredients != null
+        ? toIngredientArray(prevIngredients)
+        : ingredientsListRef.current;
+
+    let nextCocktailsList = prevCocktailsList;
+    if (cocktailsUpdate !== undefined) {
+      const produced =
+        typeof cocktailsUpdate === "function"
+          ? cocktailsUpdate(prevCocktailsList)
+          : cocktailsUpdate;
+      if (Array.isArray(produced)) {
+        nextCocktailsList = produced;
+      }
+    }
+
+    let nextIngredientsMap = prevIngredientsMap;
+    if (ingredientsUpdate !== undefined) {
+      const produced =
+        typeof ingredientsUpdate === "function"
+          ? ingredientsUpdate(prevIngredientsMap)
+          : ingredientsUpdate;
+      nextIngredientsMap = toIngredientMap(produced, prevIngredientsMap);
+    }
+
+    const nextIngredientsList = Array.from(nextIngredientsMap.values());
+
+    const nextById = byId || nextIngredientsMap;
+    const nextByBase = byBase || buildByBaseFromArray(nextIngredientsList);
+
+    const prevIngredientsArray =
+      prevIngredients != null ? toIngredientArray(prevIngredients) : null;
+
+    const prevByIdValue =
+      prevById ||
+      (prevIngredientsArray
+        ? new Map(prevIngredientsArray.map((i) => [i.id, i]))
+        : ingredientsByIdRef.current);
+
+    const prevByBaseValue =
+      prevByBase ||
+      (prevIngredientsArray
+        ? buildByBaseFromArray(prevIngredientsArray)
+        : ingredientsByBaseRef.current);
+
+    let nextUsage = overrideUsage;
+    if (!nextUsage) {
+      nextUsage = updateUsageMapIncremental(
+        usageMapRef.current,
+        nextIngredientsList,
+        nextCocktailsList,
+        {
+          changedIngredientIds,
+          changedCocktailIds,
+          allowSubstitutes,
+          prevCocktails: prevCocktails || prevCocktailsList,
+          prevIngredients: prevIngredientsArray || prevIngredientsList,
+          byId: nextById,
+          byBase: nextByBase,
+          prevById: prevByIdValue,
+          prevByBase: prevByBaseValue,
+        }
+      );
+    }
+
+    const nextIngredientsWithUsage = applyUsageMapToIngredients(
+      nextIngredientsList,
+      nextUsage,
+      nextCocktailsList
+    );
+    const finalIngredientsMap = new Map(
+      nextIngredientsWithUsage.map((item) => [item.id, item])
+    );
+    const finalByBase = buildByBaseFromArray(nextIngredientsWithUsage);
+
+    cocktailsRef.current = nextCocktailsList;
+    ingredientsListRef.current = nextIngredientsWithUsage;
+    ingredientsMapRef.current = finalIngredientsMap;
+    ingredientsByBaseRef.current = finalByBase;
+    ingredientsByIdRef.current = finalIngredientsMap;
+    usageMapRef.current = nextUsage;
+
+    setCocktails(nextCocktailsList);
+    setIngredients(finalIngredientsMap);
+    setUsageMap(nextUsage);
+
+    return {
+      cocktails: nextCocktailsList,
+      ingredients: nextIngredientsWithUsage,
+      usageMap: nextUsage,
+      ingredientsMap: finalIngredientsMap,
+    };
+  }, [setCocktails, setIngredients, setUsageMap]);
+
   const updateUsageMap = useCallback(
     (ings, cocks, options = {}) => {
-      const useCached = ings === ingredients;
-      const byId =
-        options.byId || (useCached ? ingredientsById : new Map(ings.map((i) => [i.id, i])));
-      const byBase =
-        options.byBase ||
-        (useCached
-          ? ingredientsByBase
-          : (() => {
-              const map = new Map();
-              ings.forEach((i) => {
-                const baseId = i.baseIngredientId ?? i.id;
-                if (!map.has(baseId)) map.set(baseId, []);
-                map.get(baseId).push(i);
-              });
-              return map;
-            })());
-      const opts = { ...options, byId, byBase };
-      if (options.prevIngredients && !options.prevById && !options.prevByBase) {
-        const prevById = new Map(
-          options.prevIngredients.map((i) => [i.id, i])
-        );
-        const prevByBase = (() => {
-          const map = new Map();
-          options.prevIngredients.forEach((i) => {
-            const baseId = i.baseIngredientId ?? i.id;
-            if (!map.has(baseId)) map.set(baseId, []);
-            map.get(baseId).push(i);
-          });
-          return map;
-        })();
-        opts.prevById = prevById;
-        opts.prevByBase = prevByBase;
-      }
-      let next;
-      setUsageMap((prev) => {
-        next = updateUsageMapIncremental(prev, ings, cocks, opts);
-        return next;
+      const result = applyIngredientCocktailUpdates({
+        ingredients: ings,
+        cocktails: cocks,
+        changedIngredientIds: options.changedIngredientIds,
+        changedCocktailIds: options.changedCocktailIds,
+        allowSubstitutes: options.allowSubstitutes,
+        prevCocktails: options.prevCocktails,
+        prevIngredients: options.prevIngredients,
+        byId: options.byId,
+        byBase: options.byBase,
+        prevById: options.prevById,
+        prevByBase: options.prevByBase,
+        usageMap: options.usageMap,
       });
-      return next;
+      return result.usageMap;
     },
-    [ingredients, ingredientsById, ingredientsByBase]
+    [applyIngredientCocktailUpdates]
   );
 
   const baseRef = useRef([]);
@@ -145,6 +301,7 @@ export function IngredientUsageProvider({ children }) {
         usageMap,
         setUsageMap,
         updateUsageMap,
+        applyIngredientCocktailUpdates,
         ingredients,
         ingredientsById,
         ingredientsByBase,

--- a/src/hooks/useIngredientsData.ts
+++ b/src/hooks/useIngredientsData.ts
@@ -20,9 +20,7 @@ export default function useIngredientsData() {
     ingredients,
     setIngredients,
     cocktails,
-    setCocktails,
     usageMap,
-    setUsageMap,
     loading,
     setLoading,
     baseIngredients,
@@ -30,6 +28,7 @@ export default function useIngredientsData() {
     setIngredientTags,
     ingredientsByTag,
     setImporting,
+    applyIngredientCocktailUpdates,
   } = useContext(IngredientUsageContext);
 
   const load = useCallback(
@@ -96,9 +95,14 @@ export default function useIngredientsData() {
             singleCocktailName,
           };
         });
-        setIngredients(withUsage);
-        setCocktails(cocks);
-        setUsageMap(map);
+        applyIngredientCocktailUpdates({
+          ingredients: withUsage,
+          cocktails: cocks,
+          usageMap: map,
+          allowSubstitutes: !!allowSubs,
+          byId,
+          byBase,
+        });
         const nextTags = [
           ...BUILTIN_INGREDIENT_TAGS,
           ...((customTags || [])),
@@ -118,9 +122,7 @@ export default function useIngredientsData() {
       }
     },
     [
-      setIngredients,
-      setCocktails,
-      setUsageMap,
+      applyIngredientCocktailUpdates,
       setLoading,
       setIngredientTags,
       setImporting,

--- a/src/screens/Cocktails/AddCocktailScreen.tsx
+++ b/src/screens/Cocktails/AddCocktailScreen.tsx
@@ -67,7 +67,6 @@ import TinyDivider from "../../components/TinyDivider";
 import CocktailIngredientRow from "../../components/CocktailIngredientRow";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
-import { applyUsageMapToIngredients } from "../../domain/ingredientUsage";
 import { getAllowSubstitutes } from "../../data/settings";
 
 /* ---------- GlasswareMenu через popup-menu (Popover) ---------- */
@@ -202,9 +201,8 @@ export default function AddCocktailScreen() {
   const route = useRoute();
   const isFocused = useIsFocused();
   const { getTab } = useTabMemory();
-  const { cocktails, setCocktails, updateUsageMap } = useIngredientUsage();
-  const { ingredients: globalIngredients = [], setIngredients } =
-    useIngredientsData();
+  const { cocktails, updateUsageMap } = useIngredientUsage();
+  const { ingredients: globalIngredients = [] } = useIngredientsData();
   const initialCocktail = route.params?.initialCocktail;
   const initialIngredient = route.params?.initialIngredient;
   const fromIngredientFlow = initialIngredient != null;
@@ -667,15 +665,11 @@ export default function AddCocktailScreen() {
 
       const allowSubs = await getAllowSubstitutes();
       const nextCocktails = [...cocktails, created];
-      const nextUsage = updateUsageMap(globalIngredients, nextCocktails, {
+      updateUsageMap(globalIngredients, nextCocktails, {
         prevCocktails: cocktails,
         changedCocktailIds: [created.id],
         allowSubstitutes: !!allowSubs,
       });
-      setCocktails(nextCocktails);
-      setIngredients(
-        applyUsageMapToIngredients(globalIngredients, nextUsage, nextCocktails)
-      );
 
       if (fromIngredientFlow) {
         navigation.replace("CocktailDetails", {
@@ -704,9 +698,7 @@ export default function AddCocktailScreen() {
     ings,
     cocktails,
     globalIngredients,
-    setCocktails,
     updateUsageMap,
-    setIngredients,
     navigation,
     fromIngredientFlow,
     initialIngredient?.id,

--- a/src/screens/Cocktails/EditCocktailScreen.tsx
+++ b/src/screens/Cocktails/EditCocktailScreen.tsx
@@ -72,7 +72,6 @@ import CocktailIngredientRow from "../../components/CocktailIngredientRow";
 import { useIngredientUsage } from "../../context/IngredientUsageContext";
 import useIngredientsData from "../../hooks/useIngredientsData";
 import useInfoDialog from "../../hooks/useInfoDialog";
-import { applyUsageMapToIngredients } from "../../domain/ingredientUsage";
 import { getAllowSubstitutes } from "../../data/settings";
 import useDebounced from "../../hooks/useDebounced";
 
@@ -209,9 +208,8 @@ export default function EditCocktailScreen() {
   const params = route.params || {};
   const cocktailId =
     params?.id != null ? Number(params.id) : undefined;
-  const { cocktails, setCocktails, updateUsageMap } = useIngredientUsage();
-  const { ingredients: globalIngredients = [], setIngredients } =
-    useIngredientsData();
+  const { cocktails, updateUsageMap } = useIngredientUsage();
+  const { ingredients: globalIngredients = [] } = useIngredientsData();
 
   const headerHeight = useHeaderHeight();
   const subSearchRef = useRef(null);
@@ -377,19 +375,11 @@ export default function EditCocktailScreen() {
         }
         const nextCocktails = updateCocktailById(cocktails, updated);
         const allowSubs = await getAllowSubstitutes();
-        const nextUsage = updateUsageMap(globalIngredients, nextCocktails, {
+        updateUsageMap(globalIngredients, nextCocktails, {
           prevCocktails: cocktails,
           changedCocktailIds: [updated.id],
           allowSubstitutes: !!allowSubs,
         });
-        setCocktails(nextCocktails);
-        setIngredients(
-          applyUsageMapToIngredients(
-            globalIngredients,
-            nextUsage,
-            nextCocktails
-          )
-        );
         if (stay) setSaving(false);
       });
 
@@ -408,9 +398,7 @@ export default function EditCocktailScreen() {
       serialize,
       cocktails,
       globalIngredients,
-      setCocktails,
       updateUsageMap,
-      setIngredients,
       saving,
       showInfo,
     ]
@@ -1290,24 +1278,16 @@ export default function EditCocktailScreen() {
         onConfirm={() => {
           skipPromptRef.current = true;
           const nextCocktails = removeCocktail(cocktails, cocktailId);
-          setCocktails(nextCocktails);
           navigation.popToTop();
           setConfirmDelete(false);
           InteractionManager.runAfterInteractions(async () => {
             await deleteCocktail(cocktailId);
             const allowSubs = await getAllowSubstitutes();
-            const nextUsage = updateUsageMap(globalIngredients, nextCocktails, {
+            updateUsageMap(globalIngredients, nextCocktails, {
               prevCocktails: cocktails,
               changedCocktailIds: [cocktailId],
               allowSubstitutes: !!allowSubs,
             });
-            setIngredients(
-              applyUsageMapToIngredients(
-                globalIngredients,
-                nextUsage,
-                nextCocktails
-              )
-            );
           });
         }}
       />


### PR DESCRIPTION
## Summary
- centralize ingredient and cocktail state updates inside `IngredientUsageContext`
- reuse the shared update helper when loading data and when adding or editing cocktails
- remove duplicated manual usage-map handling in cocktail screens

## Testing
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e01f6b4548326a69c8cea852f570f)