### PR TITLE
Preserve My Cocktails scroll position on return

### DIFF
--- a/src/screens/Cocktails/MyCocktailsScreen.tsx
+++ b/src/screens/Cocktails/MyCocktailsScreen.tsx
@@ -67,6 +67,8 @@ export default function MyCocktailsScreen() {
     setIngredients: setGlobalIngredients,
   } = useIngredientUsage();
 
+  const listRef = useRef(null);
+  const scrollOffsetRef = useRef(0);
   const shoppingListChangesRef = useRef(shoppingListChanges);
   useEffect(() => {
     shoppingListChangesRef.current = shoppingListChanges;
@@ -246,6 +248,16 @@ export default function MyCocktailsScreen() {
     return data;
   }, [available, suggestions]);
 
+  useEffect(() => {
+    if (!isFocused) return;
+    const offset = scrollOffsetRef.current;
+    if (!listRef.current || offset <= 0) return;
+    const id = requestAnimationFrame(() => {
+      listRef.current?.scrollToOffset({ offset, animated: false });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [isFocused, listData]);
+
   const handlePress = useCallback(
     (id) => {
       setNavigatingId(id);
@@ -363,10 +375,15 @@ export default function MyCocktailsScreen() {
       />
       {tabsOnTop && <TopTabBar navigation={navigation} theme={theme} />}
       <FlashList
+        ref={listRef}
         data={listData}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
         estimatedItemSize={ITEM_HEIGHT}
+        onScroll={(event) => {
+          scrollOffsetRef.current = event.nativeEvent.contentOffset.y;
+        }}
+        scrollEventThrottle={16}
         keyboardShouldPersistTaps="handled"
         removeClippedSubviews
         initialNumToRender={12}
@@ -402,4 +419,3 @@ export default function MyCocktailsScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
 });
-


### PR DESCRIPTION
### Motivation
- Restore the user's scroll position in the My Cocktails list when they navigate back from a details screen to avoid losing context.
- Capture and reapply the list offset so the UX remains stable across navigation.

### Description
- Added `listRef` and `scrollOffsetRef` to `src/screens/Cocktails/MyCocktailsScreen.tsx` to keep a reference to the `FlashList` and the last known scroll offset.
- Hooked into `FlashList` `onScroll` to update `scrollOffsetRef` and set `scrollEventThrottle` to `16` to capture offsets smoothly.
- Restored position on focus by seeking to the stored offset inside an effect that runs when `isFocused` and `listData` change using `requestAnimationFrame` and `scrollToOffset({ offset, animated: false })`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69782314c6dc8326937165e9a5548b08)