### PR TITLE
Adjust substitute display ordering and prefix 'or' for missing ingredients

### DIFF
--- a/src/domain/cocktailIngredients.ts
+++ b/src/domain/cocktailIngredients.ts
@@ -124,13 +124,13 @@ export function getCocktailIngredientRows(
     let baseSubstitutes = [];
     let brandedSubstitutes = [];
 
+    if (Array.isArray(r.substitutes)) {
+      declaredSubstitutes = r.substitutes.map((s) => {
+        const candidate = ingMap.get(String(s.id));
+        return candidate?.name || s.name;
+      });
+    }
     if (ing) {
-      if (Array.isArray(r.substitutes)) {
-        declaredSubstitutes = r.substitutes.map((s) => {
-          const candidate = ingMap.get(String(s.id));
-          return candidate?.name || s.name;
-        });
-      }
       if (allowSubstitutes || r.allowBaseSubstitution) {
         const base = ingMap.get(baseId);
         if (base && base.id !== ing.id) baseSubstitutes.push(base.name);

--- a/src/screens/Cocktails/CocktailDetailsScreen.tsx
+++ b/src/screens/Cocktails/CocktailDetailsScreen.tsx
@@ -145,17 +145,23 @@ const IngredientRow = memo(function IngredientRow({
               .join(", ");
             if (propLine) lines.push(`(${propLine})`);
             if (substituteFor) lines.push(`Substitute for: ${substituteFor}`);
-            const allSubs = Array.from(
-              new Set([
-                ...declaredSubstitutes,
-                ...baseSubstitutes,
-                ...brandedSubstitutes,
-              ])
-            );
-            if (!inBar && !substituteFor && allSubs.length > 0) {
-              allSubs.forEach((s, i) =>
-                lines.push(i === 0 ? `or ${s}` : s)
-              );
+            const orderedSubs = [];
+            const pushUnique = (items) => {
+              items.forEach((item) => {
+                if (!item || orderedSubs.includes(item)) return;
+                orderedSubs.push(item);
+              });
+            };
+            pushUnique(declaredSubstitutes);
+            if (isBranded) {
+              pushUnique(baseSubstitutes);
+              pushUnique(brandedSubstitutes);
+            } else {
+              pushUnique(brandedSubstitutes);
+              pushUnique(baseSubstitutes);
+            }
+            if (!inBar && !substituteFor && orderedSubs.length > 0) {
+              orderedSubs.forEach((s) => lines.push(`or ${s}`));
             } else {
               declaredSubstitutes.forEach((s) => lines.push(s));
               baseSubstitutes.forEach((s) => lines.push(s));


### PR DESCRIPTION
### Motivation
- Update ingredient row rendering to match menu requirements so declared substitutes are shown even if the referenced ingredient row is missing.
- Ensure substitute suggestions are ordered and formatted: declared substitutes first, then base/branded siblings depending on whether the ingredient is branded, and each suggested line for missing ingredients starts with `or`.

### Description
- Collect declared substitutes regardless of whether the ingredient record (`ing`) exists by moving declared-substitute mapping into `getCocktailIngredientRows` in `src/domain/cocktailIngredients.ts`.
- Build a de-duplicated, ordered list of possible substitutes in `IngredientRow` inside `src/screens/Cocktails/CocktailDetailsScreen.tsx` and order items so declared substitutes come first, then base/branded siblings according to `isBranded`.
- When the ingredient is not available (`!inBar`) and not a `substituteFor`, render each suggested substitute line prefixed with `or `, while preserving the previous multi-line fallback when the ingredient is available.
- Avoid duplicate substitute names using a small `pushUnique` helper before rendering.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c8d16a9c8326912013fab3d01f0c)