### PR TITLE
Improve substitute-aware ingredient cocktail mapping

### DIFF
--- a/src/domain/cocktailIngredients.ts
+++ b/src/domain/cocktailIngredients.ts
@@ -43,11 +43,6 @@ export function getCocktailIngredientInfo(
       allowSubstitutes || r.allowBaseSubstitution || r.allowBaseSubstitute;
     const allowBranded =
       allowSubstitutes || r.allowBrandedSubstitutes || ing?.baseIngredientId == null;
-    const allowAnySubstitute =
-      allowSubstitutes ||
-      r.allowBaseSubstitution ||
-      r.allowBaseSubstitute ||
-      r.allowBrandedSubstitutes;
 
     const resolveIngredient = (candidate) => {
       if (!candidate) return null;
@@ -65,7 +60,7 @@ export function getCocktailIngredientInfo(
 
     let used = resolveIngredient(ing);
 
-    if (!used && allowAnySubstitute && Array.isArray(r.substitutes)) {
+    if (!used && Array.isArray(r.substitutes)) {
       for (const s of r.substitutes) {
         const candidate = ingMap.get(String(s.id));
         used = resolveIngredient(candidate);
@@ -128,11 +123,6 @@ export function getCocktailIngredientRows(
     const allowBase = allowSubstitutes || r.allowBaseSubstitution || r.allowBaseSubstitute;
     const allowBranded =
       allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient;
-    const allowAnySubstitute =
-      allowSubstitutes ||
-      r.allowBaseSubstitution ||
-      r.allowBaseSubstitute ||
-      r.allowBrandedSubstitutes;
 
     let substitute = null;
     let declaredSubstitutes = [];
@@ -178,7 +168,7 @@ export function getCocktailIngredientRows(
     if (!inBar && ing) {
       substitute = resolveCandidate(ing);
 
-      if (!substitute && allowAnySubstitute && Array.isArray(r.substitutes)) {
+      if (!substitute && Array.isArray(r.substitutes)) {
         for (const s of r.substitutes) {
           substitute = resolveCandidate(ingMap.get(String(s.id)));
           if (substitute) break;

--- a/src/domain/cocktailIngredients.ts
+++ b/src/domain/cocktailIngredients.ts
@@ -39,30 +39,37 @@ export function getCocktailIngredientInfo(
   for (const r of required) {
     const ing = ingMap.get(String(r.ingredientId));
     const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
-    let used = null;
-    if (ing?.inBar) {
-      used = ing;
-    } else {
-      if (allowSubstitutes || r.allowBaseSubstitution) {
-        const base = ingMap.get(baseId);
-        if (base?.inBar) used = base;
+    const allowBase =
+      allowSubstitutes || r.allowBaseSubstitution || r.allowBaseSubstitute;
+    const allowBranded =
+      allowSubstitutes || r.allowBrandedSubstitutes || ing?.baseIngredientId == null;
+    const allowAnySubstitute =
+      allowSubstitutes ||
+      r.allowBaseSubstitution ||
+      r.allowBaseSubstitute ||
+      r.allowBrandedSubstitutes;
+
+    const resolveIngredient = (candidate) => {
+      if (!candidate) return null;
+      const candidateBaseId = String(candidate.baseIngredientId ?? candidate.id);
+      const base = ingMap.get(candidateBaseId);
+      if (candidate.inBar) return candidate;
+      if (allowBase && candidate.id !== Number(candidateBaseId) && base?.inBar)
+        return base;
+      if (allowBranded) {
+        const brand = findBrand ? findBrand(candidateBaseId) : null;
+        if (brand && brand.id !== candidate.id) return brand;
       }
-      const isBaseIngredient = ing?.baseIngredientId == null;
-      if (
-        !used &&
-        (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient)
-      ) {
-        const brand = findBrand ? findBrand(baseId) : null;
-        if (brand) used = brand;
-      }
-      if (!used && Array.isArray(r.substitutes)) {
-        for (const s of r.substitutes) {
-          const candidate = ingMap.get(String(s.id));
-          if (candidate?.inBar) {
-            used = candidate;
-            break;
-          }
-        }
+      return null;
+    };
+
+    let used = resolveIngredient(ing);
+
+    if (!used && allowAnySubstitute && Array.isArray(r.substitutes)) {
+      for (const s of r.substitutes) {
+        const candidate = ingMap.get(String(s.id));
+        used = resolveIngredient(candidate);
+        if (used) break;
       }
     }
     if (used) {
@@ -118,6 +125,14 @@ export function getCocktailIngredientRows(
     const inBar = ing?.inBar;
     const baseId = String(ing?.baseIngredientId ?? ing?.id ?? r.ingredientId);
     const isBaseIngredient = ing?.baseIngredientId == null;
+    const allowBase = allowSubstitutes || r.allowBaseSubstitution || r.allowBaseSubstitute;
+    const allowBranded =
+      allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient;
+    const allowAnySubstitute =
+      allowSubstitutes ||
+      r.allowBaseSubstitution ||
+      r.allowBaseSubstitute ||
+      r.allowBrandedSubstitutes;
 
     let substitute = null;
     let declaredSubstitutes = [];
@@ -131,11 +146,11 @@ export function getCocktailIngredientRows(
           return candidate?.name || s.name;
         });
       }
-      if (allowSubstitutes || r.allowBaseSubstitution) {
+      if (allowBase) {
         const base = ingMap.get(baseId);
         if (base && base.id !== ing.id) baseSubstitutes.push(base.name);
       }
-      if (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient) {
+      if (allowBranded) {
         const others = (byBase.get(baseId) || []).filter(
           (i) => i.id !== ing.id && String(i.baseIngredientId) === String(baseId)
         );
@@ -143,29 +158,30 @@ export function getCocktailIngredientRows(
       }
     }
 
-    if (!inBar && ing) {
-      if (allowSubstitutes || r.allowBaseSubstitution) {
-        const base = ingMap.get(baseId);
-        if (base?.inBar && base.id !== ing.id) substitute = base;
+    const resolveCandidate = (candidate) => {
+      if (!candidate) return null;
+      const candidateBaseId = String(candidate.baseIngredientId ?? candidate.id);
+      if (candidate.inBar) return candidate;
+      if (allowBase && candidate.id !== Number(candidateBaseId)) {
+        const base = ingMap.get(candidateBaseId);
+        if (base?.inBar) return base;
       }
-
-      if (
-        !substitute &&
-        (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient)
-      ) {
-        const brand = (byBase.get(baseId) || []).find(
-          (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
+      if (allowBranded) {
+        const brand = (byBase.get(candidateBaseId) || []).find(
+          (i) => i.inBar && String(i.baseIngredientId) === candidateBaseId
         );
-        if (brand) substitute = brand;
+        if (brand && brand.id !== candidate.id) return brand;
       }
+      return null;
+    };
 
-      if (!substitute && Array.isArray(r.substitutes)) {
+    if (!inBar && ing) {
+      substitute = resolveCandidate(ing);
+
+      if (!substitute && allowAnySubstitute && Array.isArray(r.substitutes)) {
         for (const s of r.substitutes) {
-          const candidate = ingMap.get(String(s.id));
-          if (candidate?.inBar) {
-            substitute = candidate;
-            break;
-          }
+          substitute = resolveCandidate(ingMap.get(String(s.id)));
+          if (substitute) break;
         }
       }
     }

--- a/src/domain/ingredientSelection.ts
+++ b/src/domain/ingredientSelection.ts
@@ -41,11 +41,6 @@ export function chooseUsedIngredient(recipeRow, indexes, opts = {}) {
   const allowBase = allowSubstitutes || r.allowBaseSubstitution || r.allowBaseSubstitute;
   const isBaseIngredient = ing?.baseIngredientId == null;
   const allowBranded = allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient;
-  const allowAnySubstitute =
-    allowSubstitutes ||
-    r.allowBaseSubstitution ||
-    r.allowBaseSubstitute ||
-    r.allowBrandedSubstitutes;
   let used = null;
   if (ing?.inBar) {
     used = ing;
@@ -60,7 +55,7 @@ export function chooseUsedIngredient(recipeRow, indexes, opts = {}) {
         : (byBase?.get(baseId) || []).find((i) => i.inBar);
       if (brand && brand.id !== ing.id) used = brand;
     }
-    if (!used && allowAnySubstitute && Array.isArray(r.substitutes)) {
+    if (!used && Array.isArray(r.substitutes)) {
       for (const s of r.substitutes) {
         const candidate = byId?.get(s.id);
         if (!candidate) continue;

--- a/src/domain/ingredientSelection.ts
+++ b/src/domain/ingredientSelection.ts
@@ -38,26 +38,55 @@ export function chooseUsedIngredient(recipeRow, indexes, opts = {}) {
     if (candidate) ing = candidate;
   }
   const baseId = ing?.baseIngredientId ?? r.ingredientId;
+  const allowBase = allowSubstitutes || r.allowBaseSubstitution || r.allowBaseSubstitute;
+  const isBaseIngredient = ing?.baseIngredientId == null;
+  const allowBranded = allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient;
+  const allowAnySubstitute =
+    allowSubstitutes ||
+    r.allowBaseSubstitution ||
+    r.allowBaseSubstitute ||
+    r.allowBrandedSubstitutes;
   let used = null;
   if (ing?.inBar) {
     used = ing;
   } else if (ing) {
-    if (allowSubstitutes || r.allowBaseSubstitution) {
+    if (allowBase) {
       const base = byId?.get(baseId);
-      if (base?.inBar) used = base;
+      if (base?.inBar && base.id !== ing.id) used = base;
     }
-    const isBaseIngredient = ing?.baseIngredientId == null;
-    if (!used && (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient)) {
-      const brand = findBrand ? findBrand(baseId) : (byBase?.get(baseId) || []).find((i) => i.inBar);
-      if (brand) used = brand;
+    if (!used && allowBranded) {
+      const brand = findBrand
+        ? findBrand(baseId)
+        : (byBase?.get(baseId) || []).find((i) => i.inBar);
+      if (brand && brand.id !== ing.id) used = brand;
     }
-    if (!used && Array.isArray(r.substitutes)) {
+    if (!used && allowAnySubstitute && Array.isArray(r.substitutes)) {
       for (const s of r.substitutes) {
         const candidate = byId?.get(s.id);
-        if (candidate?.inBar) { used = candidate; break; }
+        if (!candidate) continue;
+        if (candidate.inBar) {
+          used = candidate;
+          break;
+        }
+        const candidateBaseId = candidate.baseIngredientId ?? candidate.id;
+        if (allowBase && candidate.id !== candidateBaseId) {
+          const base = byId?.get(candidateBaseId);
+          if (base?.inBar) {
+            used = base;
+            break;
+          }
+        }
+        if (allowBranded) {
+          const brand = findBrand
+            ? findBrand(candidateBaseId)
+            : (byBase?.get(candidateBaseId) || []).find((i) => i.inBar);
+          if (brand && brand.id !== candidate.id) {
+            used = brand;
+            break;
+          }
+        }
       }
     }
   }
   return { used, ing, baseId };
 }
-

--- a/src/domain/ingredientUsage.ts
+++ b/src/domain/ingredientUsage.ts
@@ -29,6 +29,7 @@ function hashCocktails(cocktails) {
     if (!Array.isArray(c.ingredients)) continue;
     for (const r of c.ingredients) {
       h = (h * 31 + Number(r.ingredientId)) | 0;
+      h = (h * 31 + (r.allowBaseSubstitution || r.allowBaseSubstitute ? 1 : 0)) | 0;
       h = (h * 31 + (r.allowBrandedSubstitutes ? 1 : 0)) | 0;
       if (Array.isArray(r.substitutes)) {
         for (const s of r.substitutes) {
@@ -46,6 +47,38 @@ let usageCache = {
   cockHash: 0,
   result: null,
 };
+
+function getAllowFlags(row, allowSubstitutes, ingredient) {
+  const allowBase = allowSubstitutes || row.allowBaseSubstitution || row.allowBaseSubstitute;
+  const isBaseIngredient = ingredient?.baseIngredientId == null;
+  const allowBranded =
+    allowSubstitutes || row.allowBrandedSubstitutes || isBaseIngredient;
+  const allowAnySubstitute =
+    allowSubstitutes ||
+    row.allowBaseSubstitution ||
+    row.allowBaseSubstitute ||
+    row.allowBrandedSubstitutes;
+  return { allowBase, allowBranded, allowAnySubstitute };
+}
+
+function collectIngredientIds(target, byBaseMap, flags) {
+  if (!target) return [];
+  const ids = [target.id];
+  const baseId = target.baseIngredientId ?? target.id;
+  const group = byBaseMap.get(baseId) || [];
+
+  if (flags.allowBase && target.id !== baseId) ids.push(baseId);
+
+  if (flags.allowBranded) {
+    group.forEach((item) => {
+      if (item.id === target.id) return;
+      if (item.id === baseId && !flags.allowBase) return;
+      ids.push(item.id);
+    });
+  }
+
+  return ids;
+}
 
 export function clearMapCocktailsByIngredientCache() {
   usageCache = {
@@ -91,30 +124,19 @@ export function mapCocktailsByIngredient(ingredients, cocktails, options = {}) {
         if (r.ingredientId == null) return;
         const ing = byIdMap.get(r.ingredientId);
         if (!ing) return;
-        const baseId = ing.baseIngredientId ?? ing.id;
-        const group = byBaseMap.get(baseId) || [];
+        const flags = getAllowFlags(r, allowSubstitutes, ing);
+        collectIngredientIds(ing, byBaseMap, flags).forEach((id) =>
+          add(id, c.id)
+        );
 
-        // direct usage
-        add(ing.id, c.id);
-
-        if (ing.id === baseId) {
-          // base ingredient used: count all branded versions
-          group.forEach((item) => {
-            if (item.id !== baseId) add(item.id, c.id);
+        if (flags.allowAnySubstitute && Array.isArray(r.substitutes)) {
+          r.substitutes.forEach((s) => {
+            const subIng = byIdMap.get(s.id);
+            if (!subIng) return;
+            collectIngredientIds(subIng, byBaseMap, flags).forEach((id) =>
+              add(id, c.id)
+            );
           });
-        } else {
-          // branded ingredient used: base ingredient always counts
-          add(baseId, c.id);
-          if (allowSubstitutes || r.allowBrandedSubstitutes) {
-            group.forEach((item) => {
-              if (item.id !== ing.id && item.id !== baseId) add(item.id, c.id);
-            });
-          }
-        }
-
-        // explicit substitutes
-        if (Array.isArray(r.substitutes)) {
-          r.substitutes.forEach((s) => add(s.id, c.id));
         }
       });
     });
@@ -275,26 +297,15 @@ export function addCocktailToUsageMap(prevMap, ingredients, cocktail, options = 
         if (r.ingredientId == null) return;
         const ing = byIdMap.get(r.ingredientId);
         if (!ing) return;
-        const baseId = ing.baseIngredientId ?? ing.id;
-        const group = byBaseMap.get(baseId) || [];
+        const flags = getAllowFlags(r, allowSubstitutes, ing);
+        collectIngredientIds(ing, byBaseMap, flags).forEach(add);
 
-        add(ing.id);
-
-        if (ing.id === baseId) {
-          group.forEach((item) => {
-            if (item.id !== baseId) add(item.id);
+        if (flags.allowAnySubstitute && Array.isArray(r.substitutes)) {
+          r.substitutes.forEach((s) => {
+            const subIng = byIdMap.get(s.id);
+            if (!subIng) return;
+            collectIngredientIds(subIng, byBaseMap, flags).forEach(add);
           });
-        } else {
-          add(baseId);
-          if (allowSubstitutes || r.allowBrandedSubstitutes) {
-            group.forEach((item) => {
-              if (item.id !== ing.id && item.id !== baseId) add(item.id);
-            });
-          }
-        }
-
-        if (Array.isArray(r.substitutes)) {
-          r.substitutes.forEach((s) => add(s.id));
         }
       });
     }
@@ -322,26 +333,15 @@ export function removeCocktailFromUsageMap(prevMap, ingredients, cocktail, optio
         if (r.ingredientId == null) return;
         const ing = byIdMap.get(r.ingredientId);
         if (!ing) return;
-        const baseId = ing.baseIngredientId ?? ing.id;
-        const group = byBaseMap.get(baseId) || [];
+        const flags = getAllowFlags(r, allowSubstitutes, ing);
+        collectIngredientIds(ing, byBaseMap, flags).forEach(remove);
 
-        remove(ing.id);
-
-        if (ing.id === baseId) {
-          group.forEach((item) => {
-            if (item.id !== baseId) remove(item.id);
+        if (flags.allowAnySubstitute && Array.isArray(r.substitutes)) {
+          r.substitutes.forEach((s) => {
+            const subIng = byIdMap.get(s.id);
+            if (!subIng) return;
+            collectIngredientIds(subIng, byBaseMap, flags).forEach(remove);
           });
-        } else {
-          remove(baseId);
-          if (allowSubstitutes || r.allowBrandedSubstitutes) {
-            group.forEach((item) => {
-              if (item.id !== ing.id && item.id !== baseId) remove(item.id);
-            });
-          }
-        }
-
-        if (Array.isArray(r.substitutes)) {
-          r.substitutes.forEach((s) => remove(s.id));
         }
       });
     }

--- a/src/domain/ingredientUsage.ts
+++ b/src/domain/ingredientUsage.ts
@@ -129,7 +129,7 @@ export function mapCocktailsByIngredient(ingredients, cocktails, options = {}) {
           add(id, c.id)
         );
 
-        if (flags.allowAnySubstitute && Array.isArray(r.substitutes)) {
+        if (Array.isArray(r.substitutes)) {
           r.substitutes.forEach((s) => {
             const subIng = byIdMap.get(s.id);
             if (!subIng) return;
@@ -300,7 +300,7 @@ export function addCocktailToUsageMap(prevMap, ingredients, cocktail, options = 
         const flags = getAllowFlags(r, allowSubstitutes, ing);
         collectIngredientIds(ing, byBaseMap, flags).forEach(add);
 
-        if (flags.allowAnySubstitute && Array.isArray(r.substitutes)) {
+        if (Array.isArray(r.substitutes)) {
           r.substitutes.forEach((s) => {
             const subIng = byIdMap.get(s.id);
             if (!subIng) return;
@@ -336,7 +336,7 @@ export function removeCocktailFromUsageMap(prevMap, ingredients, cocktail, optio
         const flags = getAllowFlags(r, allowSubstitutes, ing);
         collectIngredientIds(ing, byBaseMap, flags).forEach(remove);
 
-        if (flags.allowAnySubstitute && Array.isArray(r.substitutes)) {
+        if (Array.isArray(r.substitutes)) {
           r.substitutes.forEach((s) => {
             const subIng = byIdMap.get(s.id);
             if (!subIng) return;

--- a/src/domain/ingredientsAvailabilityCache.ts
+++ b/src/domain/ingredientsAvailabilityCache.ts
@@ -4,6 +4,34 @@ let cocktailMap = new Map();
 let usage = {};
 let settings = { ignoreGarnish: false, allowSubstitutes: false };
 
+function getAllowFlags(row, ingredient) {
+  const allowBase =
+    settings.allowSubstitutes || row.allowBaseSubstitution || row.allowBaseSubstitute;
+  const allowBranded =
+    settings.allowSubstitutes ||
+    row.allowBrandedSubstitutes ||
+    (ingredient?.baseIngredientId == null);
+  const allowAnySubstitute =
+    settings.allowSubstitutes ||
+    row.allowBaseSubstitution ||
+    row.allowBaseSubstitute ||
+    row.allowBrandedSubstitutes;
+  return { allowBase, allowBranded, allowAnySubstitute };
+}
+
+function resolveIngredient(candidate, row, flags) {
+  if (!candidate) return null;
+  const baseId = String(candidate.baseIngredientId ?? candidate.id);
+  const base = ingredientsMap.get(baseId);
+  if (candidate.inBar) return candidate;
+  if (flags.allowBase && candidate.id !== Number(baseId) && base?.inBar) return base;
+  if (flags.allowBranded) {
+    const brand = findBrand(baseId);
+    if (brand && brand.id !== candidate.id) return brand;
+  }
+  return null;
+}
+
 function findBrand(baseId) {
   for (const ing of ingredientsMap.values()) {
     if (ing.inBar && String(ing.baseIngredientId) === String(baseId)) return ing;
@@ -18,29 +46,14 @@ function isCocktailAvailable(cocktail) {
   if (required.length === 0) return false;
   for (const r of required) {
     const ing = ingredientsMap.get(String(r.ingredientId));
-    const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
-    let used = null;
-    if (ing?.inBar) used = ing;
-    else {
-      if (settings.allowSubstitutes || r.allowBaseSubstitution) {
-        const base = ingredientsMap.get(baseId);
-        if (base?.inBar) used = base;
-      }
-      if (
-        !used &&
-        (settings.allowSubstitutes || r.allowBrandedSubstitutes || ing?.baseIngredientId != null)
-      ) {
-        const brand = findBrand(baseId);
-        if (brand) used = brand;
-      }
-      if (!used && Array.isArray(r.substitutes)) {
-        for (const s of r.substitutes) {
-          const cand = ingredientsMap.get(String(s.id));
-          if (cand?.inBar) {
-            used = cand;
-            break;
-          }
-        }
+    const flags = getAllowFlags(r, ing);
+    const allowAnySubstitute = flags.allowAnySubstitute;
+    let used = resolveIngredient(ing, r, flags);
+    if (!used && allowAnySubstitute && Array.isArray(r.substitutes)) {
+      for (const s of r.substitutes) {
+        const candidate = ingredientsMap.get(String(s.id));
+        used = resolveIngredient(candidate, r, flags);
+        if (used) break;
       }
     }
     if (!used) return false;

--- a/src/domain/ingredientsAvailabilityCache.ts
+++ b/src/domain/ingredientsAvailabilityCache.ts
@@ -47,9 +47,8 @@ function isCocktailAvailable(cocktail) {
   for (const r of required) {
     const ing = ingredientsMap.get(String(r.ingredientId));
     const flags = getAllowFlags(r, ing);
-    const allowAnySubstitute = flags.allowAnySubstitute;
     let used = resolveIngredient(ing, r, flags);
-    if (!used && allowAnySubstitute && Array.isArray(r.substitutes)) {
+    if (!used && Array.isArray(r.substitutes)) {
       for (const s of r.substitutes) {
         const candidate = ingredientsMap.get(String(s.id));
         used = resolveIngredient(candidate, r, flags);


### PR DESCRIPTION
## Summary
- include per-ingredient substitution flags when mapping cocktails to ingredients, covering base/branded variants of substitutes
- align ingredient availability checks and selection logic with the expanded substitution rules
- ensure cached usage recalculates when substitution allowances change

## Testing
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69445ff9dc608326b55243217851f6ff)