### PR TITLE
Fix cocktail availability with substitutes

### DIFF
--- a/src/domain/cocktailIngredients.ts
+++ b/src/domain/cocktailIngredients.ts
@@ -39,29 +39,40 @@ export function getCocktailIngredientInfo(
   for (const r of required) {
     const ing = ingMap.get(String(r.ingredientId));
     const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
-    let used = null;
-    if (ing?.inBar) {
-      used = ing;
-    } else {
-      if (allowSubstitutes || r.allowBaseSubstitution) {
-        const base = ingMap.get(baseId);
-        if (base?.inBar) used = base;
+    const allowBaseSubstitution = !!(
+      r.allowBaseSubstitution ?? r.allowBaseSubstitute
+    );
+    const allowBrandedSubstitutes = !!r.allowBrandedSubstitutes;
+    const resolveIngredient = (ingredientId) => {
+      const candidate = ingMap.get(String(ingredientId));
+      if (!candidate) return null;
+      if (candidate.inBar) return candidate;
+      const candidateBaseId = String(
+        candidate.baseIngredientId ?? candidate.id ?? ingredientId
+      );
+      const isCandidateBase = candidate.baseIngredientId == null;
+      if (allowSubstitutes || allowBaseSubstitution) {
+        const baseIng = ingMap.get(candidateBaseId);
+        if (baseIng?.inBar) return baseIng;
       }
-      const isBaseIngredient = ing?.baseIngredientId == null;
       if (
-        !used &&
-        (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient)
+        allowSubstitutes ||
+        allowBrandedSubstitutes ||
+        isCandidateBase
       ) {
-        const brand = findBrand ? findBrand(baseId) : null;
-        if (brand) used = brand;
+        const brandIng = findBrand ? findBrand(candidateBaseId) : null;
+        if (brandIng) return brandIng;
       }
-      if (!used && Array.isArray(r.substitutes)) {
-        for (const s of r.substitutes) {
-          const candidate = ingMap.get(String(s.id));
-          if (candidate?.inBar) {
-            used = candidate;
-            break;
-          }
+      return null;
+    };
+    let used = null;
+    if (ing) used = resolveIngredient(ing.id);
+    if (!used && Array.isArray(r.substitutes)) {
+      for (const s of r.substitutes) {
+        const candidate = resolveIngredient(s.id);
+        if (candidate) {
+          used = candidate;
+          break;
         }
       }
     }
@@ -118,6 +129,10 @@ export function getCocktailIngredientRows(
     const inBar = ing?.inBar;
     const baseId = String(ing?.baseIngredientId ?? ing?.id ?? r.ingredientId);
     const isBaseIngredient = ing?.baseIngredientId == null;
+    const allowBaseSubstitution = !!(
+      r.allowBaseSubstitution ?? r.allowBaseSubstitute
+    );
+    const allowBrandedSubstitutes = !!r.allowBrandedSubstitutes;
 
     let substitute = null;
     let declaredSubstitutes = [];
@@ -131,11 +146,15 @@ export function getCocktailIngredientRows(
           return candidate?.name || s.name;
         });
       }
-      if (allowSubstitutes || r.allowBaseSubstitution) {
+      if (allowSubstitutes || allowBaseSubstitution) {
         const base = ingMap.get(baseId);
         if (base && base.id !== ing.id) baseSubstitutes.push(base.name);
       }
-      if (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient) {
+      if (
+        allowSubstitutes ||
+        allowBrandedSubstitutes ||
+        isBaseIngredient
+      ) {
         const others = (byBase.get(baseId) || []).filter(
           (i) => i.id !== ing.id && String(i.baseIngredientId) === String(baseId)
         );
@@ -144,14 +163,14 @@ export function getCocktailIngredientRows(
     }
 
     if (!inBar && ing) {
-      if (allowSubstitutes || r.allowBaseSubstitution) {
+      if (allowSubstitutes || allowBaseSubstitution) {
         const base = ingMap.get(baseId);
         if (base?.inBar && base.id !== ing.id) substitute = base;
       }
 
       if (
         !substitute &&
-        (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient)
+        (allowSubstitutes || allowBrandedSubstitutes || isBaseIngredient)
       ) {
         const brand = (byBase.get(baseId) || []).find(
           (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
@@ -161,9 +180,9 @@ export function getCocktailIngredientRows(
 
       if (!substitute && Array.isArray(r.substitutes)) {
         for (const s of r.substitutes) {
-          const candidate = ingMap.get(String(s.id));
-          if (candidate?.inBar) {
-            substitute = candidate;
+          const resolved = resolveIngredient(s.id);
+          if (resolved) {
+            substitute = resolved;
             break;
           }
         }

--- a/src/domain/ingredientSelection.ts
+++ b/src/domain/ingredientSelection.ts
@@ -25,6 +25,25 @@ export function buildIngredientIndexes(ingredients) {
   return { byId, byBase, bySearch, findBrand };
 }
 
+function isIngredientAvailable(ingredientId, indexes, opts) {
+  const { byId, findBrand } = indexes || {};
+  const { allowSubstitutes = false, allowBaseSubstitution = false, allowBrandedSubstitutes = false } = opts || {};
+  const ing = ingredientId ? byId?.get(ingredientId) : null;
+  if (!ing) return null;
+  if (ing.inBar) return ing;
+  const baseId = ing.baseIngredientId ?? ingredientId;
+  const isBaseIngredient = ing.baseIngredientId == null;
+  if (allowSubstitutes || allowBaseSubstitution) {
+    const base = byId?.get(baseId);
+    if (base?.inBar) return base;
+  }
+  if (allowSubstitutes || allowBrandedSubstitutes || isBaseIngredient) {
+    const brand = findBrand ? findBrand(baseId) : null;
+    if (brand) return brand;
+  }
+  return null;
+}
+
 // Select which ingredient to use for a recipe row, mirroring AllCocktails logic.
 export function chooseUsedIngredient(recipeRow, indexes, opts = {}) {
   const { byId, byBase, bySearch, findBrand } = indexes || {};
@@ -38,26 +57,25 @@ export function chooseUsedIngredient(recipeRow, indexes, opts = {}) {
     if (candidate) ing = candidate;
   }
   const baseId = ing?.baseIngredientId ?? r.ingredientId;
+  const allowBaseSubstitution = !!(r.allowBaseSubstitution ?? r.allowBaseSubstitute);
+  const allowBrandedSubstitutes = !!r.allowBrandedSubstitutes;
   let used = null;
-  if (ing?.inBar) {
-    used = ing;
-  } else if (ing) {
-    if (allowSubstitutes || r.allowBaseSubstitution) {
-      const base = byId?.get(baseId);
-      if (base?.inBar) used = base;
-    }
-    const isBaseIngredient = ing?.baseIngredientId == null;
-    if (!used && (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient)) {
-      const brand = findBrand ? findBrand(baseId) : (byBase?.get(baseId) || []).find((i) => i.inBar);
-      if (brand) used = brand;
-    }
+  if (ing) {
+    used = isIngredientAvailable(ing.id, indexes, {
+      allowSubstitutes,
+      allowBaseSubstitution,
+      allowBrandedSubstitutes,
+    });
     if (!used && Array.isArray(r.substitutes)) {
       for (const s of r.substitutes) {
-        const candidate = byId?.get(s.id);
-        if (candidate?.inBar) { used = candidate; break; }
+        used = isIngredientAvailable(s.id, indexes, {
+          allowSubstitutes,
+          allowBaseSubstitution,
+          allowBrandedSubstitutes,
+        });
+        if (used) break;
       }
     }
   }
   return { used, ing, baseId };
 }
-

--- a/src/domain/ingredientUsage.ts
+++ b/src/domain/ingredientUsage.ts
@@ -29,7 +29,10 @@ function hashCocktails(cocktails) {
     if (!Array.isArray(c.ingredients)) continue;
     for (const r of c.ingredients) {
       h = (h * 31 + Number(r.ingredientId)) | 0;
-      h = (h * 31 + (r.allowBrandedSubstitutes ? 1 : 0)) | 0;
+      const allowBase = r.allowBaseSubstitution || r.allowBaseSubstitute;
+      const allowBranded = r.allowBrandedSubstitutes;
+      h = (h * 31 + (allowBase ? 1 : 0)) | 0;
+      h = (h * 31 + (allowBranded ? 1 : 0)) | 0;
       if (Array.isArray(r.substitutes)) {
         for (const s of r.substitutes) {
           h = (h * 31 + Number(s.id)) | 0;
@@ -54,6 +57,36 @@ export function clearMapCocktailsByIngredientCache() {
     cockHash: 0,
     result: null,
   };
+}
+
+function collectUsageIds(ing, { allowSubstitutes, allowBaseSubstitution, allowBrandedSubstitutes, byBaseMap }) {
+  const ids = new Set();
+  if (!ing) return ids;
+  const baseId = ing.baseIngredientId ?? ing.id;
+  const group = byBaseMap.get(baseId) || [];
+
+  ids.add(ing.id);
+
+  if (ing.id === baseId) {
+    // base ingredient used: count all branded versions
+    group.forEach((item) => {
+      if (item.id !== baseId) ids.add(item.id);
+    });
+    return ids;
+  }
+
+  // branded ingredient used: include base only when allowed
+  if (allowSubstitutes || allowBaseSubstitution) {
+    ids.add(baseId);
+  }
+  // include other branded siblings only when allowed
+  if (allowSubstitutes || allowBrandedSubstitutes) {
+    group.forEach((item) => {
+      if (item.id !== ing.id && item.id !== baseId) ids.add(item.id);
+    });
+  }
+
+  return ids;
 }
 
 export function mapCocktailsByIngredient(ingredients, cocktails, options = {}) {
@@ -90,31 +123,21 @@ export function mapCocktailsByIngredient(ingredients, cocktails, options = {}) {
       c.ingredients.forEach((r) => {
         if (r.ingredientId == null) return;
         const ing = byIdMap.get(r.ingredientId);
-        if (!ing) return;
-        const baseId = ing.baseIngredientId ?? ing.id;
-        const group = byBaseMap.get(baseId) || [];
+        const allowBaseSub = !!(r.allowBaseSubstitution ?? r.allowBaseSubstitute);
+        const allowBranded = !!r.allowBrandedSubstitutes;
+        const opts = {
+          allowSubstitutes,
+          allowBaseSubstitution: allowBaseSub,
+          allowBrandedSubstitutes: allowBranded,
+          byBaseMap,
+        };
+        collectUsageIds(ing, opts).forEach((id) => add(id, c.id));
 
-        // direct usage
-        add(ing.id, c.id);
-
-        if (ing.id === baseId) {
-          // base ingredient used: count all branded versions
-          group.forEach((item) => {
-            if (item.id !== baseId) add(item.id, c.id);
-          });
-        } else {
-          // branded ingredient used: base ingredient always counts
-          add(baseId, c.id);
-          if (allowSubstitutes || r.allowBrandedSubstitutes) {
-            group.forEach((item) => {
-              if (item.id !== ing.id && item.id !== baseId) add(item.id, c.id);
-            });
-          }
-        }
-
-        // explicit substitutes
         if (Array.isArray(r.substitutes)) {
-          r.substitutes.forEach((s) => add(s.id, c.id));
+          r.substitutes.forEach((s) => {
+            const subIng = byIdMap.get(s.id);
+            collectUsageIds(subIng, opts).forEach((id) => add(id, c.id));
+          });
         }
       });
     });
@@ -274,27 +297,21 @@ export function addCocktailToUsageMap(prevMap, ingredients, cocktail, options = 
       cocktail.ingredients.forEach((r) => {
         if (r.ingredientId == null) return;
         const ing = byIdMap.get(r.ingredientId);
-        if (!ing) return;
-        const baseId = ing.baseIngredientId ?? ing.id;
-        const group = byBaseMap.get(baseId) || [];
-
-        add(ing.id);
-
-        if (ing.id === baseId) {
-          group.forEach((item) => {
-            if (item.id !== baseId) add(item.id);
-          });
-        } else {
-          add(baseId);
-          if (allowSubstitutes || r.allowBrandedSubstitutes) {
-            group.forEach((item) => {
-              if (item.id !== ing.id && item.id !== baseId) add(item.id);
-            });
-          }
-        }
+        const allowBaseSub = !!(r.allowBaseSubstitution ?? r.allowBaseSubstitute);
+        const allowBranded = !!r.allowBrandedSubstitutes;
+        const opts = {
+          allowSubstitutes,
+          allowBaseSubstitution: allowBaseSub,
+          allowBrandedSubstitutes: allowBranded,
+          byBaseMap,
+        };
+        collectUsageIds(ing, opts).forEach(add);
 
         if (Array.isArray(r.substitutes)) {
-          r.substitutes.forEach((s) => add(s.id));
+          r.substitutes.forEach((s) => {
+            const subIng = byIdMap.get(s.id);
+            collectUsageIds(subIng, opts).forEach(add);
+          });
         }
       });
     }
@@ -321,27 +338,21 @@ export function removeCocktailFromUsageMap(prevMap, ingredients, cocktail, optio
       cocktail.ingredients.forEach((r) => {
         if (r.ingredientId == null) return;
         const ing = byIdMap.get(r.ingredientId);
-        if (!ing) return;
-        const baseId = ing.baseIngredientId ?? ing.id;
-        const group = byBaseMap.get(baseId) || [];
-
-        remove(ing.id);
-
-        if (ing.id === baseId) {
-          group.forEach((item) => {
-            if (item.id !== baseId) remove(item.id);
-          });
-        } else {
-          remove(baseId);
-          if (allowSubstitutes || r.allowBrandedSubstitutes) {
-            group.forEach((item) => {
-              if (item.id !== ing.id && item.id !== baseId) remove(item.id);
-            });
-          }
-        }
+        const allowBaseSub = !!(r.allowBaseSubstitution ?? r.allowBaseSubstitute);
+        const allowBranded = !!r.allowBrandedSubstitutes;
+        const opts = {
+          allowSubstitutes,
+          allowBaseSubstitution: allowBaseSub,
+          allowBrandedSubstitutes: allowBranded,
+          byBaseMap,
+        };
+        collectUsageIds(ing, opts).forEach(remove);
 
         if (Array.isArray(r.substitutes)) {
-          r.substitutes.forEach((s) => remove(s.id));
+          r.substitutes.forEach((s) => {
+            const subIng = byIdMap.get(s.id);
+            collectUsageIds(subIng, opts).forEach(remove);
+          });
         }
       });
     }

--- a/src/domain/ingredientsAvailabilityCache.ts
+++ b/src/domain/ingredientsAvailabilityCache.ts
@@ -11,39 +11,45 @@ function findBrand(baseId) {
   return null;
 }
 
+function isIngredientAvailable(id, { allowBaseSubstitution, allowBrandedSubstitutes }) {
+  const ing = ingredientsMap.get(String(id));
+  if (!ing) return false;
+  if (ing.inBar) return true;
+  const baseId = String(ing.baseIngredientId ?? ing.id ?? id);
+  const isBaseIngredient = ing.baseIngredientId == null;
+  if (settings.allowSubstitutes || allowBaseSubstitution) {
+    const base = ingredientsMap.get(baseId);
+    if (base?.inBar) return true;
+  }
+  if (
+    settings.allowSubstitutes ||
+    allowBrandedSubstitutes ||
+    isBaseIngredient
+  ) {
+    const brand = findBrand(baseId);
+    if (brand) return true;
+  }
+  return false;
+}
+
 function isCocktailAvailable(cocktail) {
   const required = (cocktail.ingredients || []).filter(
     (r) => !r.optional && !(settings.ignoreGarnish && r.garnish)
   );
   if (required.length === 0) return false;
   for (const r of required) {
-    const ing = ingredientsMap.get(String(r.ingredientId));
-    const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
-    let used = null;
-    if (ing?.inBar) used = ing;
-    else {
-      if (settings.allowSubstitutes || r.allowBaseSubstitution) {
-        const base = ingredientsMap.get(baseId);
-        if (base?.inBar) used = base;
-      }
-      if (
-        !used &&
-        (settings.allowSubstitutes || r.allowBrandedSubstitutes || ing?.baseIngredientId != null)
-      ) {
-        const brand = findBrand(baseId);
-        if (brand) used = brand;
-      }
-      if (!used && Array.isArray(r.substitutes)) {
-        for (const s of r.substitutes) {
-          const cand = ingredientsMap.get(String(s.id));
-          if (cand?.inBar) {
-            used = cand;
-            break;
-          }
-        }
-      }
+    const allowBaseSubstitution = !!(
+      r.allowBaseSubstitution ?? r.allowBaseSubstitute
+    );
+    const allowBrandedSubstitutes = !!r.allowBrandedSubstitutes;
+    const opts = { allowBaseSubstitution, allowBrandedSubstitutes };
+    if (isIngredientAvailable(r.ingredientId, opts)) continue;
+    if (
+      !Array.isArray(r.substitutes) ||
+      !r.substitutes.some((s) => isIngredientAvailable(s.id, opts))
+    ) {
+      return false;
     }
-    if (!used) return false;
   }
   return true;
 }

--- a/src/domain/shakerService.ts
+++ b/src/domain/shakerService.ts
@@ -176,23 +176,42 @@ export function computeAvailableCocktails({
       (i) => i.inBar && String(i.baseIngredientId) === String(baseId)
     );
 
-  const isSatisfied = (r: any): boolean => {
-    const ing = ingMap.get(String(r.ingredientId));
-    if (ing?.inBar) return true;
-    const baseId = String(ing?.baseIngredientId ?? r.ingredientId);
-    if (allowSubstitutes || r.allowBaseSubstitution) {
+  const isIngredientAvailable = (
+    ingredientId: string | number,
+    opts: { allowBaseSubstitution: boolean; allowBrandedSubstitutes: boolean }
+  ): boolean => {
+    const ing = ingMap.get(String(ingredientId));
+    const allowBaseSubstitution = opts.allowBaseSubstitution;
+    const allowBrandedSubstitutes = opts.allowBrandedSubstitutes;
+    if (!ing) return false;
+    if (ing.inBar) return true;
+    const baseId = String(ing.baseIngredientId ?? ing.id ?? ingredientId);
+    const isBaseIngredient = ing.baseIngredientId == null;
+    if (allowSubstitutes || allowBaseSubstitution) {
       const base = ingMap.get(baseId);
       if (base?.inBar) return true;
     }
-    const isBaseIngredient = ing?.baseIngredientId == null;
-    if (allowSubstitutes || r.allowBrandedSubstitutes || isBaseIngredient) {
+    if (
+      allowSubstitutes ||
+      allowBrandedSubstitutes ||
+      isBaseIngredient
+    ) {
       const brand = findBrand(baseId);
       if (brand) return true;
     }
+    return false;
+  };
+
+  const isSatisfied = (r: any): boolean => {
+    const allowBaseSubstitution = !!(
+      r.allowBaseSubstitution ?? r.allowBaseSubstitute
+    );
+    const allowBrandedSubstitutes = !!r.allowBrandedSubstitutes;
+    const options = { allowBaseSubstitution, allowBrandedSubstitutes };
+    if (isIngredientAvailable(r.ingredientId, options)) return true;
     if (Array.isArray(r.substitutes)) {
       for (const s of r.substitutes) {
-        const candidate = ingMap.get(String(s.id));
-        if (candidate?.inBar) return true;
+        if (isIngredientAvailable(s.id, options)) return true;
       }
     }
     return false;


### PR DESCRIPTION
## Summary
- update usage mapping to include substitute ingredients and their base/branded variants based on substitution settings
- fix availability checks to consider substitutes (and their base/brand relationships) when determining makeable cocktails and ingredient details
- refresh caches to react to base-substitution flags when substitution options change

## Testing
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694465fbd10083268ee4748ae8e4d79f)