### PR TITLE
Use filter icon for sort menu anchor

### DIFF
--- a/src/components/SortMenu.tsx
+++ b/src/components/SortMenu.tsx
@@ -23,7 +23,7 @@ export default function SortMenu({ order = "desc", onChange }) {
           hitSlop={{ top: 8, bottom: 8, left: 8, right: 8, borderRadius: 16 }}
         >
           <MaterialIcons
-            name="sort"
+            name="filter-list"
             size={28}
             color={theme.colors.onSurface}
           />


### PR DESCRIPTION
## Summary
- replace the sort icon used in the header menu trigger with the filter icon to better represent filtering options

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69126e049814832681b7c7801a7b081e)