### PR TITLE
Add sliding side menu for header burger

### DIFF
--- a/src/components/HeaderWithSearch.tsx
+++ b/src/components/HeaderWithSearch.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useTheme } from "react-native-paper";
-import GeneralMenu from "./GeneralMenu";
+import SideMenu from "./SideMenu";
 import { HEADER_HEIGHT } from "../constants/layout";
 
 export default function HeaderWithSearch({
@@ -89,7 +89,7 @@ export default function HeaderWithSearch({
           </TouchableOpacity>
         )}
       </View>
-      <GeneralMenu visible={menuVisible} onClose={() => setMenuVisible(false)} />
+      <SideMenu visible={menuVisible} onClose={() => setMenuVisible(false)} />
     </SafeAreaView>
   );
 }

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef } from "react";
+import { Animated, Dimensions, Modal, Pressable, StyleSheet } from "react-native";
+import { useTheme } from "react-native-paper";
+
+const SCREEN_WIDTH = Dimensions.get("window").width;
+const MENU_WIDTH = SCREEN_WIDTH * 0.75;
+
+export default function SideMenu({ visible, onClose }) {
+  const theme = useTheme();
+  const slideAnim = useRef(new Animated.Value(-MENU_WIDTH)).current;
+
+  useEffect(() => {
+    Animated.timing(slideAnim, {
+      toValue: visible ? 0 : -MENU_WIDTH,
+      duration: 250,
+      useNativeDriver: false,
+    }).start();
+  }, [visible, slideAnim]);
+
+  return (
+    <Modal transparent visible={visible} animationType="none" onRequestClose={onClose}>
+      <Pressable
+        style={[styles.overlay, { backgroundColor: theme.colors.backdrop }]}
+        onPress={onClose}
+      >
+        <Animated.View
+          style={[
+            styles.menu,
+            {
+              width: MENU_WIDTH,
+              backgroundColor: theme.colors.background,
+              transform: [{ translateX: slideAnim }],
+            },
+          ]}
+          onStartShouldSetResponder={() => true}
+        />
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    alignItems: "flex-start",
+    justifyContent: "flex-start",
+  },
+  menu: {
+    height: "100%",
+  },
+});


### PR DESCRIPTION
## Summary
- add a reusable side menu that slides in from the left covering 75% of the screen
- connect the header burger button to open the new empty side menu and close it via backdrop taps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f448b5a8083268ca029fff42f5792)